### PR TITLE
docs(charms): add note for bundle architectures

### DIFF
--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -271,16 +271,12 @@ Check the output of the `juju status` command to see whether you need to reboot:
 
 ```sh
 ...
-Unit       Workload  Agent  Machine  Public address  Ports  Message
-lxd/0*     active    idle   3        10.75.96.23            reboot required to activate new kernel
+Unit       Workload  Agent  Machine  Public address  Ports      Message
+lxd/0*     active    idle   3        10.75.96.23     8443/tcp   Actions: Reboot Required, Role: Database-leader
 ...
 ```
 To reboot the machine hosting LXD, run the following command:
 
     juju ssh lxd/0 -- sudo reboot
-
-When the machine is back running, you must manually clear the status of the LXD units:
-
-    juju run --wait=5m lxd/0 clear-notification
 
 Once done, the reboot operation is finished.

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -246,9 +246,16 @@ machines:
     constraints: "instance-type=m6g.2xlarge root-disk=50G"
 ```
 
-To deploy, add `--overlay overlay.yaml` to your deploy command. For example:
+The default bundles for `anbox-cloud` and `anbox-cloud-core` available on Charmhub are suitable only for pure AMD64/X86 based deployments.
+Applying the overlay given above, to the bundle directly does not properly deploy the correct architecture for the charms.
+You need to download the bundle using,
 
-    juju deploy anbox-cloud --overlay ua.yaml --overlay overlay.yaml
+    juju download anbox-cloud --channel <bundle_channel>
+
+Unzip the bundle to extract the `bundle.yaml` file and remove the revisions for all Anbox Cloud charms from the bundle.
+Now use this `bundle.yaml` file to deploy `anbox-cloud` using your own overlay as follows,
+
+    juju deploy ./bundle.yaml --overlay ua.yaml --overlay overlay.yaml
 
 ## Monitor the deployment
 


### PR DESCRIPTION
# Documentation changes

Add a note about the bundles being architecture dependent and the old overlay not working anymore.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.
