### PR TITLE
Replace instance-type with resources in example manifests

### DIFF
--- a/howto/application/extend.md
+++ b/howto/application/extend.md
@@ -113,7 +113,10 @@ You can add your hooks directly to an application. To do so, complete the follow
 
    ```
    name: my-app
-   instance-type: a4.3
+   resources:
+     cpus: 4
+     memory: 3GB
+     disk-size: 3GB
    ```
 
 1. Prepare one or more hooks as described in [Create a hook](#create-a-hook-1).
@@ -168,7 +171,10 @@ Once the addon is uploaded to AMS, you can reference it from any application man
 
 ```
 name: my-app
-instance-type: a4.3
+resources:
+  cpus: 4
+  memory: 3GB
+  disk-size: 3GB
 addons: [my-addon]
 ```
 

--- a/howto/application/test.md
+++ b/howto/application/test.md
@@ -93,7 +93,10 @@ In this example we use the following application `manifest.yaml`:
 
 ```
 name: app
-instance-type: a4.3
+resources:
+  cpus: 4
+  memory: 4GB
+  disk-size: 8GB
 ```
 
 Once the application is fully bootstrapped by AMS, you can launch an instance for it with the following command:

--- a/howto/port/obb-files.md
+++ b/howto/port/obb-files.md
@@ -27,8 +27,11 @@ Let's assume that you have an application that consists of an APK file and an OB
 
    ```yaml
    name: com.foo.bar
-   instance-type: a4.3
    required-permissions: ['*']
+   resources:
+     cpus: 4
+     memory: 3GB
+     disk-size: 3GB
    extra-data:
      main.203779.com.foo.bar.obb:
        target: /sdcard/Android/obb/com.foo.bar/

--- a/reference/anbox-features.md
+++ b/reference/anbox-features.md
@@ -22,7 +22,10 @@ To configure a feature globally for all instances, use a command similar to the 
 To configure a feature for one application in the manifest, use a syntax similar to the following:
 
     name: my-app
-    instance-type: a4.3
+    resources:
+      cpus: 4
+      memory: 3GB
+      disk-size: 3GB
     features: ["foo", "bar"]
 
 ### System UI

--- a/reference/application-manifest.md
+++ b/reference/application-manifest.md
@@ -60,7 +60,10 @@ The following manifest specifies a node selector that instructs the AMS to sched
 
 ```
 name: candy
-instance-type: a4.3
+resources:
+  cpus: 4
+  memory: 3GB
+  disk-size: 3GB
 node-selector: [foo, bar]
 ```
 
@@ -91,8 +94,11 @@ When an instance is launched, Anbox enables an application watchdog by default f
 
 ```yaml
 name: candy
-instance-type: a4.3
 image: default
+resources:
+  cpus: 4
+  memory: 3GB
+  disk-size: 3GB
 watchdog:
   disabled: true
 ```
@@ -121,9 +127,7 @@ Name           | Value type | Description
 
 ## Resources
 
-Anbox Cloud provides a set of [instance types](#instance-type) that define the resources available to an instance. For example, if you start an instance for an application that uses the instance type `a4.3`, the instance is assigned 4 vCPU cores, 3 GB of RAM and 3 GB of disk space.
-
-If your application requires resources that do not correspond to any of the provided instance types, you can use the `resources` directive to override some or all of the predefined resources.
+The `resources` directive helps you define the required resources for your application.
 
 Name           | Value type | Minimum value  | Description
 ---------------|------------|----------------|-------------------------
@@ -132,7 +136,7 @@ Name           | Value type | Minimum value  | Description
 `disk-size`    | string     |     3 GB       | Disk size to be assigned to the application
 `gpu-slots`(optional) | integer |     0      | Number of GPU slots to be assigned to the application
 
-If all required fields (`cpus`/`memory`/`disk-size`) of `resources` are supplied in the application manifest, the `instance-type` field is no longer needed. Even if the `instance-type` field is provided, it will be overridden by the requirements in the `resources` fields upon application installation.
+Note that if all required fields (`cpus`/`memory`/`disk-size`) of `resources` are supplied in the application manifest and the deprecated `instance-type` field is also provided, `instance-type` will be overridden by the requirements in the `resources` fields upon application installation.
 
 See [How to configure available resources](https://discourse.ubuntu.com/t/24960) for more information.
 
@@ -212,7 +216,10 @@ To minimise the application size, most contents under the `APP_DIR` directory ar
 
 ```yaml
 name: my-application
-instance-type: a4.3
+resources:
+  cpus: 4
+  memory: 3GB
+  disk-size: 3GB
 bootstrap:
   keep:
     - 'apks/*.apk'

--- a/tutorial/creating-addon.md
+++ b/tutorial/creating-addon.md
@@ -71,7 +71,10 @@ Create an application manifest file (`my-application/manifest.yaml`) and include
 
 ```yaml
 name: my-application
-instance-type: a4.3
+resources:
+  cpus: 4
+  memory: 3GB
+  disk-size: 3GB
 addons:
   - ssh
 ```

--- a/tutorial/getting-started.md
+++ b/tutorial/getting-started.md
@@ -215,7 +215,10 @@ Complete the following steps to add a new version to your application:
 
    ```yaml
    name: my-application
-   instance-type: a4.3
+   resources:
+     cpus: 4
+     memory: 3GB
+     disk-size: 3GB
    services:
     - name: adb
       port: 5559


### PR DESCRIPTION
Since `instance-type` is deprecated, it is a good idea to use `resources` in our examples to lead by example.
I have removed some obvious places where it is a straight-forward replacement but have not done the replacements in outputs to maintain technical accuracy (we still list instance type in outputs for backwards compatibility).