### PR TITLE
feat(howto): add snap refresh to the prerequisites

### DIFF
--- a/howto/update/upgrade-appliance.md
+++ b/howto/update/upgrade-appliance.md
@@ -2,6 +2,7 @@ Before you upgrade the Anbox Cloud Appliance, make sure all packages on the mach
 
     sudo apt update
     sudo apt upgrade
+    sudo snap refresh
 
 The Anbox Cloud Appliance includes an `upgrade` command which will perform all relevant upgrade steps to a newer version of the appliance.  First, run `anbox-cloud-appliance status` to check if an update is available:
 


### PR DESCRIPTION
Users need to have the latest appliance version before they can upgrade. To that end, when they update their packages, they should also take this time to upgrade their snaps, to ensure the update goes smoothly.