### PR TITLE
Discourse: Add format for instance.network_proxy

### DIFF
--- a/reference/ams-configuration.yaml
+++ b/reference/ams-configuration.yaml
@@ -100,7 +100,8 @@ all:
     type: "string"
     default: "-"
     description: >-
-      Network proxy to use inside the instances.
+      Network proxy to use inside the instances. This value must have
+      the format <hostname>:<port>
     deprecated: "No"
   container.security_updates:
     type: "bool"


### PR DESCRIPTION
This adds the format for the value of instance.network_proxy.

Fixes https://bugs.launchpad.net/anbox-cloud/+bug/2072510