### PR TITLE
Enable link check and fix outdated links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,7 @@ spelling: html
 	. $(VENV) ; python3 -m pyspelling -c $(SPHINXDIR)/spellingcheck.yaml -j $(shell nproc)
 
 linkcheck: install
-	echo "Link check is disabled temporarily"
-#	. $(VENV) ; $(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+	. $(VENV) ; $(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
 woke: woke-install
 	woke *.rst **/*.rst --exit-1-on-failure \

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -139,7 +139,8 @@ redirects = {
 linkcheck_ignore = [
     'http://127.0.0.1:8000',
     'https://support.canonical.com/',
-    'https://assets.ubuntu.com/manager'
+    'https://assets.ubuntu.com/manager',
+    'https://images.anbox-cloud.io/stable/'
     ]
 
 # This setting will check the links but not the anchors

--- a/explanation/production-planning.md
+++ b/explanation/production-planning.md
@@ -93,4 +93,4 @@ You need the Ubuntu Pro subscription to use Anbox Cloud. Depending on the type o
 
 When you consider a production deployment, it is important to assess your upgrade roadmap. For more information about upgrading Anbox Cloud and the prerequisites required for the upgrade process, see {ref}`howto-upgrade-anbox-cloud`. 
 
-You can also choose to subscribe to the [announcements about Anbox Cloud releases](https://discourse.ubuntu.com/c/anbox-cloud/announcements/55) on discourse. For insights into the Anbox Cloud release roadmap, see {ref}`ref-release-notes`.
+You can also choose to subscribe to the [Anbox Cloud category](https://discourse.ubuntu.com/c/anbox-cloud/49) on discourse. For insights into the Anbox Cloud release roadmap, see {ref}`ref-release-notes`.

--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -2,7 +2,7 @@
 # How to upgrade the charmed deployment
 
 ```{note}
-If you're interested in getting notified for the latest Anbox Cloud releases, make sure you subscribe to notifications on the [announcements category](https://discourse.ubuntu.com/c/anbox-cloud/announcements/55) on the Anbox Cloud discourse.
+If you're interested in getting notified for the latest Anbox Cloud releases, make sure you subscribe to the [Anbox Cloud category](https://discourse.ubuntu.com/c/anbox-cloud/49) on the Ubuntu discourse.
 ```
 
 Anbox Cloud allows upgrades from older versions to newer version. This describes the steps necessary to perform the upgrade.

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -1,7 +1,7 @@
 (ref-release-notes)=
 # Release notes
 
-This page outlines the release notes of all versions of Anbox Cloud. If you're interested in getting notified for the latest Anbox Cloud releases, make sure you subscribe to notifications on the [announcements category](https://discourse.ubuntu.com/c/anbox-cloud/announcements/55) on the Anbox Cloud discourse.
+This page outlines the release notes of all versions of Anbox Cloud. If you're interested in getting notified for the latest Anbox Cloud releases, subscribe to the [Anbox Cloud category](https://discourse.ubuntu.com/c/anbox-cloud/49) on the Ubuntu discourse.
 
 For instructions on how to update your Anbox Cloud deployment to later versions, see {ref}`howto-upgrade-anbox-cloud` or {ref}`howto-upgrade-appliance`.
 


### PR DESCRIPTION
The links from the CLI help text are fixed now. So the link check can be enabled now.
This PR enables the link check target and also fixes some outdated links in the documentation.

Jira ticket number: AC-2973