### PR TITLE
feat(explanation): mark aaos as stable

### DIFF
--- a/explanation/aaos.md
+++ b/explanation/aaos.md
@@ -4,7 +4,6 @@
 Since the 1.21.0 release, in addition to providing images based on the Android Open Source Project (AOSP), Anbox Cloud also offers images based on the [Android Automotive OS (AAOS)](https://source.android.com/docs/automotive/start/what_automotive). These images help run Android in automotive infotainment systems at scale.
 
 ```{important}
-* This is currently an experimental feature.
 * The Anbox Cloud AAOS images are based on Android Automotive and *not* Android Auto. For understanding the differences between the two, see upstream documentation on [Android Automotive and Android Auto](https://source.android.com/docs/automotive/start/what_automotive#android-automotive-android-auto).
 ```
 


### PR DESCRIPTION
More accurately, this removes the 'experimental' mark for AAOS.