### PR TITLE
feat: extend appliance upgrade documentation

### DIFF
--- a/howto/upgrade/upgrade-appliance.md
+++ b/howto/upgrade/upgrade-appliance.md
@@ -1,4 +1,33 @@
 (howto-upgrade-appliance)=
-# How to upgrade the appliance
+# How to Upgrade the Appliance
 
-The Anbox Cloud Appliance does not require any specific steps to upgrade other than apply any pending snap package updates. Internally the snap will automatically apply necessary configuration changes and restart services as needed.
+The upgrade process for the Anbox Cloud Appliance is as simple as updating the snap package to the appropriate channel. Before upgrading the appliance, consider the changes that the new version brings as downgrades are not supported.
+
+If you are on the `latest` track, upgrade to the newest snap version by running:
+
+    sudo snap refresh anbox-cloud-appliance
+
+Automatic updates may install the new version without manual intervention.
+
+For installations on a versioned track (e.g. 1.25), change the track explicitly with:
+
+    sudo snap refresh --channel=1.26/stable anbox-cloud-appliance
+
+After refreshing the snap, the appliance will automatically apply the necessary configuration changes and restart services as needed.
+
+For the host system, run the upgrade script manually. This script performs additional updates, including:
+
+1. Upgrading Anbox Cloud-specific kernel modules.
+2. (If a GPU is available) Upgrading GPU driver packages from the Ubuntu archive and applying required tuning settings.
+
+Review the upgrade script by running:
+
+    anbox-cloud-appliance upgrade-node-script
+
+Then execute the script with:
+
+    anbox-cloud-appliance upgrade-node-script | sudo bash -ex
+
+After the script completes, verify the output to determine if a system reboot is necessary.
+
+


### PR DESCRIPTION
# Documentation changes

With 1.26 we introduce a new upgrade-node-script command which a user needs to run to upgrade anything on the host and outside of the snap context.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

https://warthogs.atlassian.net/browse/AC-3246