### PR TITLE
feat(streamer): add support for NVIDIA AV1 video encoder options in WebRTC streamer

### DIFF
--- a/reference/webrtc-streamer.md
+++ b/reference/webrtc-streamer.md
@@ -10,13 +10,13 @@ The configuration file uses the JSON format. It has the following structure:
 | Name | Value type | Default | Description |
 |------|------------|---------|-------------|
 | `video.bitrate_limits` | array of objects | `[]` | Bitrate limits to apply to the video encoder. |
-| `nvidia_h264.multipass` | bool | `false` | If set to true, multi-pass encoding is enabled. |
-| `nvidia_h264.multipass_quarter_resolution` | bool | `false` | If set to true, multi-pass encoding will be run only for a quarter of a frame's resolution. |
-| `nvidia_h264.aq` | bool | `false` | If set to true, adaptive quantisation is enabled. |
-| `nvidia_h264.aq_strength` | integer | `0` | Strength of adaptive quantisation: a value from `1` (least aggressive) to `15` (most aggressive). `0` means the encoder will automatically decide. |
-| `nvidia_h264.preset` | integer | `0` | Preset to use (a value from `1` to `7`). `0` means Anbox will automatically decide. |
+| `nvidia_h264.multipass`<br>`nvidia_av1.multipass` | bool | `false` | If set to true, multi-pass encoding is enabled. |
+| `nvidia_h264.multipass_quarter_resolution`<br>`nvidia_av1.multipass_quarter_resolution` | bool | `false` | If set to true, multi-pass encoding will be run only for a quarter of a frame's resolution. |
+| `nvidia_h264.aq`<br>`nvidia_av1.aq` | bool | `false` | If set to true, adaptive quantisation is enabled. |
+| `nvidia_h264.aq_strength`<br>`nvidia_av1.aq_strength` | integer | `0` | Strength of adaptive quantisation: a value from `1` (least aggressive) to `15` (most aggressive). `0` means the encoder will automatically decide. |
+| `nvidia_h264.preset`<br>`nvidia_av1.preset` | integer | `0` | Preset to use (a value from `1` to `7`). `0` means Anbox will automatically decide. |
 
-See the [NVENC Video Encoder API](https://docs.nvidia.com/video-technologies/video-codec-sdk/11.0/nvenc-video-encoder-api-prog-guide/) documentation for more details on the `nvidia_h264` options.
+See the [NVENC Video Encoder API](https://docs.nvidia.com/video-technologies/video-codec-sdk/11.0/nvenc-video-encoder-api-prog-guide/) documentation for more details on the NVIDIA video encoder options.
 
 ## Video bitrate limits
 

--- a/reference/webrtc-streamer.md
+++ b/reference/webrtc-streamer.md
@@ -16,7 +16,7 @@ The configuration file uses the JSON format. It has the following structure:
 | `nvidia_h264.aq_strength`<br>`nvidia_av1.aq_strength` | integer | `0` | Strength of adaptive quantisation: a value from `1` (least aggressive) to `15` (most aggressive). `0` means the encoder will automatically decide. |
 | `nvidia_h264.preset`<br>`nvidia_av1.preset` | integer | `0` | Preset to use (a value from `1` to `7`). `0` means Anbox will automatically decide. |
 
-See the [NVENC Video Encoder API](https://docs.nvidia.com/video-technologies/video-codec-sdk/11.0/nvenc-video-encoder-api-prog-guide/) documentation for more details on the NVIDIA video encoder options.
+See the [NVENC Video Encoder API](https://docs.nvidia.com/video-technologies/video-codec-sdk/12.0/nvenc-video-encoder-api-prog-guide/) documentation for more details on the NVIDIA video encoder options.
 
 ## Video bitrate limits
 


### PR DESCRIPTION
Anbox Cloud has supported the AV1 video encoder for some time. The relevant
options for NVIDIA video encoders apply not only to H.264 but also to AV1.

This change introduces support for NVIDIA AV1 video encoder options in the
WebRTC streamer.