### PR TITLE
Updating the terminology used to refer dashboard pages

### DIFF
--- a/contribute/anbox-style-guide.md
+++ b/contribute/anbox-style-guide.md
@@ -80,6 +80,8 @@ Use hyphens when the starting letter of a word is in capital case or starts with
 * It’s always “Anbox Cloud Appliance” when used in full form and “appliance” when used generically.
 * Always use product name in full form with capitalisation - "Anbox Cloud".
 * Within the context of Anbox Cloud, such as AMS, you can use the term "Anbox images" or "Anbox instances". When documenting about LXD images or containers that contain Anbox specific configuration from a big picture point of view,such as the architecture, use the term as "LXD images" or "LXD containers". When there is scope for ambiguity, elaborate and use as "LXD images with Anbox Cloud configuration".
+* Use the term 'page' to describe the different pages of the web dashboard.
+Example: You can see all the instances you created on the *Instances* page.
 
 ## Images and screenshots
 

--- a/explanation/web-dashboard.md
+++ b/explanation/web-dashboard.md
@@ -9,14 +9,14 @@ The dashboard comes pre-installed when you deploy the full version of Anbox Clou
 
 The dashboard allows multiple views and management of various objects such as applications, instances and nodes to some extent. The operations available from the dashboard may be limited as compared to the CLI, however if you are new to the CLI, the dashboard can be a friendlier start to Anbox Cloud.
 
-* Applications view - Allows creation, streaming and management of applications.
-* Instances view - Allows a detailed view of instances and the applications or images that they are created from, along with other options including management, streaming, connecting via Android Debug Bridge (ADB) for the instances.
-* Nodes view - Allows a list view of LXD nodes and their configuration details.
+* Applications page - Allows creation, streaming and management of applications.
+* Instances page - Allows a detailed view of instances and the applications or images that they are created from, along with other options including management, streaming, connecting via Android Debug Bridge (ADB) for the instances.
+* Nodes page - Allows a list view of LXD nodes and their configuration details.
 
 Apart from these views, the dashboard also allows you to work with the {ref}`exp-aar` and the {ref}`exp-ams`.
 
-* Registry view - Allows a list view of applications uploaded to the registry.
-* Configuration view - Allows you to edit the {ref}`ref-ams-configuration` attributes from the dashboard.
+* Registry page - Allows a list view of applications uploaded to the registry.
+* Configuration page - Allows you to edit the {ref}`ref-ams-configuration` attributes from the dashboard.
 
 ## Related topics
 

--- a/howto/android/access-instance.md
+++ b/howto/android/access-instance.md
@@ -22,7 +22,7 @@ Generate a presigned connection URL in either of the following ways:
 
 **From the Dashboard**
 
-In the *Instances* list view, locate a running instance and click *Connect ADB* ( ![Connect ADB|16x16](https://assets.ubuntu.com/v1/51973cea-adb-connect-icon.png) ).
+On the *Instances* page, locate a running instance and click *Connect ADB* ( ![Connect ADB|16x16](https://assets.ubuntu.com/v1/51973cea-adb-connect-icon.png) ).
 *Authorise* the connection and copy the command provided.
 
 **From the Command Line**:

--- a/howto/application/create-application.md
+++ b/howto/application/create-application.md
@@ -48,7 +48,7 @@ resources:
 
 ## Using the dashboard
 
-To create an application using the dashboard, click *Create application* from the applications view, enter the required and any optional details that you want to provide and confirm with *Create application* again. This screen also provides the option to customise your application manifest.
+To create an application using the dashboard, click *Create application* on the applications page, enter the required and any optional details that you want to provide and confirm with *Create application* again. The *Create application* form also provides an option to customise your application manifest.
 
 There may be more advanced scenarios while creating an application that cannot be performed using the dashboard and may require using the `amc` CLI.
 

--- a/howto/application/delete-application.md
+++ b/howto/application/delete-application.md
@@ -7,7 +7,7 @@ Once you're sure you want to remove the application, you can delete it via the d
 
 ## Using the dashboard
 
-In the applications list view, click *Delete* ( ![delete application icon](/images/delete-icon.png) ) and confirm the deletion.
+On the *Applications* page, click *Delete* ( ![delete application icon](/images/delete-icon.png) ) and confirm the deletion.
 
 ## Using the CLI
 

--- a/howto/application/stream-application.md
+++ b/howto/application/stream-application.md
@@ -58,7 +58,7 @@ The downloaded `.csv` file has the following statistics:
 
 ### Sharing a streaming session
 
-To share your stream with users without an account, click *Set up sharing* ( ![set up sharing icon](/images/share-stream-icon.png) ) in the instances list view.
+To share your stream with users without an account, click *Set up sharing* ( ![set up sharing icon](/images/share-stream-icon.png) ) on the *Instances* page.
 
 Set your stream title and expiration details and generate a link that can be shared with others.
 

--- a/howto/instance/create-instance.md
+++ b/howto/instance/create-instance.md
@@ -4,13 +4,13 @@ To launch an application or an image, Anbox Cloud creates an instance for it. To
 
 ## Using the dashboard
 
-Create an instance from the instances view to launch an instance. The information required for launching an instance depends on whether you are creating the instance from an application or an image.
+Create an instance on the *Instances* page to launch an instance. The information required for launching an instance depends on whether you are creating the instance from an application or an image.
 
 When you create the instance from an application, the attributes you define for the application decide most of the properties of the instance.
 
 When you create the instance from an image, you can define the properties of the instance during its creation.
 
-Once you create an instance by providing the necessary attributes, you can view the instance and its status in the instances list view.
+Once you create an instance by providing the necessary attributes, you can view the instance and its status on the *Instances* page.
 
 There may be more advanced scenarios while creating an instance that cannot be performed using the dashboard and may require using the `amc` CLI.
 

--- a/howto/instance/delete-instance.md
+++ b/howto/instance/delete-instance.md
@@ -5,7 +5,7 @@ An instance can be deleted, which will cause any connected user to be disconnect
 
 ## Using the dashboard
 
-In the instances list view, click *Delete* ( ![delete application icon](/images/delete-icon.png) ) and confirm the deletion.
+On the *Instances* page, click *Delete* ( ![delete application icon](/images/delete-icon.png) ) and confirm the deletion.
 
 ## Using the CLI
 

--- a/howto/troubleshoot/troubleshoot-dashboard-issues.md
+++ b/howto/troubleshoot/troubleshoot-dashboard-issues.md
@@ -29,7 +29,7 @@ See {ref}`howto-view-instance-logs` to find reasons for the session failure.
 
 *Applies to: Anbox Cloud, Anbox Cloud Appliance*
 
-The instances list view shows instances with *Error* status.
+The *Instances* page of the dashboard shows instances with *Error* status.
 
 An instance can end up with an error status due to various reasons. It may not always be simple and easy to resolve this because of the variable factors involved, for example, the application that the instance is hosting or any installed addons.
 

--- a/tutorial/getting-started-dashboard.md
+++ b/tutorial/getting-started-dashboard.md
@@ -30,7 +30,7 @@ With "virtual device" we mean a simulated device that runs a plain Android opera
    - Select the Android image that you want to use, for example, `jammy:android13:arm64`.
    - Do not upload an APK file.
 
-Click *Create application* again to complete the process. You are redirected to the applications list view. Wait until the application status changes to `ready`.
+Click *Create application* again to complete the process. You are redirected to the *Applications* page. Wait until the application status changes to `ready`.
 
 ## Test the virtual device
 
@@ -43,7 +43,7 @@ When the application has been initialised and its status changes to `ready`, com
    - Provide a name for the instance. Your application details will be auto-filled.
    - Optionally, you can select the capabilities, virtual display specifications and other configuration options for your instance. For this tutorial, you can leave these options to the defaults.
 
-   Click *Create and start*. You will be directed to the instance list view where you can monitor the status of your instance.
+   Click *Create and start*. You will be directed to the *Instances* page where you can monitor the status of your instance.
 
 3. Once the instance status is *running*, you can stream it and interact with your virtual device.
 
@@ -65,14 +65,14 @@ You can have several versions of an application. See {ref}`howto-update-applicat
 
 Complete the following steps to add a new version to your application:
 
-1. Go to the applications list view of the dashboard.
+1. Go to the *Applications* page of the dashboard.
 2. Click *Edit application* (![edit application icon](/images/edit-application-icon.png)) to add a new version to your application.
 3. Upload a new APK, or do other changes to the configuration.
 4. Click *Update application*.
 
 ## Delete an application
 
-While following this tutorial, you created several applications. You can see them in the applications list view.
+While following this tutorial, you created several applications. You can see them on the *Applications* page.
 
 To delete an application, click *Delete* ( ![delete application icon](/images/delete-icon.png) ) and confirm the deletion.
 
@@ -82,7 +82,7 @@ To skip the confirmation window, hold **Shift** when clicking *Delete*.
 
 ## View instances
 
-You can see all instances in the instance list view at `https://<your-machine-address>/instances`.
+You can see all instances on the *Instances* page at `https://<your-machine-address>/instances`.
 
 To view an instance, click the name of the instance you wish to view. 
 


### PR DESCRIPTION
* As per [feedback from the design team](https://github.com/canonical/anbox-cloud-docs/pull/106#discussion_r1699822293), update all terminology to use 'page' when referring to
the dashboard web pages. This aligns with the
terminology used by the UI team on the dashboard
pages.

* Update the style guide with the terminology guidance