### PR TITLE
fix(create-application): add cpus in sample manifest.yaml file

### DIFF
--- a/howto/application/create.md
+++ b/howto/application/create.md
@@ -38,6 +38,7 @@ services:
     protocols: [tcp]
     expose: false
 resources:
+  cpus: 4
   memory: 4GB
   disk-size: 8GB
 ```


### PR DESCRIPTION
Added a line for a mandatory field in the `manifest.yaml` file (create application page).