### PR TITLE
chore: switch github.com/anbox-cloud links to github.com/canonical

### DIFF
--- a/howto/anbox/develop-platform.md
+++ b/howto/anbox/develop-platform.md
@@ -8,11 +8,11 @@ A platform module must be built on the same version of Ubuntu as the Anbox runti
 
 However, if you're running the Anbox Cloud Appliance on a machine with a different Ubuntu version, you can build the platform on a separate system (for example, in a LXD or docker instance or on another machine).
 
-To get started, you must first install the [Anbox Platform SDK](https://github.com/anbox-cloud/anbox-platform-sdk). To do so, follow the [installation instructions](https://discourse.ubuntu.com/t/anbox-cloud-sdks/17844#anbox-platform-sdk-1).
+To get started, you must first install the [Anbox Platform SDK](https://github.com/canonical/anbox-platform-sdk). To do so, follow the [installation instructions](https://discourse.ubuntu.com/t/anbox-cloud-sdks/17844#anbox-platform-sdk-1).
 
 ## Build the example platform
 
-The [Anbox Platform SDK](https://github.com/anbox-cloud/anbox-platform-sdk) comes with various examples that demonstrate different features. The following steps use the `minimal` example. Alternatively, choose the `nvidia` example if you're working with NVIDIA GPUs and want to see graphical output.
+The [Anbox Platform SDK](https://github.com/canonical/anbox-platform-sdk) comes with various examples that demonstrate different features. The following steps use the `minimal` example. Alternatively, choose the `nvidia` example if you're working with NVIDIA GPUs and want to see graphical output.
 
 To build the `minimal` platform example, run the following commands:
 

--- a/howto/stream/client-side-keyboard.md
+++ b/howto/stream/client-side-keyboard.md
@@ -15,9 +15,9 @@ To enable the app running in the Android container to receive the texts sent fro
 
 ## 1. Import the AAR library
 
-Check out the [Anbox Streaming SDK](https://github.com/anbox-cloud/anbox-streaming-sdk) from GitHub:
+Check out the [Anbox Streaming SDK](https://github.com/canonical/anbox-streaming-sdk) from GitHub:
 
-    git clone https://github.com/anbox-cloud/anbox-streaming-sdk.git
+    git clone https://github.com/canonical/anbox-streaming-sdk.git
 
 The `android/libs` folder contains the `com.canonical.anbox.streaming_sdk.aar` AAR file. See the official [documentation](https://developer.android.com/studio/projects/android-library) for how to import an Android library into an Android application project.
 

--- a/howto/stream/oob-data.md
+++ b/howto/stream/oob-data.md
@@ -266,7 +266,7 @@ try {
 }
 ```
 <!-- wokeignore:rule=master -->
-For a complete Android example, see the [out_of_band_v2](https://github.com/anbox-cloud/anbox-streaming-sdk/tree/master/examples/android/out_of_band_v2) project.
+For a complete Android example, see the [out_of_band_v2](https://github.com/canonical/anbox-streaming-sdk/tree/master/examples/android/out_of_band_v2) project.
 
 ## Version 1
 
@@ -303,9 +303,9 @@ be disallowed, and a security exception will be raised.
 
 #### Import Java library
 
-Check out the [Anbox Streaming SDK](https://github.com/anbox-cloud/anbox-streaming-sdk) from GitHub:
+Check out the [Anbox Streaming SDK](https://github.com/canonical/anbox-streaming-sdk) from GitHub:
 
-    git clone https://github.com/anbox-cloud/anbox-streaming-sdk.git
+    git clone https://github.com/canonical/anbox-streaming-sdk.git
 
 To import the `com.canonical.anbox.platform_api_skeleton.jar` library into your
 Android project, refer to the official [documentation](https://developer.android.com/studio/build/dependencies)

--- a/reference/release-notes/1.15.0.md
+++ b/reference/release-notes/1.15.0.md
@@ -23,7 +23,7 @@ Please see [component versions](https://anbox-cloud.io/docs/component-versions) 
 * [Tracing support](https://anbox-cloud.io/docs/ref/anbox-https-api#heading--10tracing) in Anbox now includes support for tracing the WebRTC stack as well.
 * A new HTTP `/1.0/platform` API allows runtime configuration of the currently loaded platform. For WebRTC, you can now enable RTP trace collection and retrieve information about the current status of the streamer.
 * Anbox now uses the recently released [LXC 5.0](https://discuss.linuxcontainers.org/t/lxc-5-0-lts-has-been-released/14381).
-* The WebRTC streamer now allows streaming only audio, only video or neither of them, which can be useful in cases where only the exchange of OOB messages is needed. See the [JS SDK](https://github.com/anbox-cloud/anbox-streaming-sdk/blob/master/js/anbox-stream-sdk.js) <!-- wokeignore:rule=master --> for details on how to use this feature.
+* The WebRTC streamer now allows streaming only audio, only video or neither of them, which can be useful in cases where only the exchange of OOB messages is needed. See the [JS SDK](https://github.com/canonical/anbox-streaming-sdk/blob/master/js/anbox-stream-sdk.js) <!-- wokeignore:rule=master --> for details on how to use this feature.
 * Anbox now uses [`jemalloc`](https://github.com/jemalloc/jemalloc) as memory allocator to improve its overall memory footprint.
 * A new OOB version 2 implementation allows bi-directional communication with the Anbox container through the use of data channels. See [the documentation](https://anbox-cloud.io/docs/howto/stream/oob-data) for more details. With the introduction of OOB version 2, the former implementation is deprecated and will be removed in a future Anbox Cloud release.
 

--- a/reference/sdks.md
+++ b/reference/sdks.md
@@ -14,7 +14,7 @@ For more details about custom platform plugins, refer to the [Anbox Platform SDK
 
 The Anbox Platform SDK can be downloaded via Git from GitHub:
 
-    git clone https://github.com/anbox-cloud/anbox-platform-sdk.git
+    git clone https://github.com/canonical/anbox-platform-sdk.git
 
 You need the following build dependencies:
 
@@ -31,13 +31,13 @@ The Anbox Platform SDK provides a collection of example platform plugins to help
 
 The AMS SDK offers a set of [Go](https://golang.org/) packages and utilities for any external [Go](https://golang.org/) code to be able to connect to the AMS service through the exposed REST API.
 
-See the [AMS SDK documentation](https://github.com/anbox-cloud/ams-sdk) on GitHub for more information.
+See the [AMS SDK documentation](https://github.com/canonical/ams-sdk) on GitHub for more information.
 
 ### Download and installation
 
 The AMS SDK can be downloaded via Git from GitHub:
 
-    git clone https://github.com/anbox-cloud/ams-sdk.git
+    git clone https://github.com/canonical/ams-sdk.git
 
 To start using the SDK, simply add the content of the provided SDK zip file into your projects `vendor/` directory or your `GOPATH`.
 
@@ -47,7 +47,7 @@ The AMS SDK comes with a set of examples demonstrating the capabilities of the S
 
 ### Authentication setup
 
-Clients must authenticate to AMS before communicating with it. For more information, see [How to control AMS remotely](https://discourse.ubuntu.com/t/managing-ams-access/17774) and the [AMS SDK documentation](https://github.com/anbox-cloud/ams-sdk) on GitHub.
+Clients must authenticate to AMS before communicating with it. For more information, see [How to control AMS remotely](https://discourse.ubuntu.com/t/managing-ams-access/17774) and the [AMS SDK documentation](https://github.com/canonical/ams-sdk) on GitHub.
 
 ## Anbox Cloud Streaming SDK
 
@@ -83,7 +83,7 @@ To use the Anbox Cloud streaming SDK, you must have [deployed the Anbox Streamin
 
 You can download the Anbox Cloud streaming SDK via Git from GitHub:
 
-    git clone https://github.com/anbox-cloud/anbox-streaming-sdk.git
+    git clone https://github.com/canonical/anbox-streaming-sdk.git
 
 ### Examples
 

--- a/tutorial/stream-client.md
+++ b/tutorial/stream-client.md
@@ -24,7 +24,7 @@ See [How to access the stream gateway](https://discourse.ubuntu.com/t/how-to-acc
 
 Download the [Anbox Cloud streaming SDK](https://discourse.ubuntu.com/t/anbox-cloud-sdks/17844#anbox-cloud-streaming-sdk-8) from GitHub:
 
-    git clone https://github.com/anbox-cloud/anbox-streaming-sdk.git
+    git clone https://github.com/canonical/anbox-streaming-sdk.git
 
 ### Create an application
 


### PR DESCRIPTION
As the repositories have been moved to the Canonical organization from the Anbox Cloud organization, we should update the repos links to point to the correct URL.

This was done with a simple search and replace:
```bash
rg 'github.com/anbox-cloud' -l \
    | xargs -n1 sed -i 's#github.com/anbox-cloud#github.com/canonical#g'
```