### PR TITLE
Clarify upgrade documentation

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -55,6 +55,7 @@ CIS
 cgroup
 cgroup-v1
 cgroup-v2
+codebase
 config
 conformant
 CORS
@@ -80,6 +81,7 @@ datacenter
 dataset
 deallocate
 deallocated
+deauthorize
 DDoS
 Debian
 deprecations

--- a/howto/application/update-application.md
+++ b/howto/application/update-application.md
@@ -150,7 +150,7 @@ To enable automatic updates:
 
 When automatic updates are disabled, applications must be manually updated for any changed dependencies. To do this, use the following command:
 
-    amc application update <application id or name>
+    amc application update <application_id_or_name> <path_of_new_application_payload>
 
 This will initiate the update process and create a new application version.
 
@@ -158,6 +158,6 @@ This will initiate the update process and create a new application version.
 
 The image an application is based on can be changed with the following command:
 
-    amc application set com.canonical.candy image <image name or id>
+    amc application set com.canonical.candy image <image_name_or_id>
 
 Changing the image will cause AMS to generate a new version for the application. Previous versions will continue using the image the application used before.

--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -5,9 +5,9 @@
 If you're interested in getting notified for the latest Anbox Cloud releases, make sure you subscribe to the [Anbox Cloud category](https://discourse.ubuntu.com/c/anbox-cloud/49) on the Ubuntu discourse.
 ```
 
-Anbox Cloud officially supports only the latest release. This means that we support upgrades from n-1 to nth minor version, where n is the most recent minor version released.
+Anbox Cloud supports only the latest release. This means that we support upgrades from n-1 to nth minor version, where n is the most recent minor version released.
 
-If you are on an earlier version of Anbox Cloud than the most recent one, we recommend upgrading to the latest version as soon as possible. If you are multiple versions behind the supported version, there could be potential disruptions if you upgrade directly to the current version. You should keep this in consideration while planning your upgrade.
+If you are on an earlier version of Anbox Cloud than the most recent one, we recommend upgrading to the latest version as soon as possible. If you are multiple versions behind the supported version, there could be potential disruptions if you upgrade directly to the current version. The best practice in such a scenario is to upgrade incrementally, version by version.
 
 This guide contains upgrade instructions for the charmed Anbox Cloud deployment. In addition to the upgrade of the charms, any used images or addons need to be updated as well.
 
@@ -157,7 +157,7 @@ If you are running LXD clusters with the LXD snap from a channel other than 5.21
 
     juju config lxd channel=5.0/stable
 
-where `5.0/stable` is the current LXD channel. Not doing this might lead to a broken LXD cluster.
+where `5.0/stable` is the currently installed LXD snap channel. Not doing this might lead to a broken LXD cluster.
 ```
 
 To start, upgrade the AMS LXD charm to the latest revision using:
@@ -168,11 +168,11 @@ Upgrading the charm does not upgrade the LXD snap or any of the internal package
 
     juju run lxd/0 upgrade-info
 
-Make a note of all the Juju units having available updates. Before proceeding, make sure that there are no active instances on the nodes. Then mark each LXD node that has updates available as unschedulable within AMS.
+Make a note of all the Juju units having available updates. Before proceeding, make sure that there are no active instances on the nodes. Then mark each LXD node that has updates available as unschedulable in AMS.
 
     juju run ams/leader node-start-maintenance node=”<node_name>”
 
-where `<node_name>` refers to the LXD node name stored within AMS, e.g. `lxd0` if the Juju unit is `lxd/0`. This ensures that no new instances are spawned on those LXD nodes.
+where `<node_name>` refers to the LXD node name stored in AMS, e.g. `lxd0` if the Juju unit is `lxd/0`. This ensures that no new instances are spawned on those LXD nodes.
 
 After a node is successfully marked as unschedulable, we can safely upgrade it. To do this, run:
 
@@ -210,10 +210,10 @@ Existing applications will be automatically updated by AMS as soon as the new im
 
 You can check the status of an existing application by running:
 
-    amc application show <application id or name>
+    amc application show <application_id_or_name>
 
 In case automatic updates are disabled for applications, AMS cannot update the application. You need to manually update the applications using:
 
-    amc application update <application id or name>
+    amc application update <application_id_or_name> <path_of_new_application_payload>
 
 See {ref}`sec-configure-automatic-app-updates` for instructions on enabling automatic updates.

--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -5,23 +5,28 @@
 If you're interested in getting notified for the latest Anbox Cloud releases, make sure you subscribe to the [Anbox Cloud category](https://discourse.ubuntu.com/c/anbox-cloud/49) on the Ubuntu discourse.
 ```
 
-Anbox Cloud allows upgrades from older versions to newer version. This describes the steps necessary to perform the upgrade.
+Anbox Cloud officially supports only the latest release. This means that we support upgrades from n-1 to nth minor version, where n is the most recent minor version released.
 
-The upgrade instructions detail the revisions each charm needs to be upgraded to, to bring it to the latest version. Next to the upgrade of the charms any used images or addons need to be updated as well.
+If you are on an earlier version of Anbox Cloud than the most recent one, we recommend upgrading to the latest version as soon as possible. If you are multiple versions behind the supported version, there could be potential disruptions if you upgrade directly to the current version. You should keep this in consideration while planning your upgrade.
+
+This guide contains upgrade instructions for the charmed Anbox Cloud deployment. In addition to the upgrade of the charms, any used images or addons need to be updated as well.
 
 ## Prerequisites
 
 As with all upgrades, there is a possibility that there may be unforeseen difficulties. It is highly recommended that you make a backup of any important data, including any running workloads.
 
-You should also make sure that:
+Check if your deployment is running normally without any instances in an error state.
 
-* Your deployment is running normally.
-* Your Juju client and controller/models are running the latest version.
-* You have read the release notes for the version you are upgrading to, which will alert you to any important changes to the operation of your cluster.
+Read the release notes for your target version to learn about important changes that may affect your cluster operations.
+
+### Upgrade Juju
+
+Check the [required Juju version](https://documentation.ubuntu.com/anbox-cloud/reference/requirements/#juju).
+If your deployment uses an earlier Juju version, you must upgrade your controller and all models first. See the [Juju documentation](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-models/#upgrade-a-model) for instructions on how to upgrade the Juju controller and all models to a newer Juju version.
 
 ```{note}
 
-The following assume you're using Juju >= 3.1. If you're using Juju 2.9, you have to map the following commands:
+The following instructions assume that you're using Juju >= 3.1. If you're using Juju 2.9, you have to map the following commands:
 
 | Juju 3.x | Juju 2.9 |
 |----------|----------|
@@ -30,7 +35,7 @@ The following assume you're using Juju >= 3.1. If you're using Juju 2.9, you hav
 
 ```
 
-## Upgrade OS
+### Upgrade OS
 
 Before you run the upgrade of the charms, you should make sure all packages on the machines that are part of the deployment are up-to-date. To do so, run the following commands on each machine:
 
@@ -41,62 +46,51 @@ You can either run the package update manually or use the Juju command to run it
 
     juju exec --all -- /bin/sh -c 'sudo apt update && sudo apt upgrade -y'
 
-If the LXD charm is deployed on a machine that has an NVIDIA GPU installed, running the above command for the machine may upgrade the NVIDIA drivers, which accidentally suspends running instances with GPU support. Starting with the 1.17.1 release, the NVIDIA drivers are held from being upgraded until you upgrade the LXD charm using the Juju command. To check if the currently installed NVIDIA drivers are held from being upgraded:
+To ensure NVIDIA drivers are upgraded only when the LXD charm is upgraded, the NVIDIA driver upgrades are held until you upgrade the LXD charm. So if the LXD charm is deployed on a machine that has an NVIDIA GPU installed, running this command on that machine may upgrade the NVIDIA drivers, which accidentally suspends running instances with GPU support.
+
+To check if NVIDIA driver upgrades are held, run:
 
     apt-mark showhold "libnvidia-.*-$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | cut -d'.' -f1)"
 
-If they are not, run the following command to do so:
+If the upgrades are not held, run the following command to hold them until the LXD charm is upgraded:
 
     sudo apt-mark hold 'linux-modules-nvidia-*' 'nvidia-*' 'libnvidia-*'
 
-## Check Juju version
-
-Before you upgrade, check the required {ref}`sec-juju-version-requirements`.
-
-If your deployment uses an earlier Juju version, you must upgrade your controller and all models first. See the [Juju documentation](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-models/#upgrade-a-model) for instructions on how to upgrade the Juju controller and all models to a newer Juju version.
 
 ## Upgrade all charms
 
-The deployed Juju charms need to be upgraded next. You can find a list of all charm, snap, bundle and Debian package versions for each Anbox Cloud release in the {ref}`ref-component-versions` overview. This also includes the charm and bundle revisions and channels for each release.
+You can find a list of all charm, snap, bundle and Debian package versions for each Anbox Cloud release in the {ref}`ref-component-versions` overview. This also includes the charm and bundle revisions and channels for each release.
 
-If you want to deploy a particular revision of a charm, you can do so by adding `--revision=<rev>` to the `juju upgrade-charm` command.
+Before you run the `juju refresh` command to upgrade the charms, there are a few points you should know:
 
-```{note}
-- Starting with the 1.21 release, the NATS charm has been switched from its [older version](https://charmhub.io/nats-charmers-nats) to a [newer version](https://charmhub.io/nats) on Charmhub. This switch does not have any breaking changes from a user's perspective but since the framework of the charm has been overhauled, the upgrade to the new charm would require users to `switch` the charm's source while refreshing/updating the charm.
+* If you don't run Anbox Cloud in a high availability configuration, upgrading the charms will cause a short down time of individual service components during the process.
+* Starting with the 1.21 release, the NATS charm has been switched from its [older version](https://charmhub.io/nats-charmers-nats) to a [newer version](https://charmhub.io/nats) on Charmhub. This switch does not have any breaking changes from a user's perspective but since the framework of the charm has been overhauled, the upgrade to the new charm would require users to `switch` the charm's source while refreshing/updating the charm.
+* Starting with the 1.22 release, the `anbox-stream-agent` charm has a new relation `client` which can be used to register new clients for the Anbox Stream Agent. This new relation is used by the new AMS charm to create stream-enabled instances using the `--enable-streaming` option. For deployments using the bundles from or after 1.22 release, the relation is created automatically. For users upgrading from older versions of Anbox Cloud, the relation needs to be manually created using `juju relate anbox-stream-agent:client ams:agent` after upgrading both the `ams` and the `anbox-stream-agent` charms to 1.22.
+* If you want to deploy a particular revision of a charm, you can do so by adding `--revision=<rev>` to the `juju upgrade-charm` command.
+* For any of the charm upgrades, you can watch the upgrade status by running `juju status`.
 
-- Starting with the 1.22 release, the `anbox-stream-agent` charm has a new relation `client` which can be used to register new clients for the Anbox Stream Agent. This new relation is used by the new AMS charm to create stream-enabled instances using the `--enable-streaming` option. For deployments using the bundles from or after 1.22 release, the relation is created automatically. For users upgrading from older versions of Anbox Cloud, the relation needs to be manually created using `juju relate anbox-stream-agent:client ams:agent` after upgrading both the `ams` and the `anbox-stream-agent` charms to 1.22.
-```
-
-For any of the charm upgrades, you can watch the upgrade status by running:
-
-     juju status
-
-Continue with the next step only when the current step has completed successfully and all units in the output are marked as **active**.
-
-```{note}
-If you don't run Anbox Cloud in a high availability configuration, upgrading the charms will cause a short down time of individual service components during the process.
-```
+  At any point during the upgrade process, proceed to the next step only when the current step has completed successfully and all units in the `juju status` output are marked as **active**.
 
 ### Upgrade infrastructure components
 
-As a first step, we will update all infrastructure components. This includes deployed internal certificate authorities and etcd.
+As a first step, upgrade all infrastructure components. This includes deployed internal certificate authorities and etcd.
 
-First we update easyrsa:
+Upgrade easyrsa:
 
     juju refresh internal-ca --revision=26
     juju refresh etcd-ca --revision=26
 
 ### Upgrade application registry
 
-The Anbox Application Registry (AAR) can be updated independently of the other services. The upgrade process will cause a short down time of the service providing the registry API but connected AMS instances will retry connecting with it automatically.
+The Anbox Application Registry (AAR) can be upgraded independently of other services. The upgrade process will cause a short downtime of the service providing the registry API but AMS instances that are already connected will retry connecting with the service automatically.
 
-To upgrade the registry, run
+Upgrade the registry:
 
     juju refresh --channel=1.24/stable aar
 
 ### Upgrade control plane
 
-If you have the streaming stack deployed, you need to update the charms responsible for the control plane next. If you do not use the streaming stack, you can skip this step.
+If you have the streaming stack deployed, the next step is to update the charms responsible for the control plane. If you do not use the streaming stack, you can skip this step and proceed to upgrading AMS.
 
 ```{note}
 If you don't run any of the services in a high availability configuration, upgrading the charms will cause a short down time of the service.
@@ -118,13 +112,13 @@ Since the NATS charm has been overhauled to use the modern charm framework (Ops 
 
 ### Upgrade AMS
 
-The AMS service needs to be updated independently of the other service components to ensure minimal down time. The charm can be upgraded by running the following command.
+Upgrade the AMS service independently of the other service components to ensure minimal down time:
 
     juju refresh --channel=1.25/stable ams
 
 ### Upgrade LXD
 
-As the last step, you have to upgrade the LXD cluster. Upgrading LXD will not restart running instances but it's recommended to take a backup before continuing.
+As the last step, upgrade the LXD cluster. Upgrading LXD will not restart running instances but it's recommended to take a backup before continuing.
 
 ```{note}
 In Anbox Cloud's 1.25.0 release, the LXD charm has been reworked and hence there are changes in the upgrade instructions for the charm.
@@ -132,7 +126,7 @@ In Anbox Cloud's 1.25.0 release, the LXD charm has been reworked and hence there
 
 <details>
 <summary>Click here for upgrade instructions for Anbox Cloud versions < 1.25.0 </summary>
-In some cases, specifically when you maintain bigger LXD clusters or want to keep a specific set of LXD nodes active until users have dropped, it makes sense to run the upgrade process manually on a per node basis. To enable this, you can set the following configuration option for the LXD charm before running the refresh command above:
+In some cases, specifically when you maintain bigger LXD clusters or want to keep a specific set of LXD nodes active until users have dropped, it is pragmatic to run the upgrade process manually on a per node basis. To manually upgrade individual nodes, run the following command before running the `juju refresh` command:
 
     juju config lxd enable_manual_upgrade=true
 
@@ -146,51 +140,49 @@ Once the unnecessary nodes are dropped, the upgrade for a single LXD deployment 
 
 Once the upgrade has completed, the unit will be marked as active.
 
-For major and minor version upgrades, an update of the LXD charm may upgrade kernel modules or GPU drivers. This requires stopping any running instances before applying the upgrade and performing a reboot of the machine once the upgrade completed.
+Major and minor version upgrades may include upgrades to kernel modules or GPU drivers. This requires stopping any running instances before applying the upgrade and performing a reboot of the machine once the upgrade completed.
 
-In case a reboot of the machine is required, a status message will be shown. When the machine has been rebooted, the status message can be cleared by running:
+In case a reboot is required, a notification is displayed. When the machine is rebooted, you can clear the notification by running:
 
     juju run --wait=1m lxd/0 clear-notification
 
-If the LXD charm is deployed on a machine with an NVIDIA GPU installed, by default, the NVIDIA drivers are held from being upgraded in case of downtime for all running instances due to either a manual upgrade or an [unattended-upgrade](https://wiki.debian.org/UnattendedUpgrades). The downside to this is that the machine may miss security updates for the NVIDIA drivers. To manually upgrade the NVIDIA drivers, you need to run the following Juju action:
+If the LXD charm is deployed on a machine with an NVIDIA GPU installed, by default, the NVIDIA drivers are held from being upgraded as it may cause downtime for all running instances. The downside to this held upgrade is that security updates for the NVIDIA drivers could be missed. To manually upgrade the NVIDIA drivers, run:
 
     juju run --wait=30m lxd/0 upgrade-gpu-drivers
 
 </details>
 
 ```{important}
-For users running LXD clusters with the LXD snap tracking a channel which is different than 5.21/stable, it is important that you set the charm configuration item `channel` *explicitly* to the currently running channel before running the `upgrade-cluster` command, e.g. if the current LXD cluster consists of the LXD snap tracking the 5.0/stable channel, you should run:
+If you are running LXD clusters with the LXD snap from a channel other than 5.21/stable, you need to set the current LXD channel before running the `upgrade-cluster` command. You can set this by running a command like
 
     juju config lxd channel=5.0/stable
 
-Not doing this might lead to a broken LXD cluster.
+where `5.0/stable` is the current LXD channel. Not doing this might lead to a broken LXD cluster.
 ```
 
-The first step to upgrade LXD is to update the corresponding charm to the latest revision using:
+To start, upgrade the AMS LXD charm to the latest revision using:
 
     juju refresh --channel=1.25/stable lxd
 
-Updating the charm does not update the LXD snap or any of the internal packages on the LXD node. After updating the charm, check which nodes have package updates available using:
+Upgrading the charm does not upgrade the LXD snap or any of the internal packages on the LXD node. After updating the charm, check which nodes have package updates available using:
 
     juju run lxd/0 upgrade-info
 
-If you have multiple Juju units for LXD nodes, make a note of all the Juju units having available updates.
-
-Before proceeding make sure that there are no more active instances on the nodes. Then mark the LXD node as unschedulable within AMS which would make sure that no new instances are spawned on the LXD node. This can be done using:
+Make a note of all the Juju units having available updates. Before proceeding, make sure that there are no active instances on the nodes. Then mark each LXD node that has updates available as unschedulable within AMS.
 
     juju run ams/leader node-start-maintenance node=”<node_name>”
 
-where `<node_name>` refers to the LXD node name stored within AMS, e.g. `lxd0` if the Juju unit is `lxd/0`.
+where `<node_name>` refers to the LXD node name stored within AMS, e.g. `lxd0` if the Juju unit is `lxd/0`. This ensures that no new instances are spawned on those LXD nodes.
 
-After the node is successfully marked as unschedulable, we can safely upgrade the machine. To do this run:
+After a node is successfully marked as unschedulable, we can safely upgrade it. To do this, run:
 
     juju run lxd/<unit_number> --wait=30m upgrade-machine reboot=<true_or_false>
 
-where `<unit_number>` refers to the Juju unit number on each node having available updates.
+where `<unit_number>` refers to the Juju unit number on the corresponding node.
 
-This action will update the GPU drivers as well as installed kernel modules which might result in a reboot being required to successfully load the new modules and drivers. This can be done automatically by setting `reboot=true` or manually at a later point in time by setting `reboot=false` and then running `juju exec lxd/<unit_number> -- sudo reboot` when required.
+Upgrading a node will also upgrade the GPU drivers and the installed kernel modules. When done, this action might require a reboot to successfully load the new modules and drivers. If you want to set the reboot to happen automatically, set `reboot=true`. Otherwise, run `juju exec lxd/<unit_number> -- sudo reboot` when you are ready to reboot the node.
 
-After the updates to all the nodes have finished, update the LXD snap on the node using:
+After the upgrades to all the nodes have finished, upgrade the LXD snap on the node using:
 
     juju run lxd/<unit_number> --wait=30m upgrade-cluster
 
@@ -208,16 +200,20 @@ Some parts of Anbox Cloud are distributed as Debian packages coming from the [An
     sudo apt update
     sudo apt upgrade
 
-or apply the updates via [Landscape](https://landscape.canonical.com/) if available.
+or apply the updates via [Landscape](https://landscape.canonical.com/), if available.
 
 ## Upgrade LXD images
 
 LXD images are automatically being fetched by AMS from the image server once they are published.
 
-Existing applications will be automatically updated by AMS as soon as the new image is uploaded. Watch out for new versions being added for any of the existing applications based on the new image version.
+Existing applications will be automatically updated by AMS as soon as the new image is uploaded. Watch out for new versions being added for any of the existing applications.
 
-You can check for the status of an existing application by running:
+You can check the status of an existing application by running:
 
     amc application show <application id or name>
 
-In case automatic updates are disabled for applications, AMS cannot update the application. See {ref}`sec-configure-automatic-app-updates` to enable automatic updates or to manually update the applications.
+In case automatic updates are disabled for applications, AMS cannot update the application. You need to manually update the applications using:
+
+    amc application update <application id or name>
+
+See {ref}`sec-configure-automatic-app-updates` for instructions on enabling automatic updates.

--- a/reference/release-notes/1.25.2.md
+++ b/reference/release-notes/1.25.2.md
@@ -39,7 +39,7 @@ To deauthorize and remove a user's UID, run:
 
 ## Known issues
 
-* The fix for [CVE-2025-30215](https://nvd.nist.gov/vuln/detail/CVE-2025-30215) is not included in this releease.
+* The fix for [CVE-2025-30215](https://nvd.nist.gov/vuln/detail/CVE-2025-30215) is not included in this release.
 
 ## CVEs
 

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -35,7 +35,7 @@ Minor releases
 Patch releases
 : A patch release for Anbox Cloud is released every month and includes Android and Chrome security updates alongside Anbox Cloud specific bug fixes.
 
-Anbox Cloud officially supports only the most recent release. Older releases are only supported for a short time after a new minor release was published.
+Anbox Cloud supports only the most recent release. Older releases are only supported for a short time after a new minor release was published.
 
 Feature deprecations are generally announced two releases in advance before the deprecated features are dropped. See {ref}`ref-deprecation-notes` for details.
 

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -35,7 +35,7 @@ Minor releases
 Patch releases
 : A patch release for Anbox Cloud is released every month and includes Android and Chrome security updates alongside Anbox Cloud specific bug fixes.
 
-Anbox Cloud currently officially supports only the most recent release. Older releases are only supported for a short time after a new minor release was published.
+Anbox Cloud officially supports only the most recent release. Older releases are only supported for a short time after a new minor release was published.
 
 Feature deprecations are generally announced two releases in advance before the deprecated features are dropped. See {ref}`ref-deprecation-notes` for details.
 


### PR DESCRIPTION
# Documentation changes

This PR clarifies the upgrade documentation to state that we don't officially support any other upgrade than from the n-1 to n upgrade path. This should fix issue #214. 

# Review and preview

Have you reviewed and previewed your documentation updates?
Yes

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

AC-3141