### PR TITLE
Update the doc for the service exposure after port forwarding change in 1.26

### DIFF
--- a/howto/instance/expose-services.md
+++ b/howto/instance/expose-services.md
@@ -42,6 +42,15 @@ If we want to expose the service on the public endpoint of a LXD node, we must s
 
     amc launch -s +tcp:22 bdp7kmahmss3p9i8huu0
 
+
+```{note}
+By default, for security reasons, the LXD charm restricts external access to each instance. To allow external access, you must explicitly expose the LXD charm and configure the allowed port range:
+
+    juju expose lxd
+    juju config lxd exposed_instance_ports=10000-11000
+
+```
+
 Notice the `+` in front of the port definition. This tells AMS to expose the service on the public endpoint of the LXD node on which the instance is scheduled. The instance list shows the public address of the node on which the instance is running, in the list of endpoints:
 
 ```bash

--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -198,7 +198,7 @@ For security reasons, any ports previously exposed by the node controller will b
 
        juju refresh --channel=1.26/stable ams-node-controller
 
-If there is no need to expose services from Anbox instances, revokes the application's exposure to the public network:
+If there is no need to expose services from Anbox instances, revokes the application's exposure to the public network after the AMS node controller is upgraded:
 
        juju unexpose ams-node-controller
 
@@ -206,6 +206,10 @@ If you do need to allow external access to services running inside LXD nodes, ru
 
        juju expose lxd
        juju config lxd exposed_instance_ports=10000-11000
+
+To revoke external access to services after enabling it for the LXD charm, run:
+
+       juju unexpose lxd
 
 
 ## Upgrade Debian packages

--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -192,6 +192,21 @@ Finally after all the upgrades finish and the nodes are healthy, run:
 
 where `<node_name>` refers to the LXD node name stored within AMS.
 
+As a subordinate charm deployed alongside the LXD charm, and following the [deprecation of the node controller charm](https://documentation.ubuntu.com/anbox-cloud/reference/deprecation-notices/#node-controller-charm) in the Anbox Cloud 1.26.0 release, the node controller will no longer manage port forwarding for service exposure on Anbox instances.
+
+For security reasons, any ports previously exposed by the node controller will be closed after upgrading it via:
+
+       juju refresh --channel=1.26/stable ams-node-controller
+
+If there is no need to expose services from Anbox instances, revokes the application's exposure to the public network:
+
+       juju unexpose ams-node-controller
+
+If you do need to allow external access to services running inside LXD nodes, run:
+
+       juju expose lxd
+       juju config lxd exposed_instance_ports=10000-11000
+
 
 ## Upgrade Debian packages
 

--- a/reference/deprecation-notices.md
+++ b/reference/deprecation-notices.md
@@ -39,3 +39,8 @@ Support for Ubuntu 20.04 (Focal Fossa) is deprecated in 1.22.0 and is planned to
 *Deprecated in 1.22.0* ; *Unsupported in 1.23.0*
 
 Support for the EmuGL renderer is deprecated in 1.22.0 and planned to be removed in Anbox Cloud 1.23.0. Starting with 1.22.0, VirGL will be the default renderer for NVIDIA GPUs with driver version 545 and later.
+
+## Node Controller charm
+*Deprecated in 1.26.0* ; *Removal in 1.28.0*
+
+Use of node controller charm to manage the port forwarding from an instance to expose a service is deprecated in 1.26.0. Instead, the Anbox Management Service (AMS) will use a LXD proxy device to manage the port forwarding.

--- a/reference/network-ports.md
+++ b/reference/network-ports.md
@@ -13,7 +13,6 @@ For the Anbox Cloud Appliance, ports are exposed only for accessing the Anbox Cl
 |-----------------------|-------------|-----------|--------------------|------------------------------|---------------------------------------|
 | AMS                   | 8444        | TCP       | no                 | yes                          | HTTPS API                             |
 | AMS                   | 20002       | TCP       | no                 | no                           | HTTPS Prometheus endpoint             |
-| AMS node controller   | 10000-11000 | UDP & TCP | yes                | no                           | Instance service ports                |
 | Anbox Cloud Dashboard | 5000        | TCP       | no                 | no                           | HTTPS website                         |
 | Anbox Stream Agent    | 443         | TCP       | no                 | yes                          | HTTPS API                             |
 | Anbox Stream Gateway  | 4000        | TCP       | no                 | yes                          | HTTPS API                             |
@@ -25,6 +24,7 @@ For the Anbox Cloud Appliance, ports are exposed only for accessing the Anbox Cl
 | HAProxy               | 80          | TCP       | yes                | no                           | HTTP (redirects to HTTPS on port 443) |
 | HAProxy               | 443         | TCP       | yes                | no                           | Redirects to HTTPS website            |
 | LXD                   | 8443        | TCP       | no                 | yes                          | HTTPS API                             |
+| LXD                   | 10000-11000 | UDP & TCP | yes                | no                           | Instance service ports                |
 | NATS                  | 4222        | TCP       | no                 | yes                          | NATS API                              |
 
 ## Anbox Cloud Appliance


### PR DESCRIPTION
# Documentation changes

1. update the expose-services to cover port-forwarding change in 1.26
2. update the network ports table due to port forwarding changes in 1.26
3. document port forwarding changes in 1.26
3. add deprecation notice for the node controller charm

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

https://warthogs.atlassian.net/browse/AC-3333