### PR TITLE
Switch to sphinx-design tabs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -267,7 +267,7 @@ linkcheck_retries = 3
 # NOTE: By default, the following MyST extensions are enabled:
 #       substitution, deflist, linkify
 
-# myst_enable_extensions = set()
+myst_enable_extensions = set({"colon_fence"})
 
 
 # Custom Sphinx extensions; see

--- a/contribute/doc-cheat-sheet.md
+++ b/contribute/doc-cheat-sheet.md
@@ -165,16 +165,15 @@ The following example uses local images folder:
 
 ## Tabs
 
-````{tabs}
-```{group-tab} Tab 1
-
+::::{tab-set}
+:::{tab-item} Tab 1
 Content Tab 1
-```
+:::
 
-```{group-tab} Tab 2
+:::{tab-item} Tab 2
 Content Tab 2
-```
-````
+:::
+::::
 
 ## Glossary
 

--- a/howto/android/access-instance.md
+++ b/howto/android/access-instance.md
@@ -34,8 +34,9 @@ If you are using the dashboard, you can also find the session ID in the *Instanc
 
 ### Create a share for the session
 
-````{tabs}
-```{group-tab} CLI
+::::{tab-set}
+:::{tab-item} CLI
+:sync: cli
 
 Using the session's ID, share it the session:
 
@@ -45,15 +46,16 @@ Providing a description helps you identify a share later on, if you are sharing 
 
 The output returns a presigned URL that you can use to connect to the remote Android instance.
 
-```
-```{group-tab} Dashboard
+:::
+
+:::{tab-item} Dashboard
+:sync: dashboard
 
 On the *Instances* page, locate a running instance and click *Connect ADB* ( ![Connect ADB|16x16](/images/icons/adb-connect-icon.png) ).
 
 After you authorize the connection, copy the `anbox-connect <connection_url>` provided.
-
-```
-````
+:::
+::::
 
 Watch this [video](https://youtu.be/qsFF0eqj_JE) for a detailed demonstration of how to use an ADB connection to debug an Android application with Android studio.
 

--- a/howto/application/create-application.md
+++ b/howto/application/create-application.md
@@ -46,8 +46,9 @@ resources:
   disk-size: 8GB
 ```
 
-`````{tabs}
-````{group-tab} CLI
+::::{tab-set}
+:::{tab-item} CLI
+:sync: cli
 
 An application can be created from a directory, a zip archive or a tarball file. If you cannot use a directory, the second best option is to use a zip archive that provides better optimization when compared to a tarball.
 
@@ -119,9 +120,10 @@ resources:
   disk-size: 8GB
 ```
 
-````
+:::
 
-```{group-tab} Dashboard
+:::{tab-item} Dashboard
+:sync: dashboard
 
 Click *Create application* on the applications page, enter the required and any optional details that you want to provide and confirm with *Create*.
 
@@ -142,8 +144,8 @@ There may be more advanced scenarios while creating an application that cannot b
 After you create an application, the *Applications* page lists all the available applications. Clicking an application name opens the *Application details* page that displays information about the application, its configuration, and deployment features in the *Overview* section.
 
 The *Versions* section lists all created versions of the application. Use the *Actions* menu to either upload to the registry, unpublish, or delete a specific version. Click a specific version to open the version side panel, which provides detailed information about the version related to the parent image and watchdog.
-```
-`````
+:::
+::::
 
 Once the status of the application switches to `ready`, the application is ready and can be used. See {ref}`howto-wait-for-application` for information about how to monitor the application status.
 

--- a/howto/application/delete-application.md
+++ b/howto/application/delete-application.md
@@ -7,19 +7,21 @@ When an application is no longer needed, it can be fully removed from Anbox Clou
 
 Once you're sure you want to remove the application, you can delete it via the dashboard or the CLI.
 
-````{tabs}
+::::{tab-set}
 
-```{group-tab} CLI
+:::{tab-item} CLI
+:sync:cli
 
 Run:
 
     amc application delete bcmap7u5nof07arqa2ag
 
 The command will ask for your approval before the application is removed. If you want to bypass the check, you can add the `--yes` flag to the command.
-```
+:::
 
-```{group-tab} Dashboard
+:::{tab-item} Dashboard
+:sync: dashboard
 
 On the *Applications* page, click *Delete* ( ![delete application icon](/images/icons/delete-icon.png) ) and confirm the deletion.
-```
-````
+:::
+::::

--- a/howto/application/stream-application.md
+++ b/howto/application/stream-application.md
@@ -3,8 +3,9 @@
 
 You can stream applications using the Anbox Cloud dashboard or your custom stream client. You can also stream applications by launching an instance with streaming enabled, using the `amc` CLI.
 
-````{tabs}
-```{group-tab} CLI
+::::{tab-set}
+:::{tab-item} CLI
+:sync: cli
 
 If you are using the `amc` CLI, you can use the `--enable-streaming` option at the time of launching the instance:
 
@@ -20,8 +21,9 @@ To further customize the streaming configuration, use the following arguments:
 For example, to create an instance with a 1080p resolution, a frame rate of 60 and a DPI of 120, run:
 
     amc launch --enable-streaming --display-size=1920x1080 --display-density=120 --fps=60 <application_id>
-```
-```{group-tab} Dashboard
+:::
+:::{tab-item} Dashboard
+:sync: dashboard
 
 The dashboard has in-browser streaming capabilities through WebRTC. It uses the {ref}`sec-streaming-sdk`.
 
@@ -30,8 +32,8 @@ When creating an instance, make sure you select the *Enable Streaming* capabilit
 You can start a streaming session for any of the successfully created applications. Once the associated instance is created and ready, click *Stream* ( ![stream icon](/images/icons/stream-icon.png) ) to start the stream.
 
 To understand how the streaming stack of Anbox Cloud works, see {ref}`exp-application-streaming`.
-```
-````
+:::
+::::
 
 ## Streaming statistics
 
@@ -62,8 +64,10 @@ The downloaded `.csv` file has the following statistics:
 ### Sharing a streaming session
 
 
-````{tabs}
-```{group-tab} CLI
+::::{tab-set}
+:::{tab-item} CLI
+:sync: cli
+
 ```{tip}
 If you are running the appliance, use `anbox-cloud-appliance.gateway` for all gateway commands instead of `anbox-stream-gateway`
 ```
@@ -76,15 +80,14 @@ Running this command generates a presigned URL for the session, that is valid fo
 
 You can later update the expiration date and description of a shared session. See {ref}`howto-access-android-instance` for detailed steps.
 
-```
+:::
 
-```{group-tab} Dashboard
+:::{tab-item} Dashboard
+:sync: dashboard
 
 To share your stream with users without an account, click *Set up sharing* ( ![set up sharing icon](/images/icons/share-stream-icon.png) ) on the *Instances* page.
 
 Set your stream title and expiration details and generate a link that can be shared with others.
-```
-````
 
 ### Developer Tools
 
@@ -102,8 +105,8 @@ In the *Logs* tabs, you can toggle auto-scroll, pause and resume log messages, c
 
 For a detailed demonstration of the *Developer Tools* and their full capabilities, refer to: [Developer Tools](https://youtu.be/M1N8pfIUjOI?t=257&si=DJsoziD0NRTrLPff).
 
-```
-````
+:::
+::::
 
 ## Related topics
 

--- a/howto/application/update-application.md
+++ b/howto/application/update-application.md
@@ -3,8 +3,9 @@
 
 Updating an existing application works similar to creating a new one. Each time an existing application is updated, it is extended with a new version. All versions that an application currently has are individually usable, but only one can be launched at a time.
 
-`````{tabs}
-````{group-tab} CLI
+::::{tab-set}
+:::{tab-item} CLI
+:sync: cli
 
 When you want to update an existing application with a new manifest or APK, provide both in the same format as when the application was created. The `amc application update` command accepts both a directory and an absolute file path.
 
@@ -85,9 +86,10 @@ resources:
   disk-size: 8GB
 ```
 
-````
+:::
 
-```{group-tab} Dashboard
+:::{tab-item} Dashboard
+:sync: dashboard
 
 You can edit an application from the *Applications* list page.
 
@@ -102,8 +104,8 @@ Similar to the application creation process, you can unlock advanced customizati
 
 When you click *Update*, you will be redirected either to the *Overview* tab of the application detail page - if the fields changed did not trigger a new version creation - or to the *Versions* tab of that page, when a new version of the application was created.
 
-```
-`````
+:::
+::::
 
 Each version gets a monotonically increasing number assigned (here we have version `0` and version `1`).
 In addition, each version has a status which indicates the status of the bootstrap process AMS is performing for it. Once an application version is marked as `active`, it is ready to be used.

--- a/howto/images/add-image.md
+++ b/howto/images/add-image.md
@@ -1,9 +1,10 @@
 (howto-add-image)=
 # How to add an image
 
-````{tabs}
+::::{tab-set}
 
-```{group-tab} CLI
+:::{tab-item} CLI
+:sync: cli
 
 An image can be added with the following command:
 
@@ -17,9 +18,10 @@ You can set any image as your default with the following command:
 
 Running `amc image list` will now show this image marked as default.
 
-```
+:::
 
-```{group-tab} Dashboard
+:::{tab-item} Dashboard
+:sync: dashboard
 
 You can add an image from the *Images* page of the Anbox Cloud dashboard. While adding an image, you can also edit its name and set it as a default.
 
@@ -33,5 +35,5 @@ Click the *Sync* button ( ![sync image icon](/images/icons/sync-image-icon.png) 
 
 The *Sync* button is enabled only for images with the *available* status.
 
-```
-````
+:::
+::::

--- a/howto/images/delete-image.md
+++ b/howto/images/delete-image.md
@@ -1,9 +1,10 @@
 (howto-delete-image)=
 # How to delete an image
 
-````{tabs}
+::::{tab-set}
 
-```{group-tab} CLI
+:::{tab-item} CLI
+:sync: cli
 
 Deleting an image will make it unavailable to Anbox Cloud. However, it will not affect any application based on the image directly, as the application keeps a copy of the image internally. As the image is not available to AMS anymore after deleting it, updating the underlying image of applications with a new version is not possible anymore.
 
@@ -24,9 +25,10 @@ The following command removes version `1` of the image with the name `image-name
 
     amc image delete image-name --version=1
 
-```
+:::
 
-```{group-tab} Dashboard
+:::{tab-item} Dashboard
+:sync: dashboard
 
 To delete an image, click the *Delete* button ( ![delete application icon](/images/icons/delete-icon.png) ) either in the actions column of the table on the *Images* page or in the header of the *Image details* page. Deleting an image will remove all of its versions.
 
@@ -38,8 +40,8 @@ Images can not be deleted in the following scenarios:
 - Images currently in use by applications cannot be deleted until all the associated applications are deleted first.
 - Specific versions of images that are immutable cannot be deleted. However, the entire immutable image can still be force-deleted.
 
-```
-````
+:::
+::::
 
 ```{note}
 Unless you have only one image left, you cannot delete an image that is marked as default. You must set a new default image first.

--- a/howto/instance/create-instance.md
+++ b/howto/instance/create-instance.md
@@ -2,8 +2,9 @@
 # How to create an instance
 To launch an application or an image, Anbox Cloud creates an instance for it. To create and launch an instance, you can use the Anbox Cloud dashboard or the CLI.
 
-`````{tabs}
-````{group-tab} CLI
+::::{tab-set}
+:::{tab-item} CLI
+:sync: cli
 
 Depending on what you need, you can use the either of the following commands to create an instance for a registered application or an image.
 
@@ -128,10 +129,10 @@ You can launch instances with additional development features turned on. This de
 To launch an instance with development mode enabled, add the `--devmode` flag to the launch command:
 
     amc launch --devmode <application_id>
+:::
 
-````
-
-```{group-tab} Dashboard
+:::{tab-item} Dashboard
+:sync: dashboard
 
 You can create instances from the *Images* and *Applications* pages using the *Create an Instance* button ( ![create instance icon](/images/icons/create-instance-icon.png) ). You can also create instances from the details page of an image and an application.
 
@@ -142,7 +143,6 @@ When you create the instance from an application, the attributes you define for 
 ```{note}
 There may be more advanced scenarios while creating an instance that cannot be performed using the dashboard and may require using the `amc` CLI.
 ```
-
 Once you create an instance by providing the necessary attributes, you can view the instance and its status on the *Instances* page.
 
 You can view details about a particular instance when you click on the instance name in the *Instances* list page. The instance details page offers three types of information: *Overview*, *Terminal*, and *Logs*.
@@ -155,9 +155,8 @@ The *Logs* tab helps you debug issues with the instances as it provides  downloa
 
 The instance details page also contains all the available actions including streaming, setting up sharing, connecting ADB, starting or stopping the instance, and deleting the instance.
 
-```
-
-`````
+:::
+::::
 
 ## Related topics
 

--- a/howto/instance/delete-instance.md
+++ b/howto/instance/delete-instance.md
@@ -3,8 +3,10 @@
 
 An instance can be deleted, which will cause any connected user to be disconnected immediately.
 
-````{tabs}
-```{group-tab} CLI
+::::{tab-set}
+:::{tab-item} CLI
+:sync: cli
+
 Run:
 
     amc delete <instance_id>
@@ -15,11 +17,12 @@ In some cases, it is helpful to delete all instances currently available.
 The `amc` command provides a `--all` flag for this, but be careful while performing a deletion of all instances.
 
     amc delete --all
-```
+:::
 
-```{group-tab} Dashboard
+:::{tab-item} Dashboard
+:sync: dashboard
 
 On the *Instances* page, click *Delete* ( ![delete application icon](/images/icons/delete-icon.png) ) and confirm the deletion.
 
-```
-````
+:::
+::::

--- a/tutorial/create-test-virtual-device.md
+++ b/tutorial/create-test-virtual-device.md
@@ -7,8 +7,9 @@ By the end of this tutorial, we will be familiar with an {term}`Application` and
 
 This tutorial has two paths - you can use the CLI or the dashboard, depending on your learning goals. The CLI is more powerful and gives you access to all features of Anbox Cloud, while the dashboard is a simpler user interface. For this tutorial, it does not matter which path you choose.
 
-`````{tabs}
-````{group-tab} CLI
+::::{tab-set}
+:::{tab-item} CLI
+:sync: cli
 
 We will use the {term}`Anbox Management Client (AMC)` in this tutorial to work with applications and instances. AMC communicates with the {term}`Anbox Management Service (AMS)`, the instance management module of Anbox Cloud.
 
@@ -271,9 +272,10 @@ Go to `https://machine-address` using a browser and go to the *Instances* page w
 ## Success!
 You now know how to use the command line to create and test an Android virtual device in Anbox Cloud. 
 
-````
+:::
 
-````{group-tab} Dashboard
+:::{tab-item} Dashboard
+:sync: dashboard
 
 ## Create the device
 
@@ -349,8 +351,8 @@ If you have an instance with an *error* status, you can explore the different ty
 
 You now know how to use the Anbox Cloud dashboard to create and test an Android virtual device. 
 
-````
-`````
+:::
+::::
 
 > Next: You can check out the following how-to sections to try out other applications with applications and instances:
 


### PR DESCRIPTION
# Documentation changes
This PR switches from using sphinx-tabs to sphinx-design extension. See https://github.com/canonical/sphinx-docs-starter-pack/pull/383 for details on why sphinx-design tabs are reasons why the recommendation changed from sphinx-tabs to sphinx-design for the starter pack.

# Review and preview

Have you reviewed and previewed your documentation updates?
Yes

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

AC-3387