### PR TITLE
Polish the LXD cluster scale up and down section

### DIFF
--- a/howto/cluster/scale-down.md
+++ b/howto/cluster/scale-down.md
@@ -8,10 +8,10 @@ Scaling down a LXD cluster involves more checks than scaling up.
 The following are important requirements when scaling down:
  - The node you remove must not have any instances left.
  - You must wait for a node to be fully removed before you can start removing another one.
- - Unless you are removing the entire cluster or are prepared for breaking changes, you should not remove database nodes. Especially, never remove a database leader node unless you are planning to remove the entire cluster.
-
-   You can identify whether a LXD node is a database node by running `lxc cluster list` on the node. For the database leader node, you can also figure it out by the role displayed in the *Message* column when you run `juju status`.
-
+ - Unless you are removing the entire cluster or are prepared for breaking changes, you should **not**
+   - remove database nodes. Especially, never remove a database leader node unless you are planning to remove the entire cluster. You can identify whether a LXD node is a database node by running `lxc cluster list` on the node.
+   - remove the LXD leader unit. You can identify the LXD leader unit by running `juju status lxd`. The leader is indicated by an asterisk (*) appended to the unit name in the output.
+ - If the LXD leader unit is in the process of rebooting due to a kernel module or GPU driver update, do not scale down the LXD cluster until the leader has fully rebooted or Juju elects a new LXD unit as the leader.
 - Since Anbox Cloud 1.25.0, the default channel for the LXD charm has changed to 5.21/stable.
 For users running LXD clusters with the LXD snap tracking a channel which is different than 5.21/stable, it is important that you set the charm configuration item `channel` *explicitly* to the currently running channel for LXD before scaling up or down, e.g. if the current LXD cluster consists of the LXD snap tracking the 5.0/stable channel, you should run:
 

--- a/howto/cluster/scale-up.md
+++ b/howto/cluster/scale-up.md
@@ -3,6 +3,18 @@
 
 Scaling up a LXD cluster can be achieved via Juju. Juju automates the deployment of the individual units and links them together.
 
+### Prerequisites
+
+The following are important requirements when scaling up:
+- If the LXD leader unit is in the process of rebooting due to a kernel module or GPU driver update, do not scale up the LXD cluster until the leader has fully rebooted or Juju elects a new LXD unit as the leader.
+- Since Anbox Cloud 1.25.0, the default channel for the LXD charm has changed to 5.21/stable.
+For users running LXD clusters with the LXD snap tracking a channel which is different than 5.21/stable, it is important that you set the charm configuration item `channel` *explicitly* to the currently running channel for LXD before scaling up or down, e.g. if the current LXD cluster consists of the LXD snap tracking the 5.0/stable channel, you should run:
+
+    juju config lxd channel=5.0/stable
+
+Bypassing any of these requirements could lead to a broken LXD cluster.
+
+
 Adding additional LXD units or removing existing ones is not an instant operation. Adding a new node, for example, can take 5-10 minutes and must be planned in advance. The deployment of a single node will include the following steps:
 
 1. Allocation of a new machine from the underlying cloud provider
@@ -11,14 +23,6 @@ Adding additional LXD units or removing existing ones is not an instant operatio
 4. Registration of the LXD node with the existing cluster and AMS
 5. Synchronization of necessary artifacts from other nodes in the LXD cluster (for example, images)
 
-```{important}
-Since Anbox Cloud 1.25.0, the default channel for the LXD charm has changed to 5.21/stable.
-For users running LXD clusters with the LXD snap tracking a channel which is different than 5.21/stable, it is important that you set the charm configuration item `channel` *explicitly* to the currently running channel for LXD before scaling up or down, e.g. if the current LXD cluster consists of the LXD snap tracking the 5.0/stable channel, you should run:
-
-    juju config lxd channel=5.0/stable
-
-Not doing this might lead to a broken LXD cluster.
-```
 
 To add additional LXD nodes, run the following commands:
 


### PR DESCRIPTION
# Documentation changes

- Avoid scaling up or down a LXD cluster while the LXD leader is
  rebooting, unless Juju has elected a new leader.
- Updated scale-down to distinguish between database leader and Juju
   leader unit, and emphasized best practices for safe removal of units.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

https://warthogs.atlassian.net/browse/AC-3365