### PR TITLE
Configure link check to ignore anchors

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -133,6 +133,8 @@ linkcheck_ignore = [
     ]
 
 # This setting will check the links but not the anchors
+linkcheck_anchors = False
+
 # This list will be appended to linkcheck_anchors_ignore_for_url
 custom_linkcheck_anchors_ignore_for_url = [
     r'https://matrix\.to/.*',

--- a/reference/supported-codecs.md
+++ b/reference/supported-codecs.md
@@ -7,7 +7,7 @@ Not all codecs are supported by one or more of the supported GPU models, neither
 
 The supported video codecs are:
 
- * H.264 - The use of H.264 requires a license from the [MPEG LA](https://www.mpegla.com/). Ensure you have the rights to stream H.264 encoded video content to your users.
+ * H.264 - The use of H.264 requires a license from the [MPEG LA](https://www.via-la.com/). Ensure you have the rights to stream H.264 encoded video content to your users.
  * AV1 - Depending on the GPU model used in the deployment, AV1 hardware encoding is the default preference over H.264 on supported GPUs, such as NVIDIA Ada Lovelace Architecture-based GPUs like L4. Otherwise, it will fallback to AV1 software encoding.
  * VP8
 


### PR DESCRIPTION
The link check is flaky when it comes to checking anchors. It often reports working anchors as broken and is unpredictable.

This PR adds configuration to disable checking the anchors.