### PR TITLE
List of supported Anbox features depending on image type

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -293,6 +293,7 @@ validator
 vCPU
 vCPUs
 VHAL
+VhalConnector
 VhalPropertyStatus
 viewport
 VirGL

--- a/howto/port/install-system-app.md
+++ b/howto/port/install-system-app.md
@@ -1,5 +1,7 @@
 Usually, Anbox Cloud installs APKs as user apps in the Android container. It is possible to install apps as system apps though.
 
+[note type="information" status="Note"]Installing apps as system apps is not supported on AAOS images.[/note]
+
 A user app is normally signed by the developer and has restricted permissions at runtime. A system app, on the other hand, is usually [signed with the platform key](https://source.android.com/devices/tech/ota/sign_builds) when building an Android image. It is pre-installed under the system partition and runs a process with some ["signature" protection level permissions](https://developer.android.com/guide/topics/manifest/permission-element.html#plevel) in the Android container.
 
 An application must be running as a system app if:

--- a/index.md
+++ b/index.md
@@ -143,6 +143,7 @@ Thinking about using Anbox Cloud for your next project? [Get in touch!](https://
 | 2 | reference/supported-rendering-resources | [Supported rendering resources](https://discourse.ubuntu.com/t/supported-rendering-resources/37322) |
 | 2 | reference/supported-codecs | [Supported codecs](https://discourse.ubuntu.com/t/37323)|
 | 2 | reference/android-features | [Supported Android features](https://discourse.ubuntu.com/t/supported-android-features/28825)|
+| 2 | reference/anbox-features | [Supported Anbox features](TBD)|
 | 2 | reference/ams-configuration | [AMS configuration](https://discourse.ubuntu.com/t/ams-configuration/20872)|
 | 2 | reference/application-manifest | [Application manifest](https://discourse.ubuntu.com/t/application-manifest/24197)|
 | 2 | reference/api-reference | [APIs](https://discourse.ubuntu.com/t/api-reference/24339) |

--- a/reference/ams-configuration.tmpl.md
+++ b/reference/ams-configuration.tmpl.md
@@ -74,7 +74,7 @@ Once set, this feature flag will be considered by all newly launched instances.
 
 #### Custom Android ID
 
-*since 1.18.0*
+*since 1.18.0, supported on AOSP images only*
 
 To enable the Android container to use a custom Android ID, add the feature flag `android.allow_custom_android_id` upon application creation. A system app can influence the Android ID of a specific app during the Android runtime by setting the system property in the format of:
   ```

--- a/reference/anbox-features.md
+++ b/reference/anbox-features.md
@@ -1,0 +1,11 @@
+Anbox Cloud provides images based on the Android Open Source Project (AOSP), an operating system typically used in mobile devices or an Anbox Cloud AAOS image which is based on the Android Automotive OS (AAOS), an infotainment platform used in automobiles. Supported Anbox features differ depending what a given image is based on.
+
+The following table lists some Anbox features and whether they are supported for a given base.
+
+| Feature                                                                                                             | AOSP | AAOS |
+|---------------------------------------------------------------------------------------------------------------------|------|------|
+| boot-package and boot-activity in [application manifest](https://discourse.ubuntu.com/t/application-manifest/24197) | ✓    |      |
+| [Install app as system app](https://discourse.ubuntu.com/t/how-to-install-an-apk-as-a-system-app/27086)             | ✓    |      |
+| [Custom Android ID](https://discourse.ubuntu.com/t/ams-configuration/20872#custom-android-id-10)                    | ✓    |      |
+| [VHAL HTTP API](https://discourse.ubuntu.com/t/anbox-http-api/17819#h-10vhal-31)                                    |      | ✓    |
+| [VhalConnector](TBD) in Platform SDK API                                                                            |      | ✓    |

--- a/reference/android-features.md
+++ b/reference/android-features.md
@@ -8,6 +8,7 @@ Anbox Cloud implements support for various Android features. The following table
 | [Camera](https://source.android.com/devices/camera) |  ✓  |     |
 | [Sensors](https://source.android.com/devices/sensors) |  ✓  |   |
 | Location           |  ✓  |          |
+| [VHAL](https://source.android.com/docs/automotive/vhal) |  ✓  | Only on [AAOS images](https://discourse.ubuntu.com/t/provided-images/24185). |
 | NFC                |      |            |
 | [Bluetooth](https://source.android.com/devices/bluetooth) | | |
 | WiFi               |  ✓  | Only simulated WiFi is provided to the Android instance. |

--- a/reference/application-manifest.md
+++ b/reference/application-manifest.md
@@ -11,8 +11,8 @@ Name          | Value type | Description | Status |
 `image` (optional) | string     | Name or ID of an image to be used for the application. The default image is used if empty. [Jump to details](#image-2) | Supported |
 `addons` (optional) | array      | List of addons to be installed during the application bootstrap process. | Supported |
 `tags` (optional) | array      | List of tags to be associated with the application. | Supported |
-`boot-package` (optional) | string     | Package to launch once the system has booted (default: package name retrieved from the APK if APK file is present). | Supported |
-`boot-activity` (optional) | string     | Activity of boot package to launch once the system has booted (default: main activity as defined in the application manifest). | Supported |
+`boot-package` (optional) | string     | Package to launch once the system has booted (default: package name retrieved from the APK if APK file is present). | Supported on AOSP only |
+`boot-activity` (optional) | string     | Activity of boot package to launch once the system has booted (default: main activity as defined in the application manifest). | Supported on AOSP only |
 `video-encoder` (optional) | string     | Video encoder to be used by an instance launched from the application  (default: `gpu-preferred`). Possible values are: `gpu`, `gpu-preferred`, `software`. [Jump to details](#video-encoder-4) | Supported |
 `watchdog` (optional)    | map        | Watchdog settings to be configured on application installation. [Jump to details](#watchdog-5)| Supported |
 `services` (optional)    | array      | Services to be provided from the installed application. [Jump to details](#services-6) | Supported |

--- a/reference/provided-images.md
+++ b/reference/provided-images.md
@@ -8,8 +8,8 @@ The following table lists supported images available on the official image serve
 
 | Name                        | Based on | Android Version | Ubuntu Version | Available since |
 |-----------------------------|----------|-----------------|----------------|---------------|
-| `jammy:android13:amd64`     | AAOS     | 13              | 22.04          | 1.21.0 |
-| `jammy:android13:arm64`     | AAOS     | 13              | 22.04          | 1.21.0 |
+| `jammy:aaos13:amd64`        | AAOS     | 13              | 22.04          | 1.21.0 |
+| `jammy:aaos13:arm64`        | AAOS     | 13              | 22.04          | 1.21.0 |
 | `jammy:android13:amd64`     | AOSP     | 13              | 22.04          | 1.16.0 |
 | `jammy:android13:arm64`     | AOSP     | 13              | 22.04          | 1.16.0 |
 | `jammy:android12:amd64`     | AOSP     | 12              | 22.04          | 1.14.0 |


### PR DESCRIPTION
This updates the documentation by adding what features are supported/unsupported on AOSP/AAOS.

One link is missing for the Platform SDK API while https://github.com/canonical/anbox-cloud.github.com/pull/1 is not merged.