### PR TITLE
fix(release-notes): add a workaround to enable streaming in an insecure way

### DIFF
--- a/reference/release-notes/1.26.0.md
+++ b/reference/release-notes/1.26.0.md
@@ -70,7 +70,18 @@ The following issues exist in the 1.26.0 release and we are working to fix them 
 
 * A `program was killed: context canceled` error occurs during appliance initialization even though all services are active. ([LP 2110321](https://bugs.launchpad.net/anbox-cloud/+bug/2110321)).
 * Security patch level for AOSP 15 and AAOS 15 remains unchanged at `2025-05-05` despite applying the latest security patches.([LP 2110323](https://bugs.launchpad.net/anbox-cloud/+bug/2110323)).
-* Unable to stream an instance after deploying the regular Anbox Cloud using Juju([LP 2110194](https://bugs.launchpad.net/anbox-cloud/+bug/2110194)). This issues exists since the 1.25.0 release.
+* Unable to stream an instance after deploying the regular Anbox Cloud using Juju([LP 2110194](https://bugs.launchpad.net/anbox-cloud/+bug/2110194)). This issues exists since the 1.25.0 release. Run the following command to work around this issue:
+
+    ```
+    juju ssh anbox-cloud-dashboard/0 -- "sudo sed -i '/^ASG_API_SERVER_CERTIFICATE: /d' /var/snap/anbox-cloud-dashboard/common/service/config.yaml"
+    juju ssh anbox-cloud-dashboard/0 -- "sudo snap restart anbox-cloud-dashbaord"
+    ```
+    Once you relaunch the session, streaming will work properly.
+
+    ```{note}
+    With the above workaround, HTTPS requests made by the dashboard will no longer verify SSL certificates, increasing the risk that data can be intercepted or altered. Hence only use only it in trusted environments. The proper fix will be included in the 1.26.1 release.
+    ```
+
 
 ## CVEs
 


### PR DESCRIPTION
# Documentation changes

This change adds a workaround to the bug 
  https://bugs.launchpad.net/anbox-cloud/+bug/2110194
and enable streaming in an insecure way.

Note: we can't not simply replace the incorrect certificate with
the ca certificate by copying it from the anbox-stream-gateway unit
to anbox-cloud-dashboard due to the fact the private IP was not
included into the SAN list when generating the private certificates
for stream-gateway used in the tls verification.
See the following commits for details:
   https://github.com/canonical/anbox-cloud-charms/commit/65cc339f89ef57a7a3f5322865e113cbc8f29f73

Hence so far, the easiest way to unblock people from streaming is
to disable TLS verification on the dashboard side.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.