### PR TITLE
Limit session shares to a maximum of 5

### DIFF
--- a/howto/android/access-instance.md
+++ b/howto/android/access-instance.md
@@ -41,7 +41,7 @@ Using the session's ID, share it the session:
 
     anbox-stream-gateway session share <session_id> --description="Grant access to xxx"
 
-Providing a description helps you identify a share later on, if you are sharing a session multiple times.
+Providing a description helps you identify a share later on, if you are sharing a session multiple times. Each session can be shared up to a maximum of 5 times.
 
 The output returns a presigned URL that you can use to connect to the remote Android instance.
 


### PR DESCRIPTION
Starting from Anbox Cloud 1.25.1, each session can create up to 5 shares. 
This enforces the limit at the session level. A configurable option for adjusting
this limit may be introduced in a future release.

# Documentation changes

[Summary of documentation updates]

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

https://warthogs.atlassian.net/browse/AC-2835