### PR TITLE
feat: add docs for application details page

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -357,6 +357,7 @@ vTextureCoord
 vec
 uResolution
 presigned
+unpublish
 upstream
 upstreams
 YouTube

--- a/howto/application/create-application.md
+++ b/howto/application/create-application.md
@@ -132,6 +132,8 @@ The advanced fields allows you to define a {ref}`version <ref-application-manife
 The *Create application* form also provides an option to customize your application manifest.
 
 There may be more advanced scenarios while creating an application that cannot be performed using the dashboard and may require using the `amc` CLI.
+
+After you create an application, the *Applications* page lists all the available applications. Clicking an application name opens the *Application details* page that displays information about the application, its configuration, and deployment features in the *Overview* section. The *Versions* section lists all created versions of the application. Use the *Actions* menu to either upload to the registry, unpublish, or delete a specific version.
 ```
 `````
 


### PR DESCRIPTION
# Documentation changes

Added info about the applications details page including the overview & versions section and how to upload to the registry, unpublish and delete a specific application version. 

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.
