### PR TITLE
fix(gh): use correct yq option on noble

### DIFF
--- a/.github/workflows/update-api-specs.yaml
+++ b/.github/workflows/update-api-specs.yaml
@@ -6,7 +6,7 @@ on:
   - cron: '0 1 * * *'
 
 jobs:
-  backport:
+  update-api-specs:
     runs-on: ubuntu-24.04
     steps:
     - name: Check out repository
@@ -29,7 +29,7 @@ jobs:
         sudo apt install -y jq yq
         curl \
           --unix-socket /var/snap/anbox-cloud-appliance/common/ams-unix.socket \
-          s/1.0/swagger.json | yq -P > ./reference/api-reference/ams-api.yaml
+          s/1.0/swagger.json | yq -y > ./reference/api-reference/ams-api.yaml
     - name: Create PR
       uses: canonical/create-pull-request@3ad9cef62791c00f1c71d4aca902f4ea6abe0302
       with:


### PR DESCRIPTION
Yq on jammy has -P for emitting YAMl from JSON but on noble a newer verison of yq used -y for that.

-----

This is the last fix necessary to get the workflow to actually do its job :-)