### PR TITLE
docs(tutorial): add warning to reboot system before running prepare-node-script

### DIFF
--- a/tutorial/installing-appliance.md
+++ b/tutorial/installing-appliance.md
@@ -38,6 +38,10 @@ On your machine, run the following commands to ensure that all installed package
     sudo apt update
     sudo apt upgrade
 
+```{caution}
+Please reboot your system after the upgrade (if required) before proceeding with the other steps.
+```
+
 ### Attach your machine to Ubuntu Pro
 
 The Anbox Cloud Appliance requires a valid Ubuntu Pro subscription.


### PR DESCRIPTION


This is required as the kernel modules and drivers installed during the node setup should be installed in the correct and updated kernel on the machine.