### PR TITLE
chore: pin all external workflows/actions to git rev

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -7,10 +7,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true  
+  cancel-in-progress: true
 
 jobs:
   documentation-checks:
-    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main
+    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@d86428a8aa00b3d8c5b3f43af0a1ffe42028d4ad
     with:
       working-directory: '.'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check if CLA signed
-      uses: canonical/has-signed-canonical-cla@main
+      uses: canonical/has-signed-canonical-cla@5d1443b94417bd150ad234a82fe21f7340a25e4d # v2


### PR DESCRIPTION
# Documentation changes

We should never refer to a branch or tag but always an explicit git sha256 revision.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

n/a

# JIRA / Launchpad bug

n/a