### PR TITLE
Add 1.23.3 release documentation

### DIFF
--- a/reference/component-versions.md
+++ b/reference/component-versions.md
@@ -9,6 +9,10 @@ Not all components are updated with each release. When components are not update
 
 The following Anbox images are the only artefacts released for this patch.
 
+```{note}
+There are no VM images for ARM64.
+```
+
 | Name | Version |
 |----------|--------------|
 | `jammy:android13:amd64` | `1.23.3-20241128155118.git5e43037d8` |

--- a/reference/component-versions.md
+++ b/reference/component-versions.md
@@ -5,6 +5,20 @@ This documents the versions of the different components for each Anbox Cloud rel
 
 Not all components are updated with each release. When components are not updated, they are marked with `n/a` below.
 
+## 1.23.3
+
+The following Anbox images are the only artefacts released for this patch.
+
+| Name | Version |
+|----------|--------------|
+| `jammy:android13:amd64` | `1.23.3-20241128155118.git5e43037d8` |
+| `jammy:android13:arm64` | `1.23.3-20241128155118.git5e43037d8` |
+| `jammy:android12:amd64` | `1.23.3-20241128155118.git5e43037d8` |
+| `jammy:android12:arm64` | `1.23.3-20241128155118.git5e43037d8` |
+| `jammy:aaos13:amd64`    | `1.23.3-20241128155118.git5e43037d8` |
+| `jammy:aaos13:arm64`    | `1.23.3-20241128155118.git5e43037d8` |
+
+
 ## 1.24.0
 
 ### Charms

--- a/reference/release-notes/1.23.3.md
+++ b/reference/release-notes/1.23.3.md
@@ -1,0 +1,14 @@
+---
+orphan: true
+---
+# 1.23.3
+
+This release is specifically for fixing an issue where an unusually high GPU memory consumption by an Anbox process was reported.
+
+The main trigger for this issue is when multiple clients connect with varying screen resolutions, the system is forced to reallocate GPU buffers of different sizes and does not release memory.
+
+The corresponding bug for this is reported at [LP 2089631](https://bugs.launchpad.net/anbox-cloud/+bug/2089631).
+
+## Upgrade instructions
+
+See {ref}`howto-upgrade-anbox-cloud` and {ref}`howto-upgrade-appliance` for instructions on how to update your Anbox Cloud deployment to the 1.23.3 release.

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -9,6 +9,7 @@ For instructions on how to update your Anbox Cloud deployment to later versions,
 
 | Release date   |  Release notes  |
 |----|----|
+| December 4, 2024 | [Anbox Cloud 1.23.3](1.23.3.md) |
 | November 13 2024 | [Anbox Cloud 1.24.0](1.24.0.md) |
 | October 23 2024 | [Anbox Cloud 1.23.2 hotfix 1](1.23.2-hotfix1.md) |
 | October 16 2024 | [Anbox Cloud 1.23.2](1.23.2.md) |


### PR DESCRIPTION
Since this is an unplanned patch release, this PR is targeted directly to the `main` branch.

This PR adds the 1.23.3 release notes and image version.