### PR TITLE
Reword kernel deprecation to exclude 6.8

### DIFF
--- a/reference/deprecation-notices.md
+++ b/reference/deprecation-notices.md
@@ -3,10 +3,10 @@
 
 This document contains a list of deprecation notices for Anbox Cloud and its components.
 
-## Kernel 6.8 and earlier
+## Kernels older than 6.8
 *Deprecated in 1.25.0* ; *Removal in 1.27.0*
 
-The support for kernel 6.8 and earlier is deprecated as of 1.25.0. Starting from 1.27.0, Anbox Cloud will only be supported on kernels with version later than 6.8.
+The support for kernels older than 6.8 is deprecated as of 1.25.0. Starting from 1.27.0, Anbox Cloud will only be supported on kernels with version 6.8 and later.
 
 ## LXD 5.0
 *Deprecated in 1.25.0* ; *Removal in 1.28.0*

--- a/reference/release-notes/1.25.0.md
+++ b/reference/release-notes/1.25.0.md
@@ -62,7 +62,7 @@ To start using the new appliance snap with `epoch=1`, a fresh install of the app
 The following deprecations are announced as part of the 1.25.0 release. See {ref}`ref-deprecation-notes` for more information on when the support for these items will be dropped:
 
 * The support for LXD 5.0 snap is deprecated.<!--AC-2734-->
-* The support for kernel 6.8 and earlier is deprecated.<!--AC-3106-->
+* The support for kernels older than 6.8 is deprecated.<!--AC-3106-->
 
 ## CVEs
 


### PR DESCRIPTION
# Documentation changes

Reword kernel deprecation to only include kernels strictly before 6.8. We do support 6.8, we only plan to drop support for older verions.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]