### PR TITLE
Fixing AMS config missing deprecated column

### DIFF
--- a/reference/ams-configuration.yaml
+++ b/reference/ams-configuration.yaml
@@ -7,7 +7,7 @@ all:
       Comma-separated list of addons that every application managed by
       AMS will use. See
       [How to enable an addon globally](https://discourse.ubuntu.com/t/enable-an-addon-globally/25285).
-    deprecated: false
+    deprecated: "No"  # Unquoted No will be considered as false in YAML parsing
   application.auto_publish:
     type: "bool"
     default: "true"
@@ -16,7 +16,7 @@ all:
       versions when the bootstrap process is finished. `false`
       disables this. See
       [Publish application versions](https://discourse.ubuntu.com/t/update-an-application/24201#publish-application-versions-1).
-    deprecated: false
+    deprecated: "No"
   application.auto_update:
     type: "bool"
     default: "true"
@@ -25,7 +25,7 @@ all:
       whenever any dependencies (parent image, addons, global
       configuration) change. `false` disables this. See
       [Configure automatic application updates](https://discourse.ubuntu.com/t/update-an-application/24201#configure-automatic-application-updates-3).
-    deprecated: false
+    deprecated: "No"
   application.default_abi:
     type: "string"
     default: "-"
@@ -33,7 +33,7 @@ all:
       Default Android ABI that applications should use. See
       [Android ABIs](https://developer.android.com/ndk/guides/abis)
       for a list of available ABIs.
-    deprecated: false
+    deprecated: "No"
   application.max_published_versions:
     type: "integer"
     default: "3"
@@ -41,7 +41,7 @@ all:
       Maximum number of published versions per application. If the
       number of versions of an application exceeds this configuration,
       AMS will automatically clean up older versions.
-    deprecated: false
+    deprecated: "No"
   container.apt_mirror:
     type: "string"
     default: "-"
@@ -50,7 +50,7 @@ all:
       `http://archive.ubuntu.com` (amd64) or `http://ports.ubuntu.com`
       (arm64) is used. This configuration item is deprecated since 1.20,
       use `instance.apt_mirror` instead.
-    deprecated: true
+    deprecated: "Yes"
   instance.apt_mirror:
     type: "string"
     default: "-"
@@ -58,7 +58,7 @@ all:
       APT mirror to use within the instances. By default,
       `http://archive.ubuntu.com` (amd64) or `http://ports.ubuntu.com`
       (arm64) is used.
-    deprecated: false
+    deprecated: "No"
   container.default_platform:
     type: "string"
     default: "-"
@@ -66,14 +66,14 @@ all:
       The name of the platform that Anbox Cloud uses by default to launch
       containers. This configuration item is deprecated since 1.20,
       use `instance.default_platform` instead.
-    deprecated: true
+    deprecated: "Yes"
   instance.default_platform:
     type: "string"
     default: "-"
     description: >-
       The name of the platform that Anbox Cloud uses by default to launch
       instances.
-    deprecated: false
+    deprecated: "No"
   container.features:
     type: "string"
     default: "-"
@@ -81,13 +81,13 @@ all:
       Comma-separated list of features to enable (see list below).
       This configuration item is deprecated since 1.20, use
       `instance.features` instead.
-    deprecated: true
+    deprecated: "Yes"
   instance.features:
     type: "string"
     default: "-"
     description: >-
       Comma-separated list of features to enable (see list below).
-    deprecated: false
+    deprecated: "No"
   container.network_proxy:
     type: "string"
     default: "-"
@@ -95,20 +95,20 @@ all:
       Network proxy to use inside the containers. This configuration
       item is deprecated since 1.20, use `instance.network_proxy`
       instead.
-    deprecated: true
+    deprecated: "Yes"
   instance.network_proxy:
     type: "string"
     default: "-"
     description: >-
       Network proxy to use inside the instances.
-    deprecated: false
+    deprecated: "No"
   container.security_updates:
     type: "bool"
     default: "true"
     description: >-
       If set to `true`, automatic Ubuntu security updates are applied
       during the application bootstrap process. `false` disables this.
-    deprecated: true
+    deprecated: "Yes"
   instance.security_updates:
     type: "bool"
     default: "true"
@@ -117,32 +117,32 @@ all:
       during the application bootstrap process. `false` disables this.
       This configuration item is deprecated since 1.20, use
       `instance.security_updates` instead.
-    deprecated: false
+    deprecated: "No"
   core.proxy_http:
     type: "string"
     default: "-"
     description: >-
       HTTP proxy to use for HTTP requests that AMS performs.
-    deprecated: false
+    deprecated: "No"
   core.proxy_https:
     type: "string"
     default: "-"
     description: >-
       HTTPS proxy to use for HTTPS requests that AMS performs.
-    deprecated: false
+    deprecated: "No"
   core.proxy_ignore_hosts:
     type: "string"
     default: "-"
     description: >-
       Comma-separated list that defines the hosts for which a
       configured proxy is not used.
-    deprecated: false
+    deprecated: "No"
   core.trust_password:
     type: "string"
     default: "-"
     description: >-
       The AMS trust password.
-    deprecated: false
+    deprecated: "No"
   cpu.limit_mode:
     type: "string"
     default: "scheduler"
@@ -150,7 +150,7 @@ all:
       The mode AMS uses to limit CPU access for an instance. See
       [About performance](https://discourse.ubuntu.com/t/about-performance/29416) for details.
       Possible values are: `scheduler`, `pinning`
-    deprecated: false
+    deprecated: "No"
   gpu.allocation_mode:
     type: "string"
     default: "`all`"
@@ -158,20 +158,20 @@ all:
       Method of allocating GPUs: `all` tells AMS to allocate all
       available GPUs on a system to an instance. `single` allocates
       only a single GPU.
-    deprecated: false
+    deprecated: "No"
   gpu.type:
     type: "string"
     default: "`none`"
     description: >-
       Type of GPU: `none`, `intel`, `nvidia`, `amd`
-    deprecated: false
+    deprecated: "No"
   images.allow_insecure:
     type: "bool"
     default: "false"
     description: >-
       If set to `true`, AMS allows accepting untrusted certificates
       provided by the configured image server.
-    deprecated: false
+    deprecated: "No"
   images.auth:
     type: "string"
     default: "-"
@@ -180,19 +180,19 @@ all:
       reading this configuration, a Boolean value that indicates
       whether the item is set is returned, to avoid exposing
       credentials.
-    deprecated: false
+    deprecated: "No"
   images.update_interval:
     type: "string"
     default: "`5m`"
     description: >-
       Frequency of image updates (for example: 1h, 30m).
-    deprecated: false
+    deprecated: "No"
   images.url:
     type: "string"
     default: "`https://images.anbox-cloud.io/stable/`"
     description: >-
       URL of the image server to use.
-    deprecated: false
+    deprecated: "No"
   images.version_lockstep:
     type: "bool"
     default: "true"
@@ -202,7 +202,7 @@ all:
       automatically updated to newer image versions if AMS is still at
       an older version. This only applies for new major and minor but
       not patch version updates.
-    deprecated: false
+    deprecated: "No"
   load_balancer.url:
     type: "string"
     default: "-"
@@ -211,7 +211,7 @@ all:
       handed to instances started by AMS to allow them to contact AMS
       through the load balancer and not via the address of an
       individual AMS instance.
-    deprecated: false
+    deprecated: "No"
   node.queue_size:
     type: "integer"
     default: "100"
@@ -219,14 +219,14 @@ all:
       Maximum size of the queue containing requests to start and stop
       instances per LXD node. Changing the value requires a restart of
       AMS.
-    deprecated: false
+    deprecated: "No"
   node.workers_per_queue:
     type: "integer"
     default: "4"
     description: >-
       Number of workers processing instance start and stop requests.
       Changing the value requires a restart of AMS.
-    deprecated: false
+    deprecated: "No"
   registry.filter:
     type: "string"
     default: "-"
@@ -235,7 +235,7 @@ all:
       fetched from the
       [Anbox Application Registry](https://discourse.ubuntu.com/t/application-registry/17761).
       If empty, no filter is applied.
-    deprecated: false
+    deprecated: "No"
   registry.fingerprint:
     type: "string"
     default: "-"
@@ -244,7 +244,7 @@ all:
       [Anbox Application Registry](https://discourse.ubuntu.com/t/application-registry/17761)
       uses to TLS-secure its HTTPS endpoint. This is used by AMS for
       mutual TLS authentication with the registry.
-    deprecated: false
+    deprecated: "No"
   registry.mode:
     type: "string"
     default: "`pull`"
@@ -252,7 +252,7 @@ all:
       Mode in which the
       [Anbox Application Registry](https://discourse.ubuntu.com/t/application-registry/17761)
       client in AMS operates: `manual`, `pull`, `push`
-    deprecated: false
+    deprecated: "No"
   registry.update_interval:
     type: "string"
     default: "`1h`"
@@ -260,7 +260,7 @@ all:
       Frequency of
       [Anbox Application Registry](https://discourse.ubuntu.com/t/application-registry/17761)
       updates (for example: 1h, 30m).
-    deprecated: false
+    deprecated: "No"
   registry.url:
     type: "string"
     default: "-"
@@ -268,7 +268,7 @@ all:
       URL of the
       [Anbox Application Registry](https://discourse.ubuntu.com/t/application-registry/17761)
       to use.
-    deprecated: false
+    deprecated: "No"
   scheduler.strategy:
     type: "string"
     default: "`spread`"
@@ -276,7 +276,7 @@ all:
       Strategy that the internal instance scheduler in AMS uses to
       distribute instances across available LXD nodes: `binpack`,
       `spread`
-    deprecated: false
+    deprecated: "No"
 node:
   cpu-allocation-rate:
     type: "integer"
@@ -284,13 +284,13 @@ node:
     description: >-
       CPU allocation rate used for
       [over-committing resources](https://discourse.ubuntu.com/t/about-capacity-planning/28717#over-committing-resources-3).
-    deprecated: false
+    deprecated: "No"
   cpus:
     type: "integer"
     default: "all available"
     description: >-
       Number of CPUs dedicated to instances.
-    deprecated: false
+    deprecated: "No"
   gpu-encoder-slots:
     type: "integer"
     default: >-
@@ -298,7 +298,7 @@ node:
       NVIDIA GPU)<br/>10 (for nodes with Intel GPU)
     description: >-
       Number of GPU encoder slots available on the node.
-    deprecated: false
+    deprecated: "No"
   gpu-slots:
     type: "integer"
     default: >-
@@ -308,42 +308,42 @@ node:
       Number of
       [GPU slots](https://discourse.ubuntu.com/t/about-capacity-planning/28717#gpu-slots-2)
       available on the node.
-    deprecated: false
+    deprecated: "No"
   memory:
     type: "integer"
     default: "all available"
     description: >-
       Memory dedicated to instances.
-    deprecated: false
+    deprecated: "No"
   memory-allocation-rate:
     type: "integer"
     default: "2"
     description: >-
       Memory allocation rate used for
       [over-committing resources](https://discourse.ubuntu.com/t/about-capacity-planning/28717#over-committing-resources-3).
-    deprecated: false
+    deprecated: "No"
   public-address:
     type: "string"
     default: "-"
     description: >-
       The public, reachable address of the node.
-    deprecated: false
+    deprecated: "No"
   subnet:
     type: "string"
     default: "-"
     description: >-
       The network subnet of the machine where the node runs.
-    deprecated: false
+    deprecated: "No"
   tags:
     type: "string"
     default: "-"
     description: >-
       Tags to identify the node.
-    deprecated: false
+    deprecated: "No"
   unschedulable:
     type: "bool"
     default: "false"
     description: >-
       If set to `true`, the node cannot be scheduled, which prevents
       new instances from being launched on it.
-    deprecated: false
+    deprecated: "No"

--- a/scripts/generate-ams-config.py
+++ b/scripts/generate-ams-config.py
@@ -11,12 +11,13 @@ with open("reference/ams-configuration.yaml", 'r') as f:
     # Loop through the different sections/tables in the YAML file
     # and generate a table for each
     for which, options in config.items():
-        table = "| Name | Type | Default |  Description            |\n"
-        table += "|------|------|---------|-------------------------|\n"
+        table = "| Name | Type | Deprecated |    Default    | Description           |\n"
+        table += "|-----|------|------------|---------------|-----------------------|\n"
 
         for option, info in sorted(options.items()):
             table += "| `" + str(option) + "` "
             table += "| " + str(info['type']) + " "
+            table += "| " + str(info['deprecated']) + " "
             table += "| " + str(info['default']) + " "
             table += "| " + str(info['description']) + " |\n"
 


### PR DESCRIPTION
(Need this PR to test the auto generation of AMS configuration tables)

The deprecated data about AMS config attributes are available in the source but it is not getting generated when being published. This PR is to fix it.