### PR TITLE
fix(howto): remove database leader info from status message

### DIFF
--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -272,7 +272,7 @@ Check the output of the `juju status` command to see whether you need to reboot:
 ```sh
 ...
 Unit       Workload  Agent  Machine  Public address  Ports      Message
-lxd/0*     active    idle   3        10.75.96.23     8443/tcp   Actions: Reboot Required, Role: Database-leader
+lxd/0*     active    idle   3        10.75.96.23     8443/tcp   Actions: Reboot Required
 ...
 ```
 To reboot the machine hosting LXD, run the following command:


### PR DESCRIPTION
# Documentation changes

fix(howto): remove database leader info from status message

The misleading "Role: Database-leader" message has been removed
from `juju status`, as it was inconsistent with the actual LXD
cluster state and could cause confusion.

[Summary of documentation updates]

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

https://warthogs.atlassian.net/browse/AC-3365