### PR TITLE
docs: update juju tutorial to use version 3.0 instead of 2.9

### DIFF
--- a/howto/install/deploy-bare-metal.md
+++ b/howto/install/deploy-bare-metal.md
@@ -19,9 +19,9 @@ Before you start the installation, ensure that you have the required prerequisit
 
 Juju is a tool for deploying, configuring and operating complex software on public or private clouds.
 
-You must install a Juju client on the machine that you use to run the deployment commands. To install Juju 2.9, enter the following command:
+You must install a Juju client on the machine that you use to run the deployment commands. To install Juju 3.x, enter the following command:
 
-    sudo snap install --classic --channel=2.9/stable juju
+    sudo snap install --classic --channel=3/stable juju
 
 See {ref}`sec-juju-version-requirements` for information about which Juju version is required for your version of Anbox Cloud.
 

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -27,9 +27,9 @@ Before you start the installation, ensure that you have the required credentials
 
 Juju is a tool for deploying, configuring and operating complex software on public or private clouds.
 
-To install Juju 2.9, enter the following command:
+To install Juju 3.x, enter the following command:
 
-    sudo snap install --classic --channel=2.9/stable juju
+    sudo snap install --classic --channel=3/stable juju
 
 See {ref}`sec-juju-version-requirements` for information about which Juju version is required for your version of Anbox Cloud.
 


### PR DESCRIPTION
This commit updates the docs for new users to start with juju 3.0 as that is the gold standard to use right with new features being developed as a priority for it.