### PR TITLE
Fix spellcheck errors

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -130,7 +130,7 @@ HIDL
 HMAC
 Honkai
 hotfix
-HTTPS
+https
 HW
 HWE
 HVAC
@@ -146,6 +146,7 @@ IPs
 iptables
 init
 interprocess
+io
 iOS
 Javascript
 Jira

--- a/reference/api-reference/ams-api.yaml
+++ b/reference/api-reference/ams-api.yaml
@@ -1312,7 +1312,7 @@ paths:
                         type: boolean
                         default: true
                       load_balancer.url:
-                        description: Set host URL for AMS to loadbalancer's URL
+                        description: Set host URL for AMS to load balancer's URL
                         type: string
                         default: ''
                         example: https://load-balanced-ams.com
@@ -1335,7 +1335,7 @@ paths:
                         default: ''
                         example: foo,bar
                       registry.fingerprint:
-                        description: Fingerprint used to verify the ceritifcate of
+                        description: Fingerprint used to verify the certificate of
                           the application registry
                         type: string
                         default: ''
@@ -1360,7 +1360,7 @@ paths:
                         default: ''
                         example: https://foo.bar/
                       scheduler.strategy:
-                        description: Container scheduling startegy
+                        description: Container scheduling strategy
                         type: string
                         default: spread
                         enum:


### PR DESCRIPTION
This PR is to fix spellcheck errors in the API yaml files. This is being done by hand just this one time to unblock checks failing on other unrelated PRs.

The spelling errors are fixed in the latest swagger output and when 1.23.2 rolls out, the API yaml file will be rewritten with the automatically generated file.
