### PR TITLE
fix(monitor): split deploy and integration command

### DIFF
--- a/howto/monitor/landing.md
+++ b/howto/monitor/landing.md
@@ -67,7 +67,8 @@ Finally, deploy COS:
 
 To have an Anbox Cloud specific dashboard and alert rules, deploy the relevant configuration charm:
 
-    juju deploy anbox-cloud-cos-configuration:grafana-dashboard grafana:grafana-dashboard
+    juju deploy anbox-cloud-cos-configuration
+    juju relate anbox-cloud-cos-configuration:grafana-dashboard grafana:grafana-dashboard
 
 The deployment will take a while and you can use `juju status` to monitor the current status.
 


### PR DESCRIPTION
# Documentation changes

Both deployment and integration commands were mixed and combined in a single command. 

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

n/a