### PR TITLE
Add troubleshooting for image authentication

### DIFF
--- a/howto/troubleshoot/troubleshoot-instance-failures.md
+++ b/howto/troubleshoot/troubleshoot-instance-failures.md
@@ -5,7 +5,7 @@ The following information should help you in determining issues related to insta
 
 ## Images not available
 
-*Applies to: Anbox Cloud Appliance*
+*Applies to: Anbox Cloud, Anbox Cloud Appliance*
 
 > I completed the installation and initialization process correctly. When I try creating an instance, I don't see any available images.
 

--- a/howto/troubleshoot/troubleshoot-instance-failures.md
+++ b/howto/troubleshoot/troubleshoot-instance-failures.md
@@ -1,9 +1,25 @@
 (howto-ts-instance-failures)=
 # Troubleshoot instance failures
 
-The following information should help you in determining why your instance failed.
+The following information should help you in determining issues related to instances.
 
-## More information on instance failures
+## Images not available
+
+*Applies to: Anbox Cloud Appliance*
+
+> I completed the installation and initialization process correctly. When I try creating an instance, I don't see any available images.
+
+This issue occurs most likely because the Ubuntu Pro token was not attached before the appliance was initialized for the first time. Even when you attach the Ubuntu Pro token later on, the authentication to sync images from the media server is not set correctly and hence the images are inaccessible.
+
+You can confirm this by running:
+
+    amc config show | grep images.auth
+
+If the output displays `images.auth: false`, then the image authentication is not set. To set the image authentication correctly and access images, run:
+
+    amc config set images.auth bearer:$(sudo cat /var/lib/ubuntu-advantage/private/machine-token.json | jq -r '.resourceTokens[] | select(.type=="anbox-images").token')
+
+## Instance failed to start
 
 *Applies to: Anbox Cloud, Anbox Cloud Appliance*
 


### PR DESCRIPTION
# Documentation changes

This PR adds troubleshooting information for users who fail to attach the Ubuntu Pro token the first time when they initialize the appliance and end with image authentication set as False. 

# Review and preview

Have you reviewed and previewed your documentation updates?
Yes

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

N/A