### PR TITLE
fix(exp,ref): swap container and vm minimum disk size

### DIFF
--- a/explanation/resources.md
+++ b/explanation/resources.md
@@ -7,7 +7,7 @@ name: my-application
 resources:
   cpus: 2
   memory: 3GB
-  disk-size: 15GB
+  disk-size: 3GB
 ```
 For a virtual machine instance, the default resource preset is:
 
@@ -16,7 +16,7 @@ name: my-application
 resources:
   cpus: 2
   memory: 3GB
-  disk-size: 3GB
+  disk-size: 15GB
 ```
 
 If your application requires different resources than the default, specify the required resources in the application manifest to override some or all of default resource preset options.

--- a/reference/amc-command-reference/init.md
+++ b/reference/amc-command-reference/init.md
@@ -10,7 +10,7 @@ The following options are available:
 | `-c`, `--cpus` | Integer | Number of CPU cores to be assigned for the instance. | 2 |
 | `--devmode` |    | Enables developer mode for the instance. | Disabled |
 | `--disable-watchdog` | | Disables watchdog for the instance. Applicable for regular instances only. | |
-| `-d`, `--disk-size` | String | Disk size of the instance. | 15 GB for a container instance;<br/> 3 GB for a virtual machine instance |
+| `-d`, `--disk-size` | String | Disk size of the instance. | 3 GB for a container instance;<br/> 15 GB for a virtual machine instance |
 | `--enable-graphics` | | Enables graphics for the instance | Disabled |
 | `-f`, `--features` | String | Comma-separated list of features to enable for the Anbox runtime inside the instance | |
 | `-g`, `--gpu-slots` |  Integer | Number of GPU slots to be assigned for the instance. | -1 |

--- a/reference/amc-command-reference/launch.md
+++ b/reference/amc-command-reference/launch.md
@@ -10,7 +10,7 @@ The following options are available:
 | `-c`, `--cpus` | Integer | Number of CPU cores to be assigned for the instance. | 2 |
 | `--devmode` |    | Enables developer mode for the instance. | Disabled |
 | `--disable-watchdog` | | Disables watchdog for the instance. Applicable for regular instances only. | |
-| `-d`, `--disk-size` | String | Disk size of the instance. | 15 GB for a container instance;<br/> 3 GB for a virtual machine instance |
+| `-d`, `--disk-size` | String | Disk size of the instance. | 3 GB for a container instance;<br/> 15 GB for a virtual machine instance |
 | `--enable-graphics` | | Enables graphics for the instance | Disabled |
 | `-f`, `--features` | String | Comma-separated list of features to enable for the Anbox runtime inside the instance | |
 | `-g`, `--gpu-slots` |  Integer | Number of GPU slots to be assigned for the instance. | -1 |


### PR DESCRIPTION
In the docs, the minimum disk size for containers and VMs was swapped: the minimum disk size for a container is 3GB, but the minimum disk size for a VM is 15GB.