### PR TITLE
Create 1.24.0 release documentation

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -129,6 +129,7 @@ HIDL
 HMAC
 Honkai
 hotfix
+http
 https
 HW
 HWE
@@ -284,6 +285,7 @@ subcommand
 subcommands
 subnet
 subnets
+sgsr
 SurfaceFlinger
 swiftshader
 swrast
@@ -296,6 +298,7 @@ tryCapture
 TCP
 Telegraf
 Tensorflow
+terraform
 TLS
 Traefik
 TypeError

--- a/explanation/anbox-cloud.md
+++ b/explanation/anbox-cloud.md
@@ -26,7 +26,7 @@ See the following table for a comparison of features for the different variants:
 |---------|-----------------------|-------------|
 | {ref}`exp-application-streaming` | ✓ | ✓ |
 | {ref}`exp-web-dashboard` | ✓ | ✓ |
-| {ref}`Android versions <ref-provided-images>` | 12, 13 | 12, 13 |
+| {ref}`Android versions <ref-provided-images>` | 12, 13, 14** | 12, 13, 14** |
 | [Security updates](https://ubuntu.com/support) | ✓ | ✓ |
 | [Community support](https://discourse.ubuntu.com/c/anbox-cloud/users/148) | ✓ | ✓ |
 | [Vendor support available](https://ubuntu.com/support) | ✓* | ✓ |
@@ -34,6 +34,8 @@ See the following table for a comparison of features for the different variants:
 | {ref}`exp-custom-images`| ✓ | ✓ |
 
 *\* When purchasing the Anbox Cloud Appliance through the AWS Marketplace, the Ubuntu Pro subscription does not include vendor support.*
+
+*\*\* Android 14 images are available only for AOSP images and not AAOS.*
 
 We recommend starting with the Anbox Cloud Appliance. You can choose to expand to a full Anbox Cloud installation later.
 

--- a/explanation/performance.md
+++ b/explanation/performance.md
@@ -32,7 +32,7 @@ AMS has different modes to grant CPU access to an instance. The `cpu.limit_mode`
 
    This mode uses the LXD [`limits.cpu`](https://documentation.ubuntu.com/lxd/en/latest/reference/instance_options/#cpu-limits) configuration option to pin a set of CPU cores to an instance. LXD is responsible for allocating a specific number of cores to an instance and load-balancing all running instances on all available cores.
 
-   Using `pinning` requires a system with [cgroup-v2](https://docs.kernel.org/admin-guide/cgroup-v2.html) enabled. Otherwise, limitations of [cgroup-v1](https://docs.kernel.org/admin-guide/cgroup-v1/index.html) might cause the load distribution over available CPU cores to not be optimal. [cgroup-v2](https://docs.kernel.org/admin-guide/cgroup-v2.html) is enabled by default starting with Ubuntu 22.04 and can be enabled on Ubuntu 20.04 by booting with `systemd.unified_cgroup_hierarchy=1` added to [the kernel boot parameters](https://wiki.ubuntu.com/Kernel/KernelBootParameters).
+   Using `pinning` requires a system with [cgroup-v2](https://docs.kernel.org/admin-guide/cgroup-v2.html) enabled. Otherwise, limitations of [cgroup-v1](https://docs.kernel.org/admin-guide/cgroup-v1/index.html) might cause the load distribution over available CPU cores to not be optimal. [cgroup-v2](https://docs.kernel.org/admin-guide/cgroup-v2.html) is enabled by default.
 
 By default, AMS uses the `scheduler` option, because it provides the most generic solution to a large set of use cases that Anbox Cloud supports. However, in some cases CPU pinning might be the better option to distribute load across all available CPU cores on a system.
 

--- a/howto/application/pass-custom-data.md
+++ b/howto/application/pass-custom-data.md
@@ -9,7 +9,13 @@ The structure of the `/var/lib/anbox/userdata` file and the way how you pass in 
 
 ## Pass custom data when launching an instance
 
-When you launch an instance, you can pass in custom data through the `--userdata` or the `--userdata-path` flags:
+When you launch an instance, you can pass in custom data through the `--userdata` option:
+
+    amc launch <app-name> .... --enable-streaming --userdata="field=value"
+
+or the `--userdata-path` option, if you prefer all the custom data to be collated in a single file:
+
+    amc launch <app-name> .... --enable-streaming --userdata-path="my-user-data.json"
 
 * `--userdata` takes a string and stores the provided data in the `/var/lib/anbox/userdata` file in the instance.
 * `--userdata-path` takes a file name and copies the contents of the file to the `/var/lib/anbox/userdata` file in the instance.

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -13,7 +13,7 @@ There are differences between the full Anbox Cloud installation and the Anbox Cl
 
 Before you start the installation, ensure that you have the required credentials and prerequisites:
 
-* An Ubuntu 22.04 LTS (preferred) or 20.04 LTS environment to run the commands (or another operating system that supports snaps - see the [Snapcraft documentation](https://snapcraft.io/docs/installing-snapd)).
+* An Ubuntu 22.04 LTS to run the commands (or another operating system that supports snaps - see the [Snapcraft documentation](https://snapcraft.io/docs/installing-snapd)).
 * Account credentials for one of the following public clouds:
   * [Amazon Web Services](https://aws.amazon.com/) (including AWS-China)
   * [Google Cloud platform ](https://cloud.google.com/)

--- a/howto/stream/enable-client-side-video-upscaling.md
+++ b/howto/stream/enable-client-side-video-upscaling.md
@@ -28,6 +28,7 @@ The option `experimental.upscaling.useTargetFrameRate` allows canvas to use the 
 On a WebView where the `HTMLVideoElement.requestVideoFrameCallback` function is not supported, this option will be enabled by default.
 ```
 
+(sec-custom-fragment-shader)=
 ### Use custom fragment shader
 
 The option `options.experimental.upscaling.fragmentShaders` allows the use of custom fragment shader-based upscaling algorithms for video streaming. By providing an array of fragment shader source codes, you can apply multiple shaders sequentially to perform multi-pass upscaling. This replaces the default [AMD FidelityFX Super Resolution 1.0](https://gpuopen.com/fidelityfx-superresolution/) shader.

--- a/howto/update/upgrade-anbox.md
+++ b/howto/update/upgrade-anbox.md
@@ -106,10 +106,10 @@ If you don't run any of the services in a high availability configuration, upgra
 
 To upgrade all charms, run the following commands:
 
-    juju refresh --channel=1.23/stable anbox-cloud-dashboard
-    juju refresh --channel=1.23/stable anbox-stream-gateway
-    juju refresh --channel=1.23/stable anbox-stream-agent
-    juju refresh --channel=1.23/stable coturn
+    juju refresh --channel=1.24/stable anbox-cloud-dashboard
+    juju refresh --channel=1.24/stable anbox-stream-gateway
+    juju refresh --channel=1.24/stable anbox-stream-agent
+    juju refresh --channel=1.24/stable coturn
     juju refresh --channel=latest/stable nats
 
 ```{note}
@@ -122,19 +122,13 @@ Since the NATS charm has been overhauled to use the modern charm framework (Ops 
 
 The AMS service needs to be updated independently of the other service components to ensure minimal down time. The charm can be upgraded by running the following command.
 
-    juju refresh --channel=1.23/stable ams
+    juju refresh --channel=1.24/stable ams
 
 ### Upgrade LXD
 
 As the last step, you have to upgrade the LXD cluster. Upgrading LXD will not restart running instances but it's recommended to take a backup before continuing.
 
-As the first step, you need to upgrade the AMS node controller by running:
-
-    juju refresh --channel=1.23/stable ams-node-controller
-
-Once the upgrade is completed, you can continue upgrading LXD:
-
-    juju refresh --channel=1.23/stable lxd
+    juju refresh --channel=1.24/stable lxd
 
 In some cases, specifically when you maintain bigger LXD clusters or want to keep a specific set of LXD nodes active until users have dropped, it makes sense to run the upgrade process manually on a per node basis. To enable this, you can set the following configuration option for the LXD charm before running the refresh command above:
 

--- a/reference/component-versions.md
+++ b/reference/component-versions.md
@@ -5,6 +5,58 @@ This documents the versions of the different components for each Anbox Cloud rel
 
 Not all components are updated with each release. When components are not updated, they are marked with `n/a` below.
 
+## 1.24.0
+
+### Charms
+
+#### Ubuntu 22.04
+
+| Name | Channel | Revision |
+|----------|--------------|--------------|
+| `anbox-cloud-dashboard` | `1.24/stable` |   |
+| `coturn` | `1.24/stable` |   |
+| `ams` | `1.24/stable` |   |
+| `anbox-stream-gateway`  | `1.24/stable` |   |
+| `ams-lxd` | `1.24/stable` |   |
+| `anbox-stream-agent` | `1.24/stable` |   |
+| `aar` | `1.24/stable` |   |
+| `nats` | `latest/stable` | 9 (AMD64), 11 (ARM64) |
+
+### Bundles
+
+| Name | Channel | Revision |
+|----------|--------------|--------------|
+| `anbox-cloud` | `1.24/stable` |  |
+| `anbox-cloud-core` | `1.24/stable` |   |
+
+### Snaps
+
+| Name |  Channel | Version |
+|----------|--------------|---------|
+| `ams`    | `1.24/stable` |   |
+| `aar`    | `1.24/stable` |   |
+| `amc`    | `latest/stable` |   |
+| `anbox-cloud-dashboard` | `1.24/stable` |   |
+| `anbox-stream-agent` | `1.24/stable` |   |
+| `anbox-stream-gateway` | `1.24/stable` |   |
+| `anbox-connect` | `latest/stable` |   |
+| `anbox-cloud-appliance` | `1.24/stable` |   |
+
+### Anbox images
+
+The following Anbox images are available in two variants: one based on a container and one based on a virtual machine.
+
+| Name | Version |
+|----------|--------------|
+| `jammy:android14:amd64` |   |
+| `jammy:android14:arm64` |   |
+| `jammy:android13:amd64` |   |
+| `jammy:android13:arm64` |   |
+| `jammy:android12:amd64` |   |
+| `jammy:android12:arm64` |   |
+| `jammy:aaos13:amd64`    |   |
+| `jammy:aaos13:arm64`    |   |
+
 ## 1.23.2
 
 ### Charms

--- a/reference/component-versions.md
+++ b/reference/component-versions.md
@@ -13,34 +13,35 @@ Not all components are updated with each release. When components are not update
 
 | Name | Channel | Revision |
 |----------|--------------|--------------|
-| `anbox-cloud-dashboard` | `1.24/stable` |   |
-| `coturn` | `1.24/stable` |   |
-| `ams` | `1.24/stable` |   |
-| `anbox-stream-gateway`  | `1.24/stable` |   |
-| `ams-lxd` | `1.24/stable` |   |
-| `anbox-stream-agent` | `1.24/stable` |   |
-| `aar` | `1.24/stable` |   |
+| `anbox-cloud-dashboard` | `1.24/stable` | 575 |
+| `ams-node-controller` (Deprecated) | `1.24/stable` | 585 |
+| `coturn` | `1.24/stable` | 576 |
+| `ams` | `1.24/stable` | 679 |
+| `anbox-stream-gateway`  | `1.24/stable` |  635 |
+| `ams-lxd` | `1.24/stable` | 595  |
+| `anbox-stream-agent` | `1.24/stable` | 629 |
+| `anbox-cloud-nfs` | `latest/stable` | 41 |
+| `aar` | `1.24/stable` |  663 |
 | `nats` | `latest/stable` | 9 (AMD64), 11 (ARM64) |
 
 ### Bundles
 
 | Name | Channel | Revision |
 |----------|--------------|--------------|
-| `anbox-cloud` | `1.24/stable` |  |
-| `anbox-cloud-core` | `1.24/stable` |   |
+| `anbox-cloud` | `1.24/stable` | 497 |
+| `anbox-cloud-core` | `1.24/stable` | 509 |
 
 ### Snaps
 
 | Name |  Channel | Version |
 |----------|--------------|---------|
-| `ams`    | `1.24/stable` |   |
-| `aar`    | `1.24/stable` |   |
-| `amc`    | `latest/stable` |   |
-| `anbox-cloud-dashboard` | `1.24/stable` |   |
-| `anbox-stream-agent` | `1.24/stable` |   |
-| `anbox-stream-gateway` | `1.24/stable` |   |
-| `anbox-connect` | `latest/stable` |   |
-| `anbox-cloud-appliance` | `1.24/stable` |   |
+| `ams`    | `1.24/stable` | `1.24.0-599f42a84`  |
+| `aar`    | `1.24/stable` | `1.24.0-599f42a84`  |
+| `anbox-cloud-dashboard` | `1.24/stable` | `1.24.0-599f42a84`  |
+| `anbox-stream-agent` | `1.24/stable` | `1.24.0-599f42a84`  |
+| `anbox-stream-gateway` | `1.24/stable` |  `1.24.0-599f42a84` |
+| `anbox-cloud-appliance` | `1.24/stable` | `1.24.0-599f42a84`  |
+| `nats` | `latest/stable` | `1.24.0-599f42a84` |
 
 ### Anbox images
 
@@ -48,16 +49,16 @@ The following Anbox images are available in two variants: one based on a contain
 
 | Name | Version |
 |----------|--------------|
-| `jammy:android14:amd64` |   |
-| `jammy:android14:arm64` |   |
-| `jammy:android13:amd64` |   |
-| `jammy:android13:arm64` |   |
-| `jammy:android12:amd64` |   |
-| `jammy:android12:arm64` |   |
-| `jammy:aaos13:amd64`    |   |
-| `jammy:aaos13:arm64`    |   |
-| `jammy:aaos14:amd64`    |   |
-| `jammy:aaos14:arm64`    |   |
+| `jammy:android14:amd64` |  `1.24.0-20241108182702.gitcd2d0650b` |
+| `jammy:android14:arm64` |  `1.24.0-20241108182702.gitcd2d0650b` |
+| `jammy:android13:amd64` |  `1.24.0-20241108182702.gitcd2d0650b` |
+| `jammy:android13:arm64` |  `1.24.0-20241108182702.gitcd2d0650b` |
+| `jammy:android12:amd64` |  `1.24.0-20241108182702.gitcd2d0650b` |
+| `jammy:android12:arm64` |  `1.24.0-20241108182702.gitcd2d0650b` |
+| `jammy:aaos13:amd64`    |  `1.24.0-20241108182702.gitcd2d0650b` |
+| `jammy:aaos13:arm64`    |  `1.24.0-20241108182702.gitcd2d0650b` |
+| `jammy:aaos14:amd64`    |  `1.24.0-20241108182702.gitcd2d0650b` |
+| `jammy:aaos14:arm64`    |  `1.24.0-20241108182702.gitcd2d0650b` |
 
 ## 1.23.2
 

--- a/reference/component-versions.md
+++ b/reference/component-versions.md
@@ -56,6 +56,8 @@ The following Anbox images are available in two variants: one based on a contain
 | `jammy:android12:arm64` |   |
 | `jammy:aaos13:amd64`    |   |
 | `jammy:aaos13:arm64`    |   |
+| `jammy:aaos14:amd64`    |   |
+| `jammy:aaos14:arm64`    |   |
 
 ## 1.23.2
 

--- a/reference/component-versions.md
+++ b/reference/component-versions.md
@@ -28,8 +28,8 @@ Not all components are updated with each release. When components are not update
 
 | Name | Channel | Revision |
 |----------|--------------|--------------|
-| `anbox-cloud` | `1.24/stable` | 497 |
-| `anbox-cloud-core` | `1.24/stable` | 509 |
+| `anbox-cloud` | `1.24/stable` | 501 |
+| `anbox-cloud-core` | `1.24/stable` | 513 |
 
 ### Snaps
 

--- a/reference/deprecation-notices.md
+++ b/reference/deprecation-notices.md
@@ -4,7 +4,7 @@
 This document contains a list of deprecation notices for Anbox Cloud and its components.
 
 ## Node controller
-*Deprecated in 1.23.0* ; *Removal in 1.24.0*
+*Deprecated in 1.23.0* ; *Removal in 1.25.0*
 
 Use of node controller to manage the port forwarding from an instance to expose a service is deprecated in 1.23.0. Instead, the Anbox Management Service (AMS) will use a LXD proxy device to manage the port forwarding.
 

--- a/reference/deprecation-notices.md
+++ b/reference/deprecation-notices.md
@@ -18,10 +18,10 @@ The snap with `epoch=0` is the existing implementation that was deprecated in 1.
 
 Starting from 1.23.0, the snap with `epoch=1` will be the new implementation which is the default for new appliance installations. This implementation of the appliance will no longer use the Juju charmed operators internally but package all necessary service components directly within the snap. This helps to simplify the installation process and reduce overall footprint.
 
-## Ubuntu 20.04 (focal)
+## Ubuntu 20.04 (Focal Fossa)
 *Deprecated in 1.22.0* ; *Removal in 1.24.0*
 
-Support for Ubuntu 20.04 (focal) is deprecated in 1.22.0 and is planned to be removed in Anbox Cloud 1.24.0.
+Support for Ubuntu 20.04 (Focal Fossa) is deprecated in 1.22.0 and is planned to be removed in Anbox Cloud 1.24.0.
 
 ## EmuGL
 *Deprecated in 1.22.0* ; *Removal in 1.23.0*

--- a/reference/release-notes/1.24.0.md
+++ b/reference/release-notes/1.24.0.md
@@ -1,0 +1,96 @@
+---
+orphan: true
+---
+# 1.24.0
+
+These release notes cover new features and changes in Anbox Cloud 1.24.0.
+
+Anbox Cloud 1.24.0 is a minor release. To understand minor and patch releases, see [Release notes](https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/release-notes/release-notes).
+
+Please see [Component versions](https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/component-versions/) for a list of updated components.
+
+## Requirements
+
+See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/requirements/) for details on general and deployment specific requirements to run Anbox Cloud.
+
+## New features & improvements
+
+### Updates to components
+
+* Anbox Cloud includes and uses the following latest versions for components it uses:
+  - LXC version 6.0.2<!--AC-2812-->
+  - Mesa driver version 24.2.6<!--AC-2800-->
+  - VirGL renderer version 1.9.0.<!--AC-2800-->
+
+### Security
+
+* We have enhanced security with a minimum version of TLS 1.3 as a requirement for all services working with Anbox Cloud. TLS 1.3 is also enabled by default for the Anbox Stream Agent and Gateway.<!--AC-2728 and AC-2654-->
+
+### Anbox Management Service (AMS)
+* We have increased the maximum number of queued operations in AMS to allow better performance.<!--AC-2831-->
+* Anbox Cloud provides the image type (`android`, `aaos` or `generic`) through the following three ways:<!--AC-2757-->
+  - `metadata.yaml` of the Anbox Cloud image
+  - API response from the AMS when querying image information
+  - Output of `amc image show` command
+
+  This allows the web client to adapt its interface according to the image type.
+* We have enabled support for multiple cluster management by AMS.<!--AC-2674-->
+
+### Android
+
+* This release includes Android 14 based AOSP images.
+* We now support using the lock screen in Anbox Cloud([LP 1983426](https://bugs.launchpad.net/anbox-cloud/+bug/1983426)).
+
+### Charms
+
+* For the NFS Operator charm for Anbox Cloud, `Cachefilesd` is now optional and is used only when `fsc` is provided as a mount option.<!--AC-2839-->
+
+### Streaming improvements
+
+* Anbox Cloud now provides an option to allow the use of custom fragment shader-based upscaling algorithms for video streaming. This helps you to apply multiple shaders sequentially to perform multi-pass upscaling and replaces the default [AMD FidelityFX Super Resolution 1.0](https://gpuopen.com/fidelityfx-superresolution/) shader. See {ref}`sec-custom-fragment-shader` for more information.<!--AC-2541-->
+* The Anbox Streaming SDK now uses the [Snapdragon™ Game Super Resolution(SGSR)](https://github.com/SnapdragonStudios/snapdragon-gsr) algorithm, which integrates upscaling and sharpening in one single GPU shader pass, by default.<!--AC-2543-->
+
+### Other
+
+* Android security updates for November 2024 (see [Android Security Bulletin - November 2024](https://source.android.com/docs/security/bulletin/2024-11-01) for more information).
+* The Android WebView has been updated to 130.0.6723.73.
+
+## Removed functionality
+
+Following deprecation in earlier releases, these functionalities have been removed from Anbox Cloud with the 1.24.0 release:
+
+* Support for Ubuntu 20.04 (Focal Fossa)
+* Use of node controller to manage the port forwarding from an instance to expose a service
+
+## Deprecations
+
+< List deprecated features. Provide an alternative, if any, for the users to use instead of the deprecated features >
+
+## Known issues
+
+* Out of band support does not work as expected for Android 14 images because of a change in implicit intents feature in the upstream.<!--AC-2852-->
+* The following features are supported for AAOS images based on Android 14. This is not an intended support and will be removed in the next patch release:<!--AC-2848-->
+  - `enable_virtual_keyboard`
+  - `enable_system_ui`
+  - `enable_anbox_ime`
+  - Custom Android ID
+  - Custom system apps
+  - Boot package support
+
+## Bug fixes
+
+The following bugs have been fixed as part of the Anbox Cloud 1.24.0 release.
+
+* [LP 2064900](https://bugs.launchpad.net/anbox-cloud/+bug/2064900) If an instance fails and ends up with *Error* status, the session for the instance is set to *Error* status as well. When the instance is restarted, the session status remains in *Error* and it is not possible to stream from the instance again.
+* [LP 2084897](https://bugs.launchpad.net/anbox-cloud/+bug/2084897) Null pointer exception when opening Anbox IME.
+* [LP 2072496](https://bugs.launchpad.net/anbox-cloud/+bug/2072496) Setting user data while creating an instance with streaming enabled creates an instance but does not allow you to join the session.
+* [LP 2085098](https://bugs.launchpad.net/anbox-cloud/+bug/2085098) The dashboard fails to connect to the stream gateway because the value of the `ASG_API_URL` configuration is used to limit the dashboard's communication. So when the CORS header is set to, for example, the private address of the gateway, the dashboard cannot connect to the gateway.
+* [LP 2084800](https://bugs.launchpad.net/anbox-cloud/+bug/2084800) The `no_wait` query parameter for the `POST /1.0/instances` endpoint is not documented.
+* [LP 2084120](https://bugs.launchpad.net/anbox-cloud/+bug/2084120) Anbox WebRTC Data Proxy service takes too long to get started.
+* [LP 2083795](https://bugs.launchpad.net/anbox-cloud/+bug/2083795) When reconnecting to the ADB server, the connection is refused.
+* [LP 2077638](https://bugs.launchpad.net/anbox-cloud/+bug/2077638) After initialising the Anbox Cloud Appliance, the output of `amc image list` remains empty. This shows that the Anbox Management Service (AMS) has not loaded the image list immediately after the initialisation.
+* [LP 2084253](https://bugs.launchpad.net/anbox-cloud/+bug/2084253) 64-bit only detection on ARM systems does not work and causes a boot failure.
+
+## Upgrade instructions
+
+See [How to upgrade Anbox Cloud](https://documentation.ubuntu.com/anbox-cloud/en/latest/howto/update/upgrade-anbox/#howto-upgrade-anbox-cloud) and [How to upgrade the Anbox Cloud Appliance](https://documentation.ubuntu.com/anbox-cloud/en/latest/howto/update/upgrade-appliance/#howto-upgrade-appliance) for instructions on how to update your Anbox Cloud deployment to the 1.24.0 release.

--- a/reference/release-notes/1.24.0.md
+++ b/reference/release-notes/1.24.0.md
@@ -36,6 +36,7 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 * This release includes Android 14 based AOSP and AAOS images.
 * We now support using the lock screen in Anbox Cloud([LP 1983426](https://bugs.launchpad.net/anbox-cloud/+bug/1983426)).
+* The out of band v2 feature in Anbox Cloud requires the Android app to be running to receive broadcasts. If the app is in the [cached state](https://developer.android.com/guide/components/activities/process-lifecycle), the system places [context-registered broadcasts in a queue]((https://developer.android.com/develop/background-work/background-tasks/broadcasts#android-14)) and hence the app may not receive broadcasts immediately as it would when it is running.<!--AC-2852-->
 
 ### Charms
 
@@ -73,7 +74,6 @@ Following deprecation in earlier releases, these functionalities have been remov
 
 ## Known issues
 
-* Out of band support does not work as expected for Android 14 images because of a change in implicit intents feature in the upstream.<!--AC-2852-->
 * The following features can be enabled for AAOS images based on Android 14. However, this is not supported and may result in unexpected behaviour. This will be removed in the next patch release:<!--AC-2848-->
   - `enable_virtual_keyboard`
   - `enable_system_ui`

--- a/reference/release-notes/1.24.0.md
+++ b/reference/release-notes/1.24.0.md
@@ -36,7 +36,7 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 * This release includes Android 14 based AOSP and AAOS images.
 * We now support using the lock screen in Anbox Cloud([LP 1983426](https://bugs.launchpad.net/anbox-cloud/+bug/1983426)).
-* The out of band v2 feature in Anbox Cloud requires the Android app to be running to receive broadcasts. If the app is in the [cached state](https://developer.android.com/guide/components/activities/process-lifecycle), the system places [context-registered broadcasts in a queue]((https://developer.android.com/develop/background-work/background-tasks/broadcasts#android-14)) and hence the app may not receive broadcasts immediately as it would when it is running.<!--AC-2852-->
+* For the Android 14 image, the out of band v2 feature in Anbox Cloud requires the Android app to be running to receive broadcasts. If the app is in the [cached state](https://developer.android.com/guide/components/activities/process-lifecycle), the system places [context-registered broadcasts in a queue]((https://developer.android.com/develop/background-work/background-tasks/broadcasts#android-14)) and hence the app may not receive broadcasts immediately as it would when it is running.<!--AC-2852-->
 
 ### Charms
 
@@ -70,7 +70,7 @@ Following deprecation in earlier releases, these functionalities have been remov
 
 ## Deprecations
 
-< List deprecated features. Provide an alternative, if any, for the users to use instead of the deprecated features >
+There are no new deprecations announced for 1.24.0. For the list of features or components that were deprecated before 1.24.0 and are planned to be removed in future releases, see {ref}`ref-deprecation-notes`.
 
 ## Known issues
 
@@ -81,6 +81,8 @@ Following deprecation in earlier releases, these functionalities have been remov
   - Custom Android ID
   - Custom system apps
   - Boot package support
+
+* When using the Android 14 image, displaying an activity from a boot package using the `foregroundActivity` option in the [Anbox Streaming SDK](https://github.com/canonical/anbox-streaming-sdk/tree/main) may not work. This issue occurs due to a native crash occurring in the Android container.
 
 ## Bug fixes
 

--- a/reference/release-notes/1.24.0.md
+++ b/reference/release-notes/1.24.0.md
@@ -27,6 +27,7 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 * We have enhanced security with a minimum version of TLS 1.3 as a requirement for all services working with Anbox Cloud. TLS 1.3 is also enabled by default for the Anbox Stream Agent and Gateway.<!--AC-2728 and AC-2654-->
 
 ### Anbox Management Service (AMS)
+
 * We have increased the maximum number of queued operations in AMS to allow better performance.<!--AC-2831-->
 * Anbox Cloud provides the image type (`android`, `aaos` or `generic`) through the following three ways:<!--AC-2757-->
   - `metadata.yaml` of the Anbox Cloud image
@@ -45,7 +46,15 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 * For the NFS Operator charm for Anbox Cloud, `Cachefilesd` is now optional and is used only when `fsc` is provided as a mount option.<!--AC-2839-->
 
-### Streaming improvements
+### Dashboard
+
+* You can now debug a session with the new developer tools on the stream page. Terminal and logs are available in parallel when streaming an instance.
+* For mobile streams, a location selector is now available.
+* For increased security, HTTPS is mandatory for all connections.
+* Image type is auto-detected once application is selected. 
+* Improved accessibility with a *Skip to content* button.
+
+### Streaming
 
 * Anbox Cloud now provides an option to allow the use of custom fragment shader-based upscaling algorithms for video streaming. This helps you to apply multiple shaders sequentially to perform multi-pass upscaling and replaces the default [AMD FidelityFX Super Resolution 1.0](https://gpuopen.com/fidelityfx-superresolution/) shader. See {ref}`sec-custom-fragment-shader` for more information.<!--AC-2541-->
 * The Anbox Streaming SDK now uses the [Snapdragon™ Game Super Resolution(SGSR)](https://github.com/SnapdragonStudios/snapdragon-gsr) algorithm, which integrates upscaling and sharpening in one single GPU shader pass, by default.<!--AC-2543-->

--- a/reference/release-notes/1.24.0.md
+++ b/reference/release-notes/1.24.0.md
@@ -19,7 +19,7 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 * Anbox Cloud includes and uses the following latest versions for components it uses:
   - LXC version 6.0.2<!--AC-2812-->
-  - Mesa driver version 24.2.6<!--AC-2800-->
+  - Mesa driver version 24.2.4<!--AC-2800-->
   - VirGL renderer version 1.9.0.<!--AC-2800-->
 
 ### Security
@@ -29,17 +29,12 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 ### Anbox Management Service (AMS)
 
 * We have increased the maximum number of queued operations in AMS to allow better performance.<!--AC-2831-->
-* Anbox Cloud provides the image type (`android`, `aaos` or `generic`) through the following three ways:<!--AC-2757-->
-  - `metadata.yaml` of the Anbox Cloud image
-  - API response from the AMS when querying image information
-  - Output of `amc image show` command
-
-  This allows the web client to adapt its interface according to the image type.
-* We have enabled support for multiple cluster management by AMS.<!--AC-2674-->
+* AMS supports querying the image variant (`android` or `aaos`) for Anbox Cloud images.<!--AC-2757-->
+* The web client, for example, the Anbox Cloud dashboard can communicate with multiple AMS instances.<!--AC-2674-->
 
 ### Android
 
-* This release includes Android 14 based AOSP images.
+* This release includes Android 14 based AOSP and AAOS images.
 * We now support using the lock screen in Anbox Cloud([LP 1983426](https://bugs.launchpad.net/anbox-cloud/+bug/1983426)).
 
 ### Charms
@@ -57,7 +52,9 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 ### Streaming
 
 * Anbox Cloud now provides an option to allow the use of custom fragment shader-based upscaling algorithms for video streaming. This helps you to apply multiple shaders sequentially to perform multi-pass upscaling and replaces the default [AMD FidelityFX Super Resolution 1.0](https://gpuopen.com/fidelityfx-superresolution/) shader. See {ref}`sec-custom-fragment-shader` for more information.<!--AC-2541-->
-* The Anbox Streaming SDK now uses the [Snapdragon™ Game Super Resolution(SGSR)](https://github.com/SnapdragonStudios/snapdragon-gsr) algorithm, which integrates upscaling and sharpening in one single GPU shader pass, by default.<!--AC-2543-->
+* The Anbox Streaming SDK now includes two additional examples that demonstrate shader-based upscaling algorithms integrated with the JS SDK:<!--AC-2543-->
+  - [Snapdragon™ Game Super Resolution(SGSR)](https://github.com/SnapdragonStudios/snapdragon-gsr)
+  - [Anime4K high-quality real-time anime](https://github.com/bloc97/Anime4K)
 
 ### Other
 
@@ -69,7 +66,6 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 Following deprecation in earlier releases, these functionalities have been removed from Anbox Cloud with the 1.24.0 release:
 
 * Support for Ubuntu 20.04 (Focal Fossa)
-* Use of node controller to manage the port forwarding from an instance to expose a service
 
 ## Deprecations
 
@@ -78,7 +74,7 @@ Following deprecation in earlier releases, these functionalities have been remov
 ## Known issues
 
 * Out of band support does not work as expected for Android 14 images because of a change in implicit intents feature in the upstream.<!--AC-2852-->
-* The following features are supported for AAOS images based on Android 14. This is not an intended support and will be removed in the next patch release:<!--AC-2848-->
+* The following features can be enabled for AAOS images based on Android 14. However, this is not supported and may result in unexpected behaviour. This will be removed in the next patch release:<!--AC-2848-->
   - `enable_virtual_keyboard`
   - `enable_system_ui`
   - `enable_anbox_ime`

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -9,6 +9,7 @@ For instructions on how to update your Anbox Cloud deployment to later versions,
 
 | Release date   |  Release notes  |
 |----|----|
+| November 13 2024 | [Anbox Cloud 1.24.0](1.24.0.md) |
 | October 23 2024 | [Anbox Cloud 1.23.2 hotfix 1](1.23.2-hotfix1.md) |
 | October 16 2024 | [Anbox Cloud 1.23.2](1.23.2.md) |
 | September 18 2024 | [Anbox Cloud 1.23.1](1.23.1.md) |
@@ -16,15 +17,15 @@ For instructions on how to update your Anbox Cloud deployment to later versions,
 
 ## Upcoming release roadmap
 
-The current minor release is **1.23.0** and the next one will be **1.24.0**.
+The current minor release is **1.24.0** and the next one will be **1.25.0**.
 
 The following target dates for upcoming releases are not final and could vary depending on various factors such as availability of Android security patches. The release notes link will be updated on the day of the release.
 
 | Target date | Version | Planned updates |
 |----|----|----|
-| November 14 2024 | Anbox Cloud 1.24.0 | * VHAL improvements<br/> * Android 14 images<br/> * Support for additional upscaling algorithms in the streaming SDK<br/> * Android security updates for November 2024<br/> * Reworked charms<br/> * Bug fixes |
 | December 11 2024 | Anbox Cloud 1.24.1 | * Android security updates for December 2024<br/> * Bug fixes |
 | January 15 2025 | Anbox Cloud 1.24.2 | * Android security updates for January 2025<br/> * Bug fixes |
+| February 12 2025 | Anbox Cloud 1.25.0 | * Integration with the Canonical Observability Stack<br/> * Backup and restore support for the Anbox Cloud dashboard charm<br/> * Support for Ubuntu 24.04 (Noble Numbat) for all charms<br/> * Terraform plan replacing the Anbox Cloud bundles<br/> * Improvements to the Anbox Management Service (AMS)<br/> * Upgrade to LXD 5.21<br/> * Android security updates for February 2025<br/> * Bug fixes |
 
 ## Release and support policy
 
@@ -45,18 +46,16 @@ To ensure you receive latest security updates and bug fixes, you should upgrade 
 If you are looking for additional support, see [Ubuntu Pro](https://ubuntu.com/support). Canonical can also provide [managed solutions](https://ubuntu.com/managed) for Anbox Cloud.
 
 
-### What's new in 1.23.x?
+### What's new in 1.24.x?
 
-Along with bug fixes and general improvements, Anbox Cloud 1.23.x includes:
+Along with bug fixes and general improvements, Anbox Cloud 1.24.x includes:
 
-* Improved Anbox Cloud Appliance
-* Seamless ADB connections to remote Android instances
-* Dashboard improvements
-    - Merge of sessions and instances pages
-    - Ability to authorise ADB connections
-* Improved documentation delivery
-* Android 14 based vendor images
-* Reworked charms that install snaps from the snap store
+* VHAL improvements
+* Android 14 images
+* Support for generic application streaming
+* Support for additional upscaling algorithms in the streaming SDK
+* Support for managing multiple subclusters
+* Reworked charms
 * Android security updates
 
 <details><summary>Click to view earlier releases' notes</summary>

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -25,7 +25,7 @@ The following target dates for upcoming releases are not final and could vary de
 |----|----|----|
 | December 11 2024 | Anbox Cloud 1.24.1 | * Android security updates for December 2024<br/> * Bug fixes |
 | January 15 2025 | Anbox Cloud 1.24.2 | * Android security updates for January 2025<br/> * Bug fixes |
-| February 12 2025 | Anbox Cloud 1.25.0 | * Integration with the Canonical Observability Stack<br/> * Backup and restore support for the Anbox Cloud dashboard charm<br/> * Support for Ubuntu 24.04 (Noble Numbat) for all charms<br/> * (Alpha release) Terraform plan replacing the Anbox Cloud bundles<br/> * Improvements to the Anbox Management Service (AMS)<br/> * Upgrade to LXD 5.21<br/> * Android security updates for February 2025<br/> * Bug fixes |
+| February 12 2025 | Anbox Cloud 1.25.0 | * Integration with the [Canonical Observability Stack](https://charmhub.io/topics/canonical-observability-stack)<br/> * Backup and restore support for the Anbox Cloud dashboard charm<br/> * Support for Ubuntu 24.04 (Noble Numbat) for all charms<br/> * (Alpha release) Terraform plan replacing the Anbox Cloud bundles<br/> * Improvements to the Anbox Management Service (AMS)<br/> * Reworked charms<br/> * Upgrade to LXD 5.21<br/> * Android security updates for February 2025<br/> * Bug fixes |
 
 ## Release and support policy
 
@@ -54,7 +54,6 @@ Along with bug fixes and general improvements, Anbox Cloud 1.24.x includes:
 * Android 14 images
 * Support for additional upscaling algorithms in the streaming SDK
 * Support for communication between dashboard and multiple AMS instances
-* Reworked charms
 * Android security updates
 
 <details><summary>Click to view earlier releases' notes</summary>

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -25,7 +25,7 @@ The following target dates for upcoming releases are not final and could vary de
 |----|----|----|
 | December 11 2024 | Anbox Cloud 1.24.1 | * Android security updates for December 2024<br/> * Bug fixes |
 | January 15 2025 | Anbox Cloud 1.24.2 | * Android security updates for January 2025<br/> * Bug fixes |
-| February 12 2025 | Anbox Cloud 1.25.0 | * Integration with the Canonical Observability Stack<br/> * Backup and restore support for the Anbox Cloud dashboard charm<br/> * Support for Ubuntu 24.04 (Noble Numbat) for all charms<br/> * Terraform plan replacing the Anbox Cloud bundles<br/> * Improvements to the Anbox Management Service (AMS)<br/> * Upgrade to LXD 5.21<br/> * Android security updates for February 2025<br/> * Bug fixes |
+| February 12 2025 | Anbox Cloud 1.25.0 | * Integration with the Canonical Observability Stack<br/> * Backup and restore support for the Anbox Cloud dashboard charm<br/> * Support for Ubuntu 24.04 (Noble Numbat) for all charms<br/> * (Alpha release) Terraform plan replacing the Anbox Cloud bundles<br/> * Improvements to the Anbox Management Service (AMS)<br/> * Upgrade to LXD 5.21<br/> * Android security updates for February 2025<br/> * Bug fixes |
 
 ## Release and support policy
 
@@ -52,9 +52,8 @@ Along with bug fixes and general improvements, Anbox Cloud 1.24.x includes:
 
 * VHAL improvements
 * Android 14 images
-* Support for generic application streaming
 * Support for additional upscaling algorithms in the streaming SDK
-* Support for managing multiple subclusters
+* Support for communication between dashboard and multiple AMS instances
 * Reworked charms
 * Android security updates
 

--- a/reference/requirements.md
+++ b/reference/requirements.md
@@ -44,7 +44,6 @@ For external access to the Anbox Cloud Appliance, you must expose a couple of ne
 
 The Anbox Cloud Appliance supports the following Ubuntu versions:
 
-* Ubuntu 20.04 (Focal Fossa)
 * Ubuntu 22.04 (Jammy Jellyfish)
 * Ubuntu 24.04 (Noble Numbat)
 
@@ -62,7 +61,6 @@ Anbox Cloud deployments are managed by Juju. They can be created on all the [sup
 
 Anbox Cloud supports the following Ubuntu versions:
 
-* 20.04 (focal)
 * 22.04 (jammy)
 
 For new deployments, Ubuntu 22.04 (jammy) is preferred.

--- a/tutorial/installing-appliance.md
+++ b/tutorial/installing-appliance.md
@@ -18,7 +18,7 @@ This tutorial guides you through the steps that are required to install and init
 Make sure you have the following prerequisites:
 
 * An Ubuntu SSO account. If you don't have one yet, [create it](https://login.ubuntu.com).
-* A virtual or bare metal machine running Ubuntu 20.04 or 22.04. See the detailed {ref}`ref-requirements`.
+* A virtual or bare metal machine running Ubuntu 22.04. See the detailed {ref}`ref-requirements`.
 ```{caution}
 It is not recommended to run Anbox Cloud on an Ubuntu desktop appliance. Always use the [server](https://ubuntu.com/download/server) or the [cloud](https://ubuntu.com/download/cloud) variant.
 ```


### PR DESCRIPTION
* Add release notes for 1.24.0
* Update release information
* Add component versions
* Remove 20.04 information


Pending:

- [x] Update component versions after candidate is ready
- [x] Confirm removal of node controller information across documentation
- [x] Add dashboard improvements section from David's team
- [x] Inline comments seeking clarification
- [x] Known issue for how to force [displaying an activity](https://github.com/canonical/anbox-streaming-sdk/blob/main/js/anbox-stream-sdk.js#L99) via the streaming SDK when using Android 14 image
- [x] Update bundle versions after they are promoted to stable