### PR TITLE
Fix broken Juju links

### DIFF
--- a/explanation/anbox-security.md
+++ b/explanation/anbox-security.md
@@ -68,7 +68,7 @@ All communication between Juju units and the Juju controller happens over TLS-en
 
 With this secure channel, Juju charms can communicate with each other using relation data. The data published by one unit is sent to the controller, which then makes it available for all other units on the same relation. The data for each relation is scoped by ID and is only visible to units participating in the specific relation on which it is set.
 
-See [Security with Juju](https://juju.is/docs/juju/juju-security) for more information.
+See [Security with Juju](https://canonical-juju.readthedocs-hosted.com/en/latest/user/explanation/juju-security/) for more information.
 
 ### Security updates
 

--- a/howto/aar/configure.md
+++ b/howto/aar/configure.md
@@ -135,5 +135,5 @@ Finally, reboot the AAR:
 
 * {ref}`exp-aar`
 * {ref}`howto-revoke-aar`
-* [Juju relations](https://jaas.ai/docs/relations)
-* [Juju cross model relations](https://juju.is/docs/cross-model-relations)
+* [Juju relations](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/relation/)
+* [Juju cross model relations](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/relation/#cross-model/)

--- a/howto/anbox/control-ams-remotely.md
+++ b/howto/anbox/control-ams-remotely.md
@@ -57,7 +57,7 @@ If you are running the Anbox Cloud Appliance, you can expose the service with th
 
     anbox-cloud-appliance ams expose
 
-If you are running a charmed Anbox Cloud deployment, the service is automatically exposed within the internal subnet. If this is sufficient, you do not need further configuration. If you want to access AMS from a machine that is in a different subnet, use `juju expose` to expose the service (see [How to expose a deployed application](https://juju.is/docs/olm/expose-a-deployed-application) for instructions). Note that if you expose services externally, you should also add a load balancer or proxy to your deployment.
+If you are running a charmed Anbox Cloud deployment, the service is automatically exposed within the internal subnet. If this is sufficient, you do not need further configuration. If you want to access AMS from a machine that is in a different subnet, use `juju expose` to expose the service (see [How to expose a deployed application](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-applications/#manage-an-applications-public-availability-over-the-network) for instructions). Note that if you expose services externally, you should also add a load balancer or proxy to your deployment.
 
 ## Configure AMC to connect to AMS
 

--- a/howto/install/customize-installation.md
+++ b/howto/install/customize-installation.md
@@ -28,7 +28,7 @@ An [overlay bundle](https://juju.is/docs/juju/bundle) is a fragment of valid YAM
         series: jammy
         constraints: "instance-type=m5.xlarge root-disk=100G"
 
-See the [Juju bundle documentation](https://juju.is/docs/sdk/bundle-reference) for more information about Juju's bundle format and valid YAML.
+See the [Juju bundle documentation](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/bundle-yaml-file/ ) for more information about Juju's bundle format and valid YAML.
 
 To use one or more overlay files with the Anbox Cloud bundle, specify them during the deployment:
 
@@ -82,7 +82,7 @@ Another way to change or customize a deployment is to store the YAML bundle file
 
 The latest version of the Anbox Cloud bundles can be retrieved by fetching the current stable version from [Charmhub](https://charmhub.io/). See {ref}`sec-juju-bundles` for more details on the available bundles.
 
-Be careful when editing the YAML file, because the format is very strict. For more details on the format used by Juju, see the [Juju bundle documentation](https://juju.is/docs/sdk/bundle-reference).
+Be careful when editing the YAML file, because the format is very strict. For more details on the format used by Juju, see the [Juju bundle documentation](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/bundle-yaml-file/ ).
 
 ### Retrieve a bundle from a running model
 
@@ -102,4 +102,4 @@ Running this command will output login information and a URL for the GUI interfa
 
 ![Anbox Cloud - Juju GUI|690x444](/images/install_customize_juju_model.png)
 
-For more information on the Juju GUI, see the [Juju documentation](https://juju.is/docs/olm/accessing-the-dashboard).
+For more information on the Juju GUI, see the [Juju documentation](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-the-juju-dashboard/#manage-the-juju-dashboard).

--- a/howto/install/deploy-bare-metal.md
+++ b/howto/install/deploy-bare-metal.md
@@ -3,7 +3,7 @@
 
 To deploy Anbox Cloud on a public cloud (such as AWS, Azure or Google) or using MAAS or OpenStack, see the instructions in {ref}`howto-deploy-anbox-juju`.
 
-Alternatively, you can follow the instructions in this document to use the [manual cloud provider](https://jaas.ai/docs/manual-cloud) that Juju offers. This method allows you to deploy Anbox Cloud with Juju on a set of SSH connected machines.
+Alternatively, you can follow the instructions in this document to use the [manual cloud provider](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-manual-cloud-and-juju/) that Juju offers. This method allows you to deploy Anbox Cloud with Juju on a set of SSH connected machines.
 
 ## Prerequisites
 
@@ -27,7 +27,7 @@ See {ref}`sec-juju-version-requirements` for information about which Juju versio
 
 ## Add a controller and model
 
-The [Juju controller](https://juju.is/docs/olm/controllers) is used to manage the software deployed through Juju, from deployment to upgrades to day-two operations. One Juju controller can manage multiple projects or workspaces, which in Juju are known as [models](https://juju.is/docs/olm/models).
+The [Juju controller](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/controller/) is used to manage the software deployed through Juju, from deployment to upgrades to day-two operations. One Juju controller can manage multiple projects or workspaces, which in Juju are known as [models](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/model/).
 
 You should dedicate one machine as the Juju controller. Run the following command to bootstrap the controller onto that machine:
 
@@ -79,7 +79,7 @@ The `anbox-cloud-core` deployment bundle requires two machines: `0` and `1`. `0`
 
 The `anbox-cloud` bundle requires two additional machines to host the load balancer (`0`) and the extra services required for streaming (`1`). For this bundle, the AMS machine is `2` and the LXD machine is `3`. Check the `bundle.yaml` file in the bundle for details.
 
-The `--map-machine` argument for the `juju deploy` command maps the machines defined inside the bundle to those your Juju controller has registered in the model. See the [Juju documentation](https://jaas.ai/docs/charm-bundles) for more details. If you added the machines in the order Juju expects them, the mapping is very straight-forward: `--map-machines 0=0,1=1` for the `anbox-cloud-core` bundle or `--map-machines 0=0,1=1,2=2,3=3` for the `anbox-cloud` bundle.
+The `--map-machine` argument for the `juju deploy` command maps the machines defined inside the bundle to those your Juju controller has registered in the model. See the [Juju documentation](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/bundle/) for more details. If you added the machines in the order Juju expects them, the mapping is very straight-forward: `--map-machines 0=0,1=1` for the `anbox-cloud-core` bundle or `--map-machines 0=0,1=1,2=2,3=3` for the `anbox-cloud` bundle.
 
 (sec-customize-storage-bare-metal)=
 ## Customize storage

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -47,7 +47,7 @@ For a different cloud, just substitute the cloud name (use the name returned by 
 
 ## Add a controller and model
 
-The [Juju controller](https://juju.is/docs/olm/controllers) is used to manage the software deployed through Juju, from deployment to upgrades to day-two operations. One Juju controller can manage multiple projects or workspaces, which in Juju are known as [models](https://juju.is/docs/olm/models).
+The [Juju controller](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/controller/) is used to manage the software deployed through Juju, from deployment to upgrades to day-two operations. One Juju controller can manage multiple projects or workspaces, which in Juju are known as [models](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/model/).
 
 For example, run the following command to bootstrap the controller for AWS:
 

--- a/howto/install/enable-high-availability.md
+++ b/howto/install/enable-high-availability.md
@@ -16,7 +16,7 @@ For example, to go from 1 to 5 AMS units, you would run the following:
     juju add-unit ams -n 4
 
 ```{tip}
-By default, Juju allocates small machines to limit costs but you can request better resources by [enforcing constraints](https://juju.is/docs/olm/constraints):
+By default, Juju allocates small machines to limit costs but you can request better resources by [enforcing constraints](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/constraint/):
 
 `juju set-constraints anbox-stream-gateway cores=4 memory=8GB`
 

--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -53,7 +53,7 @@ If they are not, run the following command to do so:
 
 Before you upgrade, check the required {ref}`sec-juju-version-requirements`.
 
-If your deployment uses an earlier Juju version, you must upgrade your controller and all models first. See the [Juju documentation](https://juju.is/docs/olm/upgrade-models) for instructions on how to upgrade the Juju controller and all models to a newer Juju version.
+If your deployment uses an earlier Juju version, you must upgrade your controller and all models first. See the [Juju documentation](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-models/#upgrade-a-model) for instructions on how to upgrade the Juju controller and all models to a newer Juju version.
 
 ## Upgrade all charms
 

--- a/reference/requirements.md
+++ b/reference/requirements.md
@@ -55,7 +55,7 @@ The Anbox Cloud Appliance currently supports the following LXD versions:
 
 ## Juju-based deployments
 
-Anbox Cloud deployments are managed by Juju. They can be created on all the [supported clouds](https://juju.is/docs/clouds) as well as manually provided machines as long as they follow the required minimums.
+Anbox Cloud deployments are managed by Juju. They can be created on all the [supported clouds](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/) as well as manually provided machines as long as they follow the required minimums.
 
 ### Ubuntu version
 
@@ -88,7 +88,7 @@ To switch to the 2.9 series, use the following command:
 
     snap refresh --channel=2.9/stable juju
 
-See the [Juju documentation](https://juju.is/docs/installing) for more information.
+See the [Juju documentation](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-juju/#install-juju) for more information.
 
 (sec-minimum-hardware-requirements)=
 ### Minimum hardware requirements


### PR DESCRIPTION
# Documentation changes

This PR will fix the recently broken Juju links that don't redirect with the Juju docs moving to RTD.

# Review and preview

Have you reviewed and previewed your documentation updates?

Yes

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

N/A