### PR TITLE
Fix spellcheck errors

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -130,7 +130,7 @@ HIDL
 HMAC
 Honkai
 hotfix
-HTTPS
+https
 HW
 HWE
 HVAC
@@ -147,6 +147,7 @@ iptables
 init
 interprocess
 iOS
+io
 Javascript
 Jira
 jitter

--- a/reference/api-reference/ams-api.yaml
+++ b/reference/api-reference/ams-api.yaml
@@ -3465,7 +3465,7 @@ paths:
                                                 type: boolean
                                             load_balancer.url:
                                                 default: ""
-                                                description: Set host URL for AMS to loadbalancer's URL
+                                                description: Set host URL for AMS to load balancer's URL
                                                 example: https://load-balanced-ams.com
                                                 type: string
                                             node.queue_size:
@@ -3487,7 +3487,7 @@ paths:
                                                 type: string
                                             registry.fingerprint:
                                                 default: ""
-                                                description: Fingerprint used to verify the ceritifcate of the application registry
+                                                description: Fingerprint used to verify the certificate of the application registry
                                                 example: my-registry-fingerprint
                                                 type: string
                                             registry.mode:
@@ -3511,7 +3511,7 @@ paths:
                                                 type: string
                                             scheduler.strategy:
                                                 default: spread
-                                                description: Container scheduling startegy
+                                                description: Container scheduling strategy
                                                 enum:
                                                     - spread
                                                     - binpack


### PR DESCRIPTION
This PR is to fix spellcheck errors in the API yaml files. This is being done by hand just this one time to unblock checks failing on other unrelated PRs.

The spelling errors are fixed in the latest swagger output and when 1.23.1 rolls out, the API yaml file will be rewritten with the automatically generated file.