### PR TITLE
Set up do-no-edit workflow for automated content

### DIFF
--- a/.github/workflows/do-not-edit.yml
+++ b/.github/workflows/do-not-edit.yml
@@ -1,0 +1,26 @@
+name: Check for files that should not be edited
+
+on:
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - 'reference/ams-configuration.md'
+      - 'reference/cmd-ref/amc/*.md'
+      - 'reference/cmd-ref/appliance/*.md'
+  pull_request:
+    paths:
+      - 'reference/ams-configuration.md'
+      - 'reference/cmd-ref/amc/*.md'
+      - 'reference/cmd-ref/appliance/*.md'
+
+jobs:
+  check:
+    name: Fail
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print error
+        run: echo "::error file=reference/ams-configuration.md::Never edit reference/ams-configuration.md manually - edit reference/ams-configuration.tmpl.md or reference/ams-configuration.yaml instead!"
+
+      - name: Exit
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __pycache__
 .sphinx/vale.ini
 .sphinx/deps/
 .sphinx/_static/swagger-ui/
+reference/ams-configuration.md


### PR DESCRIPTION
This PR introduces a workflow to no edit the files that are automatically generated.
It also adds the `reference/ams-configuration.md` file to `.gitignore` to ignore tracking in local builds of documentation.