### PR TITLE
Add CLA check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,10 @@
+name: CLA check
+on: [pull_request_target]
+
+jobs:
+  check-for-cla:
+    name: Check if author has signed the Canonical CLA
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check if CLA signed
+      uses: canonical/has-signed-canonical-cla@main


### PR DESCRIPTION
As we declare docs open for contributions through GH (we have started with open docs academy but this will be the case when we move to RTD), we need the CLA check in place so that we can be sure that the contributor has signed the CLA.