### PR TITLE
Update howto for streaming applications

### DIFF
--- a/howto/application/stream.md
+++ b/howto/application/stream.md
@@ -1,4 +1,23 @@
-You can stream applications using the Anbox Cloud dashboard or your custom stream client.
+You can stream applications using the `amc` CLI or a stream client. The stream client can be the Anbox Cloud dashboard or your custom stream client.
+
+## Using the CLI
+
+If you are using the `amc` CLI, you can use the `--enable-streaming` option at the time of launching the instance:
+
+    amc launch --enable-streaming <application_id>
+
+When the `--enable-streaming` option is specified, the Anbox Management Service (AMS) automatically creates a streaming session for the instance. You can find the id of the session as a tag on the instance in the format `session=<id>`.
+
+To further customise the streaming configuration, use the following arguments:
+* `--display-size`
+* `--display-density`
+* `--fps`
+
+For example, to create an instance with a 1080p resolution, a frame rate of 60 and a DPI of 120, run:
+
+    amc launch --enable-streaming --display-size=1920x1080 --display-density=120 --fps=60 <application_id>
+
+## Using the dashboard
 
 The dashboard has in-browser streaming capabilities through WebRTC. It uses the [Streaming SDK](https://discourse.ubuntu.com/t/anbox-cloud-sdks/17844#anbox-cloud-streaming-sdk-8).
 
@@ -6,7 +25,7 @@ You can start a streaming session for any of the successfully created applicatio
 
 To understand how the streaming stack of Anbox Cloud works, see [About application streaming](https://discourse.ubuntu.com/t/streaming-android-applications/17769).
 
-## Streaming statistics
+### Streaming statistics
 
 View the streaming statistics for your running sessions by selecting the **Statistics** button on the session. The statistics display on the right pane and also have a download option to download the statistics in a `.csv` format for further analysis.
 
@@ -32,7 +51,7 @@ The downloaded `.csv` file has the following statistics:
 | `audio-packetsreceived` | Number of audio packets received |
 | `audio-packetslost` | Number of audio packets lost |
 
-## Sharing a streaming session
+### Sharing a streaming session
 
 Use the **Sharing** button on the session page to share a streaming session with users without an account. The button generates a link using which users without an account can join your session.
 

--- a/howto/application/stream.md
+++ b/howto/application/stream.md
@@ -1,4 +1,4 @@
-You can stream applications using the `amc` CLI or a stream client. The stream client can be the Anbox Cloud dashboard or your custom stream client.
+You can stream applications using the Anbox Cloud dashboard or your custom stream client. You can also stream applications by launching an instance with streaming enabled, using the `amc` CLI.
 
 ## Using the CLI
 


### PR DESCRIPTION
In addition to [PR 51](https://github.com/canonical/anbox-cloud-docs/pull/51/), the howto guide for streaming applications also needs a update to mention the `--enable-streaming` option available from 1.22.