### PR TITLE
feat(howto): add howto use a custom VHAL with Anbox Cloud

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -187,6 +187,7 @@ OAuth
 OBB
 OBD
 observability
+ODM
 OES
 OOB
 OOM
@@ -303,6 +304,7 @@ virglrenderer
 VM
 VMs
 VNC
+VNDK
 VPC
 VPN
 VPU

--- a/howto/android/landing.md
+++ b/howto/android/landing.md
@@ -3,3 +3,4 @@ The guides in this section describe how to work with Android in Anbox Cloud.
 The following guides are available:
 
 * [Graphics debugging with Renderdoc](TBD)
+* [Replace the Anbox VHAL](TBD)

--- a/howto/android/odm_vhal.md
+++ b/howto/android/odm_vhal.md
@@ -1,0 +1,139 @@
+*since 1.22.0*
+
+[note type="information" status="Note"]Replacing the Anbox VHAL is only supported on [AAOS images](https://discourse.ubuntu.com/t/24185).
+The Anbox Cloud dashboard does not support custom VHAL implementations.[/note]
+
+This document will guide through the process of replacing the Anbox Cloud VHAL
+implementation with your own implementation placed in the
+[ODM partition](https://source.android.com/docs/core/architecture/partitions/odm-partitions)
+using an [addon](https://discourse.ubuntu.com/t/38727).
+
+## Prerequisites
+
+Your custom VHAL implementation must provide an
+[HIDL VHAL interface](https://source.android.com/docs/automotive/vhal/hidl-vhal-interface)
+and be built against VNDK 29.
+
+If your VHAL implementation requires additional libraries, they must also be
+bundled with the addon and copied in the ODM partition.
+
+## Create the addon
+
+This addon will be tasked with the following:
+
+1. Copying the VHAL binary to `/odm/bin/hw`.
+1. Copying an
+[init.rc file](https://android.googlesource.com/platform/system/core/+/master/init/README.md)
+for your VHAL service to `/odm/etc/init`.
+1. Disabling the Anbox Cloud VHAL by setting the `ro.anbox.automotive.vhal`
+property to `odm`. This will be done by writing that system property to the
+`/odm/etc/build.prop` file.
+
+In the following example, we will name our addon `custom-vhal`.
+To override the VHAL implementation, we will use a
+[pre-start hook](https://discourse.ubuntu.com/t/28555) which is executed
+before Android gets started.
+
+The directory layout for the addon is strict and must be:
+
+```
+custom-vhal/
+├── hooks
+│   └── pre-start
+├── manifest.yaml
+├── vhal
+└── vhal.rc
+```
+
+As mentioned in the prerequisites, any additional libraries must also be bundled with the addon.
+
+`vhal` is your custom VHAL implementation.
+
+`vhal.rc` is an [init.rc file](https://android.googlesource.com/platform/system/core/+/main/init/README.md) for your VHAL service, such as:
+
+```
+service custom-vhal /odm/bin/hw/vhal
+    class hal
+    user vehicle_network
+    group system inet
+    disabled
+
+on property:ro.anbox.automotive.vhal=odm
+    start custom-vhal
+```
+
+`hooks/pre-start` must be an executable file which will handle the tasks
+outlined at the beginning of this section, such as the following bash script:
+
+```bash
+#!/bin/bash -x
+#
+# Copyright 2024 Canonical Ltd.  All rights reserved.
+#
+
+ANDROID_ODM_DIR="${ANBOX_DIR}/android-odm"
+
+if [ "${INSTANCE_TYPE}" != base ]; then
+    exit 0
+fi
+
+# Ensure all needed directories are created
+mkdir -p "${ANDROID_ODM_DIR}/etc/init"
+mkdir -p "${ANDROID_ODM_DIR}/bin/hw"
+
+# Copy the custom VHAL and the associated init file in /odm
+cp "${ADDON_DIR}/vhal" "${ANDROID_ODM_DIR}/bin/hw/"
+cp "${ADDON_DIR}/vhal.rc" "${ANDROID_ODM_DIR}/etc/init/"
+
+# Set the ro.anbox.anbox.vhal system property to 'odm'
+echo "ro.anbox.automotive.vhal=odm" >> "${ANDROID_ODM_DIR}/etc/build.prop"
+```
+
+The addon
+[`manifest.yaml`](https://discourse.ubuntu.com/t/25293) file
+contains metadata:
+
+```yaml
+name: custom-vhal
+description: |
+  Addon replacing the Anbox Cloud VHAL with a custom implementation.
+```
+
+Once everything is in place, you can add the addon to your Anbox Cloud instance,
+with:
+
+```bash
+amc addon add custom-vhal ./custom-vhal
+```
+
+Please note that due to Snap strict confinement, the addon directory
+(`custom-vhal` here) must be located in the home directory of the user executing
+the `amc` command.
+
+## Use the addon
+
+The newly added `custom-vhal` addon must now be enabled to be used with
+Anbox Cloud applications.
+
+If you plan to always override the Anbox Cloud VHAL implementation in all
+applications, you can
+[enable the addon globally](https://discourse.ubuntu.com/t/25285):
+
+```bash
+amc config set application.addons custom-vhal
+```
+
+Otherwise, add it to your
+[application manifest](https://discourse.ubuntu.com/t/24197):
+
+```yaml
+name: my-app
+addons:
+  - custom-vhal
+```
+
+## Related information
+
+- [Create an addon](https://discourse.ubuntu.com/t/25284)
+- [How to use addons](https://discourse.ubuntu.com/t/17759)
+- [How to extend an application](https://discourse.ubuntu.com/t/28554)

--- a/index.md
+++ b/index.md
@@ -121,6 +121,7 @@ Thinking about using Anbox Cloud for your next project? [Get in touch!](https://
 | 3 | howto/anbox/enable-virgl | [Enable VirGL](https://discourse.ubuntu.com/t/how-to-enable-virgl/42426) |
 | 2 | howto/android/landing | [Work with Android](https://discourse.ubuntu.com/t/how-to-work-with-android-in-anbox-cloud/42428) |
 | 3 | howto/android/graphics-debugging-with-renderdoc | [Graphics debugging with Renderdoc](https://discourse.ubuntu.com/t/how-to-debug-graphics-with-renderdoc/42427) |
+| 3 | howto/android/odm_vhal | [Replace the Anbox VHAL](TBD) |
 | 2 | howto/troubleshoot/landing | [Troubleshoot Anbox Cloud](https://discourse.ubuntu.com/t/how-to-troubleshoot-anbox-cloud/17837)|
 | 3 | howto/troubleshoot/initial-setup | [Troubleshoot initial setup](https://discourse.ubuntu.com/t/troubleshoot-issues-with-initial-setup/35704)|
 | 3 | howto/troubleshoot/logs | [View logs](https://discourse.ubuntu.com/t/managing-logs/17771)|


### PR DESCRIPTION
This covers how to use the ODM partition and an addon to override the Anbox Cloud VHAL implementation with a custom-built one. This doesn't cover how to build such a binary, and that's left to the reader for now.