### PR TITLE
feat(exp): update security documentation

### DIFF
--- a/explanation/anbox-security.md
+++ b/explanation/anbox-security.md
@@ -91,7 +91,9 @@ The following table helps you understand how data related to you or provided by 
 | Anbox Stream Gateway | Dqlite | Session and management metadata, service account IDs that identify the web client |
 | Anbox Cloud dashboard | SQLite | User emails that are used for authentication |
 
-Services used by Anbox Cloud have configuration files that contain secrets. A charmed Anbox Cloud deployment contains the following configuration files that contain secrets:
+Services used by Anbox Cloud have configuration files that contain secrets. The secrets are automatically generated and managed by the respective charms or the appliance. The authentication methods used are futher defined in {ref}`exp-security-landing` for managing secrets.
+
+A charmed Anbox Cloud deployment contains the following configuration files that contain secrets:
 
 `/var/snap/ams/common/server/settings.yaml`
 `/var/snap/aar/common/conf/main.yaml`

--- a/explanation/anbox-security.md
+++ b/explanation/anbox-security.md
@@ -82,7 +82,7 @@ For security reasons, always keep your systems up-to-date at all times. To ensur
 
 ## Data security
 
-We avoid storing user data as much as possible and don't provide any data encryption. The following table helps you understand how data related to you or provided by you is used within Anbox Cloud by various components.
+The following table helps you understand how data related to you or provided by you is used within Anbox Cloud by various components so that you can encrypt and backup information that needs to be secured.
 
 | Component | Databases | Data stored|
 |-----------|-----------|------------|
@@ -91,7 +91,30 @@ We avoid storing user data as much as possible and don't provide any data encryp
 | Anbox Stream Gateway | Dqlite | Session and management metadata, service account IDs that identify the web client |
 | Anbox Cloud dashboard | SQLite | User email that are used for authentication |
 
-Services used by Anbox Cloud have configuration files that contain secrets. For the Anbox Stream Gateway, the secrets are stored in Juju relation data.
+Services used by Anbox Cloud have configuration files that contain secrets. A charmed Anbox Cloud deployment contains the following configuration files that contain secrets:
+
+`/var/snap/ams/common/server/settings.yaml`
+`/var/snap/aar/common/conf/main.yaml`
+`/var/snap/anbox-cloud-dashboard/common/service/config.yaml`
+`/var/snap/anbox-stream-agent/common/agent/config.yaml`
+`/var/snap/anbox-stream-gateway/common/service/config.yaml`
+`/etc/turnserver.conf`
+`/etc/coturn/auth_secret`
+`/var/snap/nats/common/server/nats.cfg`
+
+An Anbox Cloud Appliance deployment contains the following configuration files that contain secrets:
+
+`/var/snap/anbox-cloud-appliance/common/daemon/config.yaml`
+`/var/snap/anbox-cloud-appliance/common/telegraf/main.conf`
+`/var/snap/anbox-cloud-appliance/common/agent/config.yaml`
+`/var/snap/anbox-cloud-appliance/common/coturn/turnserver.conf`
+`/var/snap/anbox-cloud-appliance/common/ams/server/settings.yaml`
+`/var/snap/anbox-cloud-appliance/common/dashboard/config.yaml`
+`/var/snap/anbox-cloud-appliance/common/nats/nats.cfg`
+`/var/snap/anbox-cloud-appliance/common/gateway/config.yaml`
+`/var/snap/anbox-cloud-appliance/common/config.yaml`
+
+For the Anbox Stream Gateway, the secrets are stored in Juju relation data.
 
 The data that you provide to your applications in Android is stored within the instance, for the duration of the instance.
 

--- a/explanation/anbox-security.md
+++ b/explanation/anbox-security.md
@@ -82,14 +82,14 @@ For security reasons, always keep your systems up-to-date at all times. To ensur
 
 ## Data security
 
-The following table helps you understand how data related to you or provided by you is used within Anbox Cloud by various components so that you can encrypt and backup information that needs to be secured.
+The following table helps you understand how data related to you or provided by you is used within Anbox Cloud by various components.
 
 | Component | Databases | Data stored|
 |-----------|-----------|------------|
 | LXD instances | Dqlite and SQLite | Information about instances, their management, authentication and certificates |
 | AMS | etcd | Information about instance management and configuration, {ref}`custom user data <howto-pass-custom-data-application>` when explicitly provided |
 | Anbox Stream Gateway | Dqlite | Session and management metadata, service account IDs that identify the web client |
-| Anbox Cloud dashboard | SQLite | User email that are used for authentication |
+| Anbox Cloud dashboard | SQLite | User emails that are used for authentication |
 
 Services used by Anbox Cloud have configuration files that contain secrets. A charmed Anbox Cloud deployment contains the following configuration files that contain secrets:
 

--- a/explanation/anbox-security.md
+++ b/explanation/anbox-security.md
@@ -80,6 +80,21 @@ It is possible to turn off this update mechanism by setting `container.security_
 
 For security reasons, always keep your systems up-to-date at all times. To ensure this, snaps update automatically, and the snap daemon is by default configured to check for updates four times a day.
 
+## Data security
+
+We avoid storing user data as much as possible and don't provide any data encryption. The following table helps you understand how data related to you or provided by you is used within Anbox Cloud by various components.
+
+| Component | Databases | Data stored|
+|-----------|-----------|------------|
+| LXD instances | Dqlite and SQLite | Information about instances, their management, authentication and certificates |
+| AMS | etcd | Information about instance management and configuration, {ref}`custom user data <howto-pass-custom-data-application>` when explicitly provided |
+| Anbox Stream Gateway | Dqlite | Session and management metadata, service account IDs that identify the web client |
+| Anbox Cloud dashboard | SQLite | User email that are used for authentication |
+
+Services used by Anbox Cloud have configuration files that contain secrets. For the Anbox Stream Gateway, the secrets are stored in Juju relation data.
+
+The data that you provide to your applications in Android is stored within the instance, for the duration of the instance.
+
 ## Android security
 
 The images that Anbox Cloud provides are based on different Android versions. They are updated with security patches monthly, based on the upstream security tags. You can find detailed information on the security patches that have been included (or considered to be included but found unrelated) in the [Android Security Bulletins](https://source.android.com/docs/security/bulletin). The relevant security bulletin for each Anbox Cloud release is linked in the {ref}`ref-release-notes`.


### PR DESCRIPTION
# Documentation changes

This PR updates our security documentation with details about how we store user data.

# Review and preview

Have you reviewed and previewed your documentation updates?
Yes, the linkchecker fails because of an issue with jwt.io which is an issue on their side rather than a broken link. So for this PR, it has to be treated as a non-blocking check.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

AC-3069