### PR TITLE
Update regular to charmed deployment

### DIFF
--- a/explanation/anbox-cloud.md
+++ b/explanation/anbox-cloud.md
@@ -18,7 +18,7 @@ The Anbox Cloud Appliance is a self-contained deployment variant of Anbox Cloud.
 
 **Anbox Cloud**
 
-The regular Anbox Cloud uses [Juju](https://juju.is/) for deployment and operations. It provides rich features and is best suited for a large scale deployment.
+The charmed Anbox Cloud uses [Juju](https://juju.is/) for deployment and operations. It provides rich features and is best suited for a large scale deployment.
 
 See the following table for a comparison of features for the different variants:
 
@@ -35,7 +35,7 @@ See the following table for a comparison of features for the different variants:
 
 *\* When purchasing the Anbox Cloud Appliance through the AWS Marketplace, the Ubuntu Pro subscription does not include vendor support.*
 
-We recommend starting with the Anbox Cloud Appliance. You can choose to expand to a full Anbox Cloud installation later.
+We recommend starting with the Anbox Cloud Appliance. You can choose to expand to a charmed Anbox Cloud installation later.
 
 ## Anbox Cloud Components
 
@@ -139,7 +139,7 @@ If you are using the Anbox Cloud Appliance, you are prompted during the initiali
 (sec-juju-bundles)=
 ## Juju bundles
 
-The regular Anbox Cloud variant provides two different Juju bundles:
+The charmed Anbox Cloud variant provides two different Juju bundles:
 
 * The `anbox-cloud-core` bundle provides a minimised version of Anbox Cloud. This version is sufficient if you don't want to use the Anbox Cloud streaming stack.
 

--- a/explanation/clustering.md
+++ b/explanation/clustering.md
@@ -1,9 +1,9 @@
 (exp-clustering)=
 # Clustering
 
-While it is possible to install Anbox Cloud on a single machine, Anbox Cloud Appliance does not support multi-node setups. If you intend to distribute the load across multiple machines in a cluster, it is recommended to use Anbox Cloud for full deployments instead.
+While it is possible to install Anbox Cloud on a single machine, Anbox Cloud Appliance does not support multi-node setups. If you intend to distribute the load across multiple machines in a cluster, it is recommended to use charmed Anbox Cloud instead.
 
-In a clustering setup for a full Anbox Cloud deployment, one node is dedicated as the management node to host the Anbox Management Service (AMS). If you use the Streaming Stack, two additional nodes are dedicated to host the extra services required for streaming. All other nodes are used as worker nodes.
+In a clustering setup for a charmed Anbox Cloud deployment, one node is dedicated as the management node to host the Anbox Management Service (AMS). If you use the Streaming Stack, two additional nodes are dedicated to host the extra services required for streaming. All other nodes are used as worker nodes.
 
 Each worker node runs [LXD](https://ubuntu.com/lxd) in [clustering mode](https://documentation.ubuntu.com/lxd/en/latest/clustering/), and this LXD cluster is used to host the Android containers.
 

--- a/explanation/production-planning.md
+++ b/explanation/production-planning.md
@@ -5,7 +5,7 @@ When you are planning a production deployment, you should consider the aspects t
 
 ## Compute resource requirements 
 
-Depending on your workload and the type of deployment you choose, hardware or cloud resource requirements can differ. See {ref}`ref-requirements` to get an idea about the kind of resources that are required to run a full Anbox Cloud deployment with the streaming stack or a minimal core version of the deployment without the streaming stack. 
+Depending on your workload and the type of deployment you choose, hardware or cloud resource requirements can differ. See {ref}`ref-requirements` to get an idea about the kind of resources that are required to run a charmed Anbox Cloud deployment with the streaming stack or a minimal core version of the deployment without the streaming stack.
 
 You should pay special attention to the hardware requirements of applications that are used but not maintained by Anbox Cloud. 
 

--- a/howto/aar/configure.md
+++ b/howto/aar/configure.md
@@ -7,7 +7,7 @@ AAR and AMS must exchange certificates to set up a trust relation. The recommend
 
 ## Register an instance using Juju (recommended)
 
-If you are running a full Anbox Cloud deployment, use Juju relations to register an instance with the AAR.
+If you are running a charmed Anbox Cloud deployment, use Juju relations to register an instance with the AAR.
 
 To register an instance as a client, use the following command:
 

--- a/howto/anbox/control-ams-remotely.md
+++ b/howto/anbox/control-ams-remotely.md
@@ -57,7 +57,7 @@ If you are running the Anbox Cloud Appliance, you can expose the service with th
 
     anbox-cloud-appliance ams expose
 
-If you are running a full Anbox Cloud deployment, the service is automatically exposed within the internal subnet. If this is sufficient, you do not need further configuration. If you want to access AMS from a machine that is in a different subnet, use `juju expose` to expose the service (see [How to expose a deployed application](https://juju.is/docs/olm/expose-a-deployed-application) for instructions). Note that if you expose services externally, you should also add a load balancer or proxy to your deployment.
+If you are running a charmed Anbox Cloud deployment, the service is automatically exposed within the internal subnet. If this is sufficient, you do not need further configuration. If you want to access AMS from a machine that is in a different subnet, use `juju expose` to expose the service (see [How to expose a deployed application](https://juju.is/docs/olm/expose-a-deployed-application) for instructions). Note that if you expose services externally, you should also add a load balancer or proxy to your deployment.
 
 ## Configure AMC to connect to AMS
 

--- a/howto/android/access-instance.md
+++ b/howto/android/access-instance.md
@@ -28,7 +28,7 @@ On the *Instances* page, locate a running instance and click *Connect ADB* ( ![C
 
 **From the Command Line**:
 
-For a full Anbox Cloud deployment, run:
+For the charmed Anbox Cloud deployment, run:
 
     anbox-stream-gateway session share <session_id>
 

--- a/howto/cluster/landing.md
+++ b/howto/cluster/landing.md
@@ -8,7 +8,7 @@ See {ref}`exp-clustering` for an introduction to how clustering works in Anbox C
 ```{important}
 Currently, Anbox Cloud Appliance does not support clustering.
 ```
-The following how-to guides are available for operations related to clustering in regular Anbox Cloud deployments:
+The following how-to guides are available for operations related to clustering in charmed Anbox Cloud deployments:
 
 ```{toctree}
 :titlesonly:

--- a/howto/dashboard/landing.md
+++ b/howto/dashboard/landing.md
@@ -8,7 +8,7 @@ Before you can log into the dashboard, you must register your Ubuntu One account
 
 ### Register in Anbox Cloud
 
-On a regular Anbox Cloud deployment, use the following Juju action to register an Ubuntu One account:
+On a charmed Anbox Cloud deployment, use the following Juju action to register an Ubuntu One account:
 
     juju run anbox-cloud-dashboard/0 --wait=5m register-account email=<Ubuntu One email address>
 

--- a/howto/install-appliance/landing.md
+++ b/howto/install-appliance/landing.md
@@ -3,7 +3,7 @@
 
 The Anbox Cloud Appliance provides a deployment of Anbox Cloud to a single machine. This offering is well suited for initial prototype and small scale deployments.
 
-The guides in this section describe how to install the Anbox Cloud Appliance on different cloud and CI/CD platforms. There is a difference between the full Anbox Cloud installation and the Anbox Cloud Appliance (see {ref}`sec-variants`). This section focuses on the **Anbox Cloud Appliance**. For instructions on how to install **Anbox Cloud**, see {ref}`howto-install-anbox-cloud`.
+The guides in this section describe how to install the Anbox Cloud Appliance on different cloud and CI/CD platforms. There is a difference between the charmed Anbox Cloud installation and the Anbox Cloud Appliance (see {ref}`sec-variants`). This section focuses on the **Anbox Cloud Appliance**. For instructions on how to install **Anbox Cloud**, see {ref}`howto-install-anbox-cloud`.
 
 We strongly recommend that you follow the {ref}`tut-installing-appliance` tutorial before you install the appliance on a cloud or CI/CD platform. The tutorial guides you through installing the appliance on a machine dedicated to Anbox Cloud and makes you familiar with the installation process and the general concepts of the Anbox Cloud Appliance.
 

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -6,7 +6,7 @@ Anbox Cloud supports various public clouds, such as AWS, Azure and Google. To de
 See the following sections for detailed instructions. If you want to install Anbox Cloud on bare metal instead of a public cloud, see {ref}`howto-deploy-anbox-baremetal` instead.
 
 ```{note}
-There are differences between the full Anbox Cloud installation and the Anbox Cloud Appliance (see {ref}`sec-variants`). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see {ref}`tut-installing-appliance`.
+There are differences between the charmed Anbox Cloud installation and the Anbox Cloud Appliance (see {ref}`sec-variants`). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see {ref}`tut-installing-appliance`.
 ```
 
 ## Prerequisites

--- a/howto/install/landing.md
+++ b/howto/install/landing.md
@@ -1,7 +1,7 @@
 (howto-install-anbox-cloud)=
 # How to install Anbox Cloud
 
-It is important to remember that there is a difference between the full Anbox Cloud installation and the Anbox Cloud Appliance (see {ref}`sec-variants`). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see {ref}`tut-installing-appliance`.
+It is important to remember that there is a difference between the charmed Anbox Cloud installation and the Anbox Cloud Appliance (see {ref}`sec-variants`). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see {ref}`tut-installing-appliance`.
 
 Also, see {ref}`ref-requirements` before you start your installation.
 

--- a/howto/stream/access-stream-gateway.md
+++ b/howto/stream/access-stream-gateway.md
@@ -16,7 +16,7 @@ To access the stream gateway,
 An internal HTTP API is exposed for managing client tokens. This API is only accessible via a Unix domain socket which resides at `/var/snap/anbox-stream-gateway/common/service/unix.socket` by default.
 For convenience, the stream gateway has a built-in client designed to communicate to that API.
 
-If you are running a full Anbox Cloud deployment, use the following command to create a token:
+If you are running the charmed Anbox Cloud deployment, use the following command to create a token:
 
     anbox-stream-gateway account create my-client
 
@@ -48,7 +48,7 @@ curl -X GET https://20.234.75.29:4000/1.0/sessions?api_token=AgEUYW5ib3...QSyzaA
 
 ### Deleting a token
 
-If you are running a full Anbox Cloud deployment, use the following command to delete a token:
+If you are running the charmed Anbox Cloud deployment, use the following command to delete a token:
 
     anbox-stream-gateway account delete my-client
 

--- a/howto/troubleshoot/landing.md
+++ b/howto/troubleshoot/landing.md
@@ -22,7 +22,7 @@ If the deployment is older than 3 months, you must upgrade Anbox Cloud to the la
 If you still need help, use any of the following utilities to collect troubleshooting information and report an [issue](https://bugs.launchpad.net/anbox-cloud/+filebug).
 
 
-The following utilities could be applicable for the regular Anbox Cloud deployed with Juju or for the Anbox Cloud Appliance or both. The *Applies to* tag in each section indicates whether it is applicable to a particular variant. To know more about Anbox Cloud variants, see {ref}`sec-variants`.
+The following utilities could be applicable for the charmed Anbox Cloud deployed with Juju or for the Anbox Cloud Appliance or both. The *Applies to* tag in each section indicates whether it is applicable to a particular variant. To know more about Anbox Cloud variants, see {ref}`sec-variants`.
 
 ## Juju crashdump
 

--- a/howto/troubleshoot/view-logs.md
+++ b/howto/troubleshoot/view-logs.md
@@ -4,7 +4,7 @@
 There are two types of logs that help you understand what is happening in your Anbox Cloud installation:
 
 - Logs for the applications that you are running, on a cluster or node level. See {ref}`howto-view-instance-logs` for more information.
-- Infrastructure logs for the deployment. These logs differ depending on whether you run a full Anbox Cloud deployment or the Anbox Cloud Appliance. See the following sections for more information.
+- Infrastructure logs for the deployment. These logs differ depending on whether you run the charmed Anbox Cloud deployment or the Anbox Cloud Appliance. See the following sections for more information.
 
 ## View logs for Anbox Cloud
 

--- a/reference/glossary.md
+++ b/reference/glossary.md
@@ -190,7 +190,7 @@ LXD cluster
     A set of LXD nodes that share the same distributed database that holds the configuration for the cluster members and their instances.
 
 LXD worker node
-    In a clustering setup for a full Anbox Cloud deployment, all nodes other than the [control node](#control-node) are worker nodes. If you have a streaming stack, all nodes other than the control node and the two nodes that are dedicated to host the streaming services are worker nodes. Each worker node runs LXD in clustering mode, and this LXD cluster is used to host the Android containers.
+    In a clustering setup for a charmed Anbox Cloud deployment, all nodes other than the [control node](#control-node) are worker nodes. If you have a streaming stack, all nodes other than the control node and the two nodes that are dedicated to host the streaming services are worker nodes. Each worker node runs LXD in clustering mode, and this LXD cluster is used to host the Android containers.
 
 Neural Autonomic Transport System (NATS)
     An open-source messaging system that the components of the streaming stack use to communicate.

--- a/reference/network-ports.md
+++ b/reference/network-ports.md
@@ -3,7 +3,7 @@
 
 Anbox Cloud exposes certain network ports for access and communication.
 
-For the regular Anbox Cloud deployment, these ports are used for communication between components, and to allow accessing the Anbox Cloud interface.
+For the charmed Anbox Cloud deployment, these ports are used for communication between components, and to allow accessing the Anbox Cloud interface.
 
 For the Anbox Cloud Appliance, ports are exposed only for accessing the Anbox Cloud interface since all components are installed on the same machine.
 

--- a/reference/prometheus.md
+++ b/reference/prometheus.md
@@ -15,12 +15,12 @@ You can access the AMS metrics from any machine that is on the same network as y
 
 Replace `<AMS_server>` with the IP address of your AMS server, which you can determine by running one of the following commands:
 
-* For a full Anbox Cloud deployment: `juju run --wait=5m --unit ams/0 -- unit-get private-address`
+* For the charmed Anbox Cloud deployment: `juju run --wait=5m --unit ams/0 -- unit-get private-address`
 * For the Anbox Cloud Appliance: `juju run --wait=5m -m appliance:anbox-cloud --unit ams/0 -- unit-get private-address`
 
 Replace `<AMS_port>` with the port for the API endpoint, which you can determine by running one of the following commands:
 
-* For a full Anbox Cloud deployment: `juju config ams prometheus_target_port`
+* For the charmed Anbox Cloud deployment: `juju config ams prometheus_target_port`
 * For the Anbox Cloud Appliance: `juju config -m appliance:anbox-cloud ams prometheus_target_port`
 
 You can then access the endpoint with `curl`, for example:
@@ -150,17 +150,17 @@ You can access the Anbox Stream Gateway metrics from any machine that is on the 
 
 Replace `<gateway_server>` with the IP address of your Anbox Stream Gateway server, which you can determine by running one of the following commands:
 
-* For a full Anbox Cloud deployment: `juju run --unit anbox-stream-gateway/0 --wait=5m -- unit-get private-address`
+* For the charmed Anbox Cloud deployment: `juju run --unit anbox-stream-gateway/0 --wait=5m -- unit-get private-address`
 * For the Anbox Cloud Appliance: `juju run --wait=5m -m appliance:anbox-cloud --unit anbox-stream-gateway/0 -- unit-get private-address`
 
 Replace `<gateway_port>` with the port for the API endpoint, which you can determine by running one of the following commands:
 
-* For a full Anbox Cloud deployment: `juju config anbox-stream-gateway prometheus_port`
+* For the charmed Anbox Cloud deployment: `juju config anbox-stream-gateway prometheus_port`
 * For the Anbox Cloud Appliance: `juju config -m appliance:anbox-cloud anbox-stream-gateway prometheus_port`
 
 The Anbox Stream Gateway endpoint is on HTTPS, and therefore you must authenticate to access it. You can retrieve the credentials from the `/var/snap/anbox-stream-gateway/common/service/config.yaml` file on the gateway server:
 
-* For a full Anbox Cloud deployment:
+* For the charmed Anbox Cloud deployment:
 
   ```
   juju ssh anbox-stream-gateway/0
@@ -241,7 +241,7 @@ You can access the LXD metrics through the following endpoint:
 
 Replace `<LXD_server>` with the IP address of your LXD server, which you can determine by running one of the following commands:
 
-* For a full Anbox Cloud deployment: `juju run --wait=5m --unit lxd/0 -- unit-get private-address`
+* For the charmed Cloud deployment: `juju run --wait=5m --unit lxd/0 -- unit-get private-address`
 * For the Anbox Cloud Appliance: `juju run --wait=5m -m appliance:anbox-cloud --unit lxd/0 -- unit-get private-address`
 
 The LXD metrics endpoint is on HTTPS, and therefore you must authenticate to access it. See [Create metrics certificate](https://documentation.ubuntu.com/lxd/en/latest/metrics/#add-a-metrics-certificate-to-lxd) in the LXD documentation for instructions on how to create a certificate.

--- a/reference/requirements.md
+++ b/reference/requirements.md
@@ -78,7 +78,7 @@ Anbox Cloud currently supports the following LXD versions:
 (sec-juju-version-requirements)=
 ### Juju version
 
-The regular Anbox Cloud variant requires [Juju 2.9 or later](https://juju.is/) to be installed to manage the different components and their dependencies. You can install Juju with the following command:
+The charmed Anbox Cloud variant requires [Juju 2.9 or later](https://juju.is/) to be installed to manage the different components and their dependencies. You can install Juju with the following command:
 
     snap install --classic --channel=3.1/stable juju
 
@@ -95,7 +95,7 @@ See the [Juju documentation](https://juju.is/docs/installing) for more informati
 
 While you can run Anbox Cloud on a single machine, we strongly recommend using several machines for a production environment.
 
-To run a full Anbox Cloud deployment including the streaming stack, we recommend the following setup:
+To run an Anbox Cloud deployment including the streaming stack, we recommend the following setup:
 
 | ID | Architecture   | CPU cores | RAM  | Disk       | GPUs |  FUNCTION |
 |----|----------------|-----------|------|------------|------|------------|

--- a/tutorial/getting-started.md
+++ b/tutorial/getting-started.md
@@ -24,7 +24,7 @@ How and where to run `amc` depends on your use case:
 
   Note that you must use the user name `ubuntu` and provide the path to your private key file when connecting. See [Connect to your Linux instance using SSH](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html) for instructions on how to connect.
 - If you are running the Anbox Cloud Appliance on a physical or virtual machine, log on to that machine and ensure that you have performed the instructions mentioned in {ref}`sec-enable-anbox-pro`.
-- If you are running a full Anbox Cloud deployment, access the `ams/0` machine to run `amc`. You can do this by opening an SSH session with the `juju` command:
+- If you are running the charmed Anbox Cloud deployment, access the `ams/0` machine to run `amc`. You can do this by opening an SSH session with the `juju` command:
 
         juju ssh ams/0
 

--- a/tutorial/installing-appliance.md
+++ b/tutorial/installing-appliance.md
@@ -3,7 +3,7 @@
 
 The Anbox Cloud Appliance provides a deployment of Anbox Cloud to a single machine. This offering is well suited for initial prototype and small scale deployments.
 
-There are differences between the Anbox Cloud Appliance and the full Anbox Cloud installation (see {ref}`sec-variants`). This tutorial focuses on installing the **Anbox Cloud Appliance** on a single dedicated machine.
+There are differences between the Anbox Cloud Appliance and the charmed Anbox Cloud installation (see {ref}`sec-variants`). This tutorial focuses on installing the **Anbox Cloud Appliance** on a single dedicated machine.
 
 ```{caution}
 Remember that installing the Anbox Cloud Appliance will take over the entire instance, install packages and override existing components to configure them as required. If you have existing components, for example, LXD containers, installing and initialising the appliance could override any existing configuration. Hence, it is important to try this tutorial on a machine dedicated for Anbox Cloud.

--- a/tutorial/landing.md
+++ b/tutorial/landing.md
@@ -12,7 +12,6 @@ The following tutorials are optional and help you further explore features of An
 1. {ref}`tut-aaos`
 1. {ref}`tut-create-addon`
 1. {ref}`tut-set-up-stream-client`
--
 
 Also check out the {ref}`how-to-guides` for instructions on how to achieve specific goals when using Anbox Cloud, as well as the {ref}`reference` and {ref}`explanation` sections for other helpful information.
 


### PR DESCRIPTION
This PR changes (almost) all the mentions of "regular" or "full" Anbox Cloud installation/deployment. We will be using the terminology "Charmed deployment" vs "appliance" to differentiate between our two variants.

I did a general sweep of the mentions and fixed them. If there are any left in specific context, we can fix them as we update the documentation.