### PR TITLE
Add security policy to documentation

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -197,6 +197,7 @@ nrpe
 null
 NUMA
 numpad
+nvd
 NvEnc
 NVIDIA
 NVMe

--- a/reference/landing.md
+++ b/reference/landing.md
@@ -59,6 +59,14 @@ Learn about the available metrics and benchmarks for measuring performance.
 | {ref}`ref-prometheus-metrics`| Performance metrics that Anbox Cloud provides |
 | {ref}`ref-performance-benchmarks`| Benchmarks for the performance that you can achieve with different versions and configurations of Anbox Cloud |
 
+## Security
+
+Learn about our security policies and about the fixes we have provided for vulnerabilities.
+|Guides | Description |
+|--|--|
+| {ref}`ref-security-notices`| Details on the CVEs we have fixed |
+| {ref}`ref-security-policy` | Anbox Cloud security policy and reporting a vulnerability |
+
 ## Other
 
 | Guides | Description |
@@ -92,6 +100,7 @@ release-notes/release-notes.md
 requirements
 roadmap
 security-notices
+security-policy
 android-features
 Supported features <anbox-features>
 supported-rendering-resources

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -144,3 +144,7 @@ Along with bug fixes and general improvements, Anbox Cloud 1.24.x includes:
 |December 2018|[Anbox Cloud 1.0.1](1.0.1.md)|
 |November 2018|[Anbox Cloud 1.0.0](1.0.0.md)|
 </details>
+
+## Security policy
+
+The Anbox Cloud security policy is available at {ref}`ref-security-policy`.

--- a/reference/security-notices.md
+++ b/reference/security-notices.md
@@ -1,7 +1,9 @@
 (ref-security-notices)=
 # Security notices
 
-This page contains information about security vulnerabilities found and fixed in Anbox Cloud:
+This page contains information about security vulnerabilities found and fixed in Anbox Cloud.
+
+For information about our security policy, see {ref}`ref-security-policy`.
 
 (sec-CVE-2024-8287)=
 ## CVE-2024-8287

--- a/reference/security-policy.md
+++ b/reference/security-policy.md
@@ -21,5 +21,10 @@ If you discover a security vulnerability with Anbox Cloud, report it using the f
 
 The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about what you can expect when you contact us and what we expect from you.
 
-The Anbox Cloud team will be notified of the issue and review the vulnerability. We may reach out to you for further information or clarification if needed. 
-If the issue is confirmed as a valid security vulnerability, we will assign a CVE and coordinate the release of the fix. We also document them as {ref}`ref-security-notices`.
+## Response to reported vulnerabilities
+
+The Anbox Cloud team will be notified of the issue and review the vulnerability. We may reach out to you for further information or clarification if needed.
+
+If the issue is confirmed as a valid security vulnerability, we use the [NVD scoring system](https://nvd.nist.gov/vuln-metrics/cvss) for deciding the severity and assign a CVE number.
+
+We fix vulnerabilities classified as _critical_ or _high_ with the subsequent monthly release of Anbox Cloud and also document them as {ref}`ref-security-notices`.

--- a/reference/security-policy.md
+++ b/reference/security-policy.md
@@ -1,0 +1,25 @@
+(ref-security-policy)=
+# Security policy
+
+Learn about our [release and support policy](https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/release-notes/release-notes/#release-and-support-policy) for the nature of our releases and versions.
+
+All our public repositories have a `SECURITY.md` file that details our security policy. However, Anbox Cloud has components for which the source is not publicly available. The same policy as listed below applies for a security vulnerability for any component of Anbox Cloud.
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability with Anbox Cloud, report it using the following steps:
+
+1. Do not publicly disclose the vulnerability before discussing it with us.
+2. Report a bug at https://bugs.launchpad.net/anbox-cloud.
+
+    **Important**: Remember to set the information type to *Private Security*. You will see a field with the text *This bug contains information that is:*
+3. Provide detailed information about the vulnerability, including:
+   - A description of the vulnerability
+   - Steps to reproduce the issue
+   - Potential impact and affected versions
+   - Suggested mitigation, if possible
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about what you can expect when you contact us and what we expect from you.
+
+The Anbox Cloud team will be notified of the issue and review the vulnerability. We may reach out to you for further information or clarification if needed. 
+If the issue is confirmed as a valid security vulnerability, we will assign a CVE and coordinate the release of the fix. We also document them as {ref}`ref-security-notices`.


### PR DESCRIPTION
Since we have some private source code, this PR adds the policy to the documentation in addition to the `SECURITY.md` file to the public repositories.