### PR TITLE
Exempt auto-generated and venv files from spellcheck

### DIFF
--- a/.sphinx/spellingcheck.yaml
+++ b/.sphinx/spellingcheck.yaml
@@ -9,7 +9,7 @@ matrix:
     - .custom_wordlist.txt
     output: .sphinx/.wordlist.dic
   sources:
-  - _build/**/*.html
+  - _build/**/*.html|!_build/venv/**/*.html|!_build/reference/cmd-ref/appliance/**/*.html|!_build/reference/cmd-ref/amc/**/*.html
   pipeline:
   - pyspelling.filters.html:
       comments: false


### PR DESCRIPTION
Because of the way the current outputs are generated for AMS configuration and API reference the spellcheck is flagging terminology from files inside the venv and the automatically generated command reference files.

Until we change the venv directory and fix our CLI help text, we need this exemption in place so that the spellcheck does not fail on other unrelated changes.