### PR TITLE
feat: remove usage of raw flag for instance creation

### DIFF
--- a/howto/anbox-runtime/develop-addon-devmode.md
+++ b/howto/anbox-runtime/develop-addon-devmode.md
@@ -10,12 +10,12 @@ This guide explains how to use an instance in development mode to develop and te
 Start a raw instance with `--devmode` enabled:
 
 ```
-amc launch --devmode --raw
+amc launch --devmode
 ```
 or
 
 ```
-amc launch --vm --devmode --raw
+amc launch --vm --devmode
 ```
 The command prints out the ID of the instance. Note down the instance ID for next steps.
 
@@ -40,7 +40,7 @@ This example uses a container for demonstration, you can create an SSH-enabled V
 
 ```bash
 # Launch and obtain the container id
-id="$(amc launch --devmode -s ssh --raw)"
+id="$(amc launch --devmode -s ssh)"
 # Install the ssh-import-id package
 amc exec $id -- apt install -y ssh-import-id
 # Import SSH keys from GitHub; Use lp:<username> for Launchpad

--- a/howto/anbox-runtime/develop-platform-plugin.md
+++ b/howto/anbox-runtime/develop-platform-plugin.md
@@ -32,7 +32,7 @@ The build process creates a `platform_minimal.so` module in the `build` director
 
 ## Install the example platform
 
-The Anbox Management Service (AMS) allows launching instances in a special development mode, which is helpful when developing addons or platforms. In development mode, the Anbox runtime does not terminate the instance when it detects failures or other problems. 
+The Anbox Management Service (AMS) allows launching instances in a special development mode, which is helpful when developing addons or platforms. In development mode, the Anbox runtime does not terminate the instance when it detects failures or other problems.
 
 We will be using this development mode to install the platform. See {ref}`sec-dev-mode` for more information.
 
@@ -40,11 +40,11 @@ To try out the `minimal` platform, complete the following steps:
 
 1. Start a raw instance with development mode turned on:
 
-        amc launch --raw --devmode --cpus 4 --memory 3GB
+        amc launch --devmode --cpus 4 --memory 3GB
 
    If you chose the `nvidia` example, you must select an instance type that supports GPUs (See {ref}`sec-application-manifest-instance-type` if you need more information on the different instance types):
 
-        amc launch --raw --devmode --cpus 4 --memory 3GB --gpu-slots 1
+        amc launch --devmode --cpus 4 --memory 3GB --gpu-slots 1
 
     ```{note}
     Use the `--vm` option to launch a VM instance.
@@ -121,7 +121,7 @@ Load this addon into AMS so that it can be used by applications and instances:
 
 When launching an instance, you must explicitly specify the platform that the Anbox runtime inside the instance should use with the `--platform` argument. If not specified, Anbox will use its default. To launch an instance with the `minimal` platform, run the following command:
 
-    amc launch --raw --addon minimal --platform minimal
+    amc launch --addon minimal --platform minimal
 
 Use the `--vm` option to launch a VM instance.
 

--- a/howto/instance/create-instance.md
+++ b/howto/instance/create-instance.md
@@ -65,7 +65,7 @@ This command lists the available images along with their IDs and status:
 
 Launch a raw instance by providing the image ID in the following command:
 
-    amc launch --raw <image_id>
+    amc launch <image_id>
 
 See {ref}`ref-provided-images` for a list of images that are available in Anbox Cloud.
 

--- a/howto/stream/exchange-oob-data.md
+++ b/howto/stream/exchange-oob-data.md
@@ -78,7 +78,7 @@ Launch a stream-enabled instance for web client to join
 
 ```
 amc launch --name test-app \
-  --raw jammy:android13:arm64 \
+  jammy:android13:arm64 \
   --enable-streaming
 ```
 
@@ -346,7 +346,7 @@ To connect the data channel to the Anbox WebRTC data proxy service within an And
 
       ```
       amc launch --name test-oobv2 \
-        --raw jammy:android13:arm64 \
+        jammy:android13:arm64 \
         --enable-streaming \
         --features allow_custom_system_signatures \
         --addons install-out-of-band-app

--- a/tutorial/stream-client.md
+++ b/tutorial/stream-client.md
@@ -32,7 +32,7 @@ See {ref}`howto-access-stream-gateway` for more information on creating, using a
 Create a streaming enabled Android instance:
 
     arch="$(dpkg-architecture -q DEB_HOST_ARCH)"
-    amc launch --enable-streaming --raw --name a13 jammy:android13:"$arch"
+    amc launch --enable-streaming --name a13 jammy:android13:"$arch"
 
 ### Determine session ID of the Android instance
 


### PR DESCRIPTION
# Documentation changes

The flag is no longer required so we can drop its usage in our documentation.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

https://warthogs.atlassian.net/browse/AC-3192