### PR TITLE
feat(gh): assign ownership to the canonical/anbox team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# The Anbox team owns all for now
+*    @canonical/anbox
+


### PR DESCRIPTION
This will setup the reviewer list automatically to always include the Anbox team.