### PR TITLE
Limit security patch level issue to Android 15 only

### DIFF
--- a/reference/release-notes/1.26.0.md
+++ b/reference/release-notes/1.26.0.md
@@ -69,7 +69,7 @@ The [AMS node controller charm](https://charmhub.io/ams-node-controller) is depr
 The following issues exist in the 1.26.0 release and we are working to fix them for the 1.26.1 patch release:
 
 * A `program was killed: context canceled` error occurs during appliance initialization even though all services are active. ([LP 2110321](https://bugs.launchpad.net/anbox-cloud/+bug/2110321)).
-* Security patch level is not updated to `2025-05-05` even after applying the latest security patches.([LP 2110323](https://bugs.launchpad.net/anbox-cloud/+bug/2110323)).
+* Security patch level for AOSP 15 and AAOS 15 remains unchanged at `2025-05-05` despite applying the latest security patches.([LP 2110323](https://bugs.launchpad.net/anbox-cloud/+bug/2110323)).
 * Unable to stream an instance after deploying the regular Anbox Cloud using Juju([LP 2110194](https://bugs.launchpad.net/anbox-cloud/+bug/2110194)). This issues exists since the 1.25.0 release.
 
 ## CVEs


### PR DESCRIPTION
# Documentation changes

Limit security patch level issue to Android 15 only

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

None