### PR TITLE
Charm noble support

### DIFF
--- a/howto/install/customize-installation.md
+++ b/howto/install/customize-installation.md
@@ -19,13 +19,13 @@ An [overlay bundle](https://juju.is/docs/juju/bundle) is a fragment of valid YAM
         series: focal
         constraints: "instance-type=m5.xlarge root-disk=40G"
       '1':
-        series: jammy
+        series: noble
         constraints: "instance-type=m5.xlarge root-disk=40G"
       '2':
-        series: jammy
+        series: noble
         constraints: "instance-type=g4dn.2xlarge root-disk=100G"
       '3':
-        series: jammy
+        series: noble
         constraints: "instance-type=m5.xlarge root-disk=100G"
 
 See the [Juju bundle documentation](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/bundle-yaml-file/ ) for more information about Juju's bundle format and valid YAML.
@@ -36,6 +36,9 @@ To use one or more overlay files with the Anbox Cloud bundle, specify them durin
 
 Make sure to use the correct local path and file name for your overlay file(s).
 
+```{note}
+Anbox Cloud charms supports deployment on both Ubuntu noble 24.04 and Ubuntu jammy 22.04. The examples above use **noble**. If you prefer to deploy on Ubuntu jammy 22.04, simply modify the `series` configuration accordingly.
+```
 
 ### Change configuration settings
 

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -13,7 +13,7 @@ There are differences between the charmed Anbox Cloud installation and the Anbox
 
 Before you start the installation, ensure that you have the required credentials and prerequisites:
 
-* An Ubuntu 22.04 LTS to run the commands (or another operating system that supports snaps - see the [Snapcraft documentation](https://snapcraft.io/docs/installing-snapd)).
+* An Ubuntu 22.04 LTS or Ubuntu noble 24.04 to run the commands (or another operating system that supports snaps - see the [Snapcraft documentation](https://snapcraft.io/docs/installing-snapd)).
 * Account credentials for one of the following public clouds:
   * [Amazon Web Services](https://aws.amazon.com/) (including AWS-China)
   * [Google Cloud platform ](https://cloud.google.com/)
@@ -136,15 +136,20 @@ Choose between the available {ref}`sec-juju-bundles`:
 
 To customize the machine configuration Juju will use for the deployment, create another overlay file. Here you can, for example, specify AWS instance types, change the size or source of the root disk or other things. See the [complete list of constraints](https://juju.is/docs/juju/constraint#heading--list-of-constraints) in the Juju documentation for details.
 
+
+```{note}
+Anbox Cloud charms supports deployment on both Ubuntu noble 24.04 and Ubuntu jammy 22.04. The examples below use **noble**. If you prefer to deploy on Ubuntu jammy 22.04, simply modify the `series` configuration accordingly.
+```
+
 For the `anbox-cloud-core` bundle, such an `overlay.yaml` file looks like this:
 
 ```
 machines:
   '0':
-    series: jammy
+    series: noble
     constraints: "instance-type=m4.xlarge root-disk=40G"
   '1':
-    series: jammy
+    series: noble
     constraints: "instance-type=m4.xlarge root-disk=40G"
 ```
 
@@ -156,13 +161,13 @@ machines:
     series: focal
     constraints: "instance-type=m4.xlarge root-disk=40G"
   '1':
-    series: jammy
+    series: noble
     constraints: "instance-type=m4.xlarge root-disk=40G"
   '2':
-    series: jammy
+    series: noble
     constraints: "instance-type=m4.xlarge root-disk=40G"
   '3':
-    series: jammy
+    series: noble
     constraints: "instance-type=m4.2xlarge root-disk=50G"
 ```
 
@@ -215,13 +220,13 @@ machines:
     series: focal
     constraints: "instance-type=m4.xlarge root-disk=40G"
   '1':
-    series: jammy
+    series: noble
     constraints: "instance-type=m4.xlarge root-disk=40G"
   '2':
-    series: jammy
+    series: noble
     constraints: "instance-type=m4.xlarge root-disk=40G"
   '3':
-    series: jammy
+    series: noble
     constraints: "instance-type=g4dn.2xlarge root-disk=50G"
 ```
 
@@ -242,7 +247,7 @@ applications:
 machines:
   ...
   '3':
-    series: jammy
+    series: noble
     constraints: "instance-type=m6g.2xlarge root-disk=50G"
 ```
 

--- a/howto/install/enable-high-availability.md
+++ b/howto/install/enable-high-availability.md
@@ -45,7 +45,6 @@ In the Streaming Stack, both the Agent and the Gateway can be run in HA. We reco
 
     juju add-unit anbox-stream-gateway -n 2
     juju add-unit anbox-stream-agent -n 2
-    juju relate anbox-stream-gateway:api anbox-stream-gateway-lb:reverseproxy
 
 This would give you 3 instances of both the Stream Gateway and the Stream Agent.
 

--- a/reference/requirements.md
+++ b/reference/requirements.md
@@ -57,7 +57,10 @@ Anbox Cloud deployments are managed by Juju. They can be created on all the [sup
 
 ### Ubuntu
 
-Charmed Anbox Cloud supports Ubuntu 22.04 (Jammy Jellyfish).
+Charmed Anbox Cloud supports the following Ubuntu versions:
+
+* Ubuntu 22.04 (Jammy Jellyfish)
+* Ubuntu 24.04 (Noble Numbat)
 
 ```{note}
 The HAProxy load balancer currently has no support for Ubuntu 22.04. Therefore, the Juju bundle uses Ubuntu 20.04 for the machine that runs the load balancer.


### PR DESCRIPTION
# Documentation changes

update docs to clarify Ubuntu noble 24.04 support for charm based
deployment.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

Fix AC-2955