### PR TITLE
fix: update links from anbox-cloud.github.io to canonical.github.io

### DIFF
--- a/explanation/ams.md
+++ b/explanation/ams.md
@@ -4,7 +4,7 @@ The Anbox Management Service (AMS) sits at the heart of Anbox Cloud and handles 
 
 AMS is usually managed through the command line interface, the Anbox Management Client (AMC), which can run either on the same machine as AMS or on a remote machine.
 
-Since AMS exposes an HTTP interface, any tool can use the [AMS HTTP API](https://anbox-cloud.github.io/latest/ams/) to interact with AMS. Both the AMC (when running as a remote client) and the Anbox Application Registry (AAR) use the AMS HTTP API to interact with AMS.
+Since AMS exposes an HTTP interface, any tool can use the [AMS HTTP API](https://canonical.github.io/anbox-cloud.github.com/latest/ams/) to interact with AMS. Both the AMC (when running as a remote client) and the Anbox Application Registry (AAR) use the AMS HTTP API to interact with AMS.
 
 You can also develop your own client by using the [AMS SDK](https://discourse.ubuntu.com/t/ams-sdk-api-reference/17845).
 

--- a/explanation/instances.md
+++ b/explanation/instances.md
@@ -75,7 +75,7 @@ Status            |  Description
 
 AMS allows to start an instance in development mode. This mode turns off some features that are usually active in an instance. It is mainly useful when developing addons inside an instance.
 
-When development mode is enabled, the instance sends status updates to AMS when the Anbox runtime is terminated, however, AMS allows the instance to continue running. This allows you to restart the Anbox runtime inside the instance, providing an easy way to test [addons](https://discourse.ubuntu.com/t/addons/25293) or develop a [platform plugin](https://anbox-cloud.github.io/latest/anbox-platform-sdk/).
+When development mode is enabled, the instance sends status updates to AMS when the Anbox runtime is terminated, however, AMS allows the instance to continue running. This allows you to restart the Anbox runtime inside the instance, providing an easy way to test [addons](https://discourse.ubuntu.com/t/addons/25293) or develop a [platform plugin](https://canonical.github.io/anbox-cloud.github.com/latest/anbox-platform-sdk/).
 
 To check whether development mode is enabled, run `amc show <instance_ID>` or look at the `/var/lib/anbox/session.yaml` file in the instance. If the `devmode` field in the configuration file is set to `true`, development mode is active.
 

--- a/howto/application/userdata.md
+++ b/howto/application/userdata.md
@@ -21,7 +21,7 @@ When you start a streaming session, you can pass in custom data through the Anbo
 
   ![Specify extra data in the web dashboard](https://assets.ubuntu.com/v1/16e9a133-manage_applications_extra-data.png)
 
-* When starting the session through the Stream Gateway API, provide your custom data through the `extra_data` field. See [Create session](https://anbox-cloud.github.io/latest/anbox-stream-gateway/#/session/handle-new-session) in the Anbox Stream Gateway documentation.
+* When starting the session through the Stream Gateway API, provide your custom data through the `extra_data` field. See [Create session](https://canonical.github.io/anbox-cloud.github.com/latest/anbox-stream-gateway/#/session/handle-new-session) in the Anbox Stream Gateway documentation.
 
 In both cases, the data is added to the `/var/lib/anbox/userdata` file in JSON format. This file already contains data added by the Stream Gateway for the streaming session. The custom data is available under the `extra_data` field. For example:
 

--- a/reference/anbox-https-api.md
+++ b/reference/anbox-https-api.md
@@ -108,7 +108,7 @@ Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.
  * Operation: sync
  * Return: Current location status
 
-[note type="information" status="Note"]After enabling the location endpoint, any location updates provided via the [Anbox Platform API](https://anbox-cloud.github.io/latest/anbox-platform-sdk/) won't be processed by Anbox until the location endpoint is disabled again.[/note]
+[note type="information" status="Note"]After enabling the location endpoint, any location updates provided via the [Anbox Platform API](https://canonical.github.io/anbox-cloud.github.com/latest/anbox-platform-sdk/) won't be processed by Anbox until the location endpoint is disabled again.[/note]
 
  Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0/location | jq .`:
 

--- a/reference/release-notes/1.14.2.md
+++ b/reference/release-notes/1.14.2.md
@@ -8,7 +8,7 @@ Please see [component versions](https://anbox-cloud.io/docs/component-versions) 
 
 * Included Android security updates for July 2022 (see [Android Security Bulletin - July 2022](https://source.android.com/security/bulletin/2022-07-01) for more information).
 * Updated Android WebView to [103.0.5060.71](https://chromereleases.googleblog.com/2022/07/chrome-for-android-update.html).
-* [Join URLs](https://anbox-cloud.github.io/latest/anbox-stream-gateway/#/session/handle-join-session) handed out by the Anbox Stream Gateway to the Anbox container instances will now not expire anymore. This allows sessions to run forever, if needed.
+* [Join URLs](https://canonical.github.io/anbox-cloud.github.com/latest/anbox-stream-gateway/#/session/handle-join-session) handed out by the Anbox Stream Gateway to the Anbox container instances will now not expire anymore. This allows sessions to run forever, if needed.
 * The Anbox Cloud Appliance now supports deploying behind a HTTP proxy through the `--proxy` argument available for the `anbox-cloud-appliance init` command.
 
 #### Bugs

--- a/reference/release-notes/1.17.0.md
+++ b/reference/release-notes/1.17.0.md
@@ -16,7 +16,7 @@ As of Anbox Cloud 1.17, support is still kept behind a feature flag and is curre
 
 ### Dynamic screen resolution
 
-Anbox Cloud allows changing the screen resolution of already running Android instances. This is helpful especially when containers are being used for clients with different display aspect ratios to avoid letter boxing. Internally, the Anbox runtime will reconfigure the Android display with the new resolution and afterwards the encoded video stream will match the new resolution. Changing the display resolution is possible at the time of connection via the [`/1.0/sessions/<id>/join` API endpoint]([https://anbox-cloud.github.io/latest/anbox-stream-gateway/](https://anbox-cloud.github.io/latest/anbox-stream-gateway/#/session/handle-join-session)) of the Anbox Stream Gateway.
+Anbox Cloud allows changing the screen resolution of already running Android instances. This is helpful especially when containers are being used for clients with different display aspect ratios to avoid letter boxing. Internally, the Anbox runtime will reconfigure the Android display with the new resolution and afterwards the encoded video stream will match the new resolution. Changing the display resolution is possible at the time of connection via the [`/1.0/sessions/<id>/join` API endpoint]([https://canonical.github.io/anbox-cloud.github.com/latest/anbox-stream-gateway/](https://canonical.github.io/anbox-cloud.github.com/latest/anbox-stream-gateway/#/session/handle-join-session)) of the Anbox Stream Gateway.
 
 ### Start and stop support for containers
 

--- a/reference/release-notes/1.19.0.md
+++ b/reference/release-notes/1.19.0.md
@@ -8,7 +8,7 @@ Please see [component versions](https://anbox-cloud.io/docs/ref/component-versio
 
 ### Core stack improvements
 
-* The Anbox Management Service (AMS) API documentation created using OpenAPI specification (Swagger 2.0) is available on the AMS host at `/1.0/swagger.json` and at https://anbox-cloud.github.io/latest/ams/.<!--AC-1474-->
+* The Anbox Management Service (AMS) API documentation created using OpenAPI specification (Swagger 2.0) is available on the AMS host at `/1.0/swagger.json` and at https://canonical.github.io/anbox-cloud.github.com/latest/ams/.<!--AC-1474-->
 * Pagination and filtering support is enabled for containers and applications in the AMS API. You can use it by directly interacting with the AMS using API calls.<!--AC-1475-->
 * A cgroup v1 emulation layer is added for cgroup v2-only hosts. This is required by Android for resource tracking and management.<!--AC-1463-->
 * Enhanced configuration of failure domain of LXD nodes to ensure LXD makes its database highly available across multiple availability zones.<!--AC-1573-->

--- a/reference/sdks.md
+++ b/reference/sdks.md
@@ -8,7 +8,7 @@ Anbox Cloud provides a series of Software Development Kits (SDKs) to facilitate 
 
 The Anbox Platform SDK provides support for developing custom platform plugins, which allows cloud providers to integrate Anbox with their existing infrastructure. The SDK provides several integration points for things like rendering, audio or input processing.
 
-For more details about custom platform plugins, refer to the [Anbox Platform SDK API documentation](https://anbox-cloud.github.io/latest/anbox-platform-sdk/).
+For more details about custom platform plugins, refer to the [Anbox Platform SDK API documentation](https://canonical.github.io/anbox-cloud.github.com/latest/anbox-platform-sdk/).
 
 ### Download and installation
 

--- a/reference/supported-rendering-resources.md
+++ b/reference/supported-rendering-resources.md
@@ -34,7 +34,7 @@ See [Component versions](https://discourse.ubuntu.com/t/21413) to refer to the a
 
 ## Supported platforms
 
-Anbox Cloud can make use of different [platforms](https://anbox-cloud.github.io/latest/anbox-platform-sdk/) to customise its behaviour and currently supports 3 platforms.
+Anbox Cloud can make use of different [platforms](https://canonical.github.io/anbox-cloud.github.com/latest/anbox-platform-sdk/) to customise its behaviour and currently supports 3 platforms.
 
 | Name     	| Behaviour                                                                                                                                            	|
 |----------	|-----------------------------------------------------------------------------------------------------------------------------------------------------	|


### PR DESCRIPTION
Changes all anbox-cloud.github.io links in the docs to instead use canonical.github.io/anbox-cloud.github.com as the previous website is not online anymore.

This was done through a quick search and replace:
```bash
rg 'anbox-cloud.github.io' -l \
    | xargs -n1 sed -i 's#anbox-cloud.github.io#canonical.github.io/anbox-cloud.github.com#g'
```