### PR TITLE
Correctly fetch gateway API spec

### DIFF
--- a/.github/workflows/update-api-specs.yaml
+++ b/.github/workflows/update-api-specs.yaml
@@ -27,6 +27,8 @@ jobs:
       run: |
         sudo apt update
         sudo apt install -y jq yq
+        # Don't allow us to succeed if the actual curl command fails
+        set -o pipefail
         curl \
           --unix-socket /var/snap/anbox-cloud-appliance/common/ams-unix.socket \
           s/1.0/swagger.json | yq -y > ./reference/api-reference/ams-api.yaml

--- a/.github/workflows/update-api-specs.yaml
+++ b/.github/workflows/update-api-specs.yaml
@@ -30,7 +30,7 @@ jobs:
         curl \
           --unix-socket /var/snap/anbox-cloud-appliance/common/ams-unix.socket \
           s/1.0/swagger.json | yq -y > ./reference/api-reference/ams-api.yaml
-        curl \
+        sudo curl \
           --unix-socket /var/snap/anbox-cloud-appliance/common/gateway/internal.sock \
           s/1.0/swagger.json | yq -y > ./reference/api-reference/gateway-api.yaml
     - name: Create PR


### PR DESCRIPTION
We need to use `sudo` as the gateway API socket doesn't allow access for unprivileged users. Furthermore we now enable the `pipefail` option to prevent the workflow succeeding while the curl command did not.