### PR TITLE
fix(application): fix the resources presets when showing application details

### DIFF
--- a/howto/application/create.md
+++ b/howto/application/create.md
@@ -116,6 +116,7 @@ versions:
       expose: false
       name: adb
 resources:
+  cpus: 4
   memory: 4GB
   disk-size: 8GB
 ```

--- a/howto/application/update.md
+++ b/howto/application/update.md
@@ -74,6 +74,7 @@ versions:
       expose: false
       name: adb
 resources:
+  cpus: 4
   memory: 4GB
   disk-size: 8GB
 ```


### PR DESCRIPTION
Need to update the resource presets on display after fixing the missing `cpus`
field upon application creation