### PR TITLE
Remove outdated discourse links checker pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,4 @@ repos:
     rev: v0.5.0
     hooks:
       - id: spellcheck
-  - repo: https://github.com/anbox-cloud/pre-commit-hooks
-    rev: 797fe47e86364afe21b7679f2dc309ee441a891d
-    hooks:
-      - id: anbox-cloud-docs-links-checker
-        exclude: |
-          (?x)^(
-            .github/.*
-            |reference/release-notes/.*
-            |README.md
-          )$
+


### PR DESCRIPTION
We no longer need URLs to point to discourse posts.