### PR TITLE
docs(charms): add upgrade instructions to enable stream attach support for charms

### DIFF
--- a/howto/update/upgrade-anbox.md
+++ b/howto/update/upgrade-anbox.md
@@ -68,7 +68,7 @@ The deployed Juju charms need to be upgraded next.
 
 - Starting with the 1.21 release, the NATS charm has been switched from its [older version](https://charmhub.io/nats-charmers-nats) to a [newer version](https://charmhub.io/nats) on Charmhub. This switch does not have any breaking changes from a user's perspective but since the framework of the charm has been overhauled, the upgrade to the new charm would require users to `switch` the charm's source while refreshing/updating the charm.
 
-- Starting with the 1.22 release, the `anbox-stream-agent` charm has a new relation `client` which can be used to register new clients for Anbox Stream Agent. This is used by the new AMS charm to enable stream attach support which is utilised by `amc`'s newly added flag `--enable-streaming`. For deployments using the bundles from or after 1.22 release, the relation is created automatically. But for users upgrading from older versions Anbox Cloud, the relation needs to be manually created using `juju relate anbox-stream-agent:client ams:agent` after upgrading both the `ams` and the `anbox-stream-agent` charms to 1.22.
+- Starting with the 1.22 release, the `anbox-stream-agent` charm has a new relation `client` which can be used to register new clients for the Anbox Stream Agent. This new relation is used by the new AMS charm to create stream-enabled instances using the `--enable-streaming` option. For deployments using the bundles from or after 1.22 release, the relation is created automatically. For users upgrading from older versions of Anbox Cloud, the relation needs to be manually created using `juju relate anbox-stream-agent:client ams:agent` after upgrading both the `ams` and the `anbox-stream-agent` charms to 1.22.
 
 [/note]
 

--- a/howto/update/upgrade-anbox.md
+++ b/howto/update/upgrade-anbox.md
@@ -68,6 +68,8 @@ The deployed Juju charms need to be upgraded next.
 
 - Starting with the 1.21 release, the NATS charm has been switched from its [older version](https://charmhub.io/nats-charmers-nats) to a [newer version](https://charmhub.io/nats) on Charmhub. This switch does not have any breaking changes from a user's perspective but since the framework of the charm has been overhauled, the upgrade to the new charm would require users to `switch` the charm's source while refreshing/updating the charm.
 
+- Starting with the 1.22 release, the `anbox-stream-agent` charm has a new relation `client` which can be used to register new clients for Anbox Stream Agent. This is used by the new AMS charm to enable stream attach support which is utilised by `amc`'s newly added flag `--enable-streaming`. For deployments using the bundles from or after 1.22 release, the relation is created automatically. But for users upgrading from older versions Anbox Cloud, the relation needs to be manually created using `juju relate anbox-stream-agent:client ams:agent` after upgrading both the `ams` and the `anbox-stream-agent` charms to 1.22.
+
 [/note]
 
 For any of the charm upgrades, you can watch the upgrade status by running:


### PR DESCRIPTION

This commit adds the instructions required to enable the new stream attach support to charms for customers upgrading from older versions of anbox-cloud bundle.