### PR TITLE
fix(troubleshoot): use `juju-crashdump` over `juju crash-dump` command

### DIFF
--- a/howto/troubleshoot/landing.md
+++ b/howto/troubleshoot/landing.md
@@ -36,7 +36,7 @@ A Juju crash dump may include the following debugging information:
 
 Use the following command to generate a crash dump:
 
-    juju crash-dump -s -a --as-root debug-layer
+    juju-crashdump -s --as-root -a debug-layer
 
 The Anbox Management Service (AMS) charm implements the `debug-layer` addon which will add a `debug-*.tar.gz` archive to the crash dump for the AMS units. The tarball may contain logs for the instances that are in `error` state in AMS and other information about the Anbox runtime process.
 


### PR DESCRIPTION
Juju 3 drops support for executing the external plug, which causes
the juju crash-dump command to be incomplete in Juju 3 and results
in the following error:
```
$ juju crashdump
ERROR juju: "crashdump" is not a juju command. See "juju --help".
``

Therefore, use the juju-crashdump command in our documentation to
ensure users can collect logs regardless of the Juju version.

Another issue with the suggested command is that we need to include
the `debug-layer` addon followed by the -a parameter, which denotes
the --addon option.