### PR TITLE
Add jwt.io to ignore list for link checker

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -144,7 +144,8 @@ linkcheck_ignore = [
     'https://assets.ubuntu.com/manager',
     'https://images.anbox-cloud.io/stable/',
     'https://10.2.9.2/',
-    'http://Add-SECURITY.md'
+    'http://Add-SECURITY.md',
+    'https://jwt.io/'
     ]
 
 # This setting will check the links but not the anchors


### PR DESCRIPTION
# Documentation changes

Adds https://jwt.io to ignore list for link checker

The URL causes a broken link check although the link directs to the correct page. Attempts to mention the browser's user agent so that the server does not mistake requests for bots also failed. Adding to the ignore list is the only option for now.

# Review and preview

Have you reviewed and previewed your documentation updates?
Yes

## Reviewers

Exception as this is a housekeeping PR

# JIRA / Launchpad bug
N/A