### PR TITLE
Add Android 14 images to the supported images list for 1.24

### DIFF
--- a/reference/provided-images.md
+++ b/reference/provided-images.md
@@ -11,6 +11,8 @@ The following table lists supported images available on the official image serve
 
 | Name                        | Based on | Android Version | Ubuntu Version | Available since |
 |-----------------------------|----------|-----------------|----------------|---------------|
+| `jammy:android14:amd64`     | AOSP     | 14              | 22.04          | 1.24.0 |
+| `jammy:android14:arm64`     | AOSP     | 14              | 22.04          | 1.24.0 |
 | `jammy:aaos13:amd64`        | AAOS     | 13              | 22.04          | 1.21.0 |
 | `jammy:aaos13:arm64`        | AAOS     | 13              | 22.04          | 1.21.0 |
 | `jammy:android13:amd64`     | AOSP     | 13              | 22.04          | 1.16.0 |


### PR DESCRIPTION
Adding only AOSP Android 14 images to the list for 1.24.0. AAOS, if supported, will have to be added for 1.24.1.

Decision on [PackageManager](https://developer.android.com/reference/android/content/pm/PackageManager) level feature listing is that we should consider providing a list of features but we will need to set it automatically (maybe using [feature list generator](https://github.com/canonical/anbox/blob/main/src/anbox/android/features_list_generator.cpp)). This needs more research and hence not covered in this PR.