### PR TITLE
Fix juju crashdump command

### DIFF
--- a/howto/troubleshoot/landing.md
+++ b/howto/troubleshoot/landing.md
@@ -36,7 +36,7 @@ A Juju crash dump may include the following debugging information:
 
 Use the following command to generate a crash dump:
 
-    juju crashdump -s -a debug-layer 
+    juju crash-dump -s -a --as-root debug-layer
 
 The Anbox Management Service (AMS) charm implements the `debug-layer` addon which will add a `debug-*.tar.gz` archive to the crash dump for the AMS units. The tarball may contain logs for the instances that are in `error` state in AMS and other information about the Anbox runtime process.
 


### PR DESCRIPTION
To fix issue #206

@canonical/anbox I validated this in theory but not sure if I can test this command in Appliance because it does not apply to the Appliance version of our deployment. Could one of you confirm or validate?