### PR TITLE
Add slight variation for appliance vs charmed deployments

### DIFF
--- a/howto/troubleshoot/troubleshoot-instance-failures.md
+++ b/howto/troubleshoot/troubleshoot-instance-failures.md
@@ -11,13 +11,19 @@ The following information should help you in determining issues related to insta
 
 This issue occurs most likely because the Ubuntu Pro token was not attached before the appliance was initialized for the first time. Even when you attach the Ubuntu Pro token later on, the authentication to sync images from the media server is not set correctly and hence the images are inaccessible.
 
-You can confirm this by running:
+On the appliance, you can confirm this by running:
 
     amc config show | grep images.auth
 
-If the output displays `images.auth: false`, then the image authentication is not set. To set the image authentication correctly and access images, run:
+If you are using the charmed deployment, you will need to first `ssh` into the machine:
+
+    juju ssh ams/leader
+    amc config show | grep images.auth
+
+If `images.auth` is set to `false`, then the image authentication not being set properly is the issue. To correct the authentication and access images on the appliance, run:
 
     amc config set images.auth bearer:$(sudo cat /var/lib/ubuntu-advantage/private/machine-token.json | jq -r '.resourceTokens[] | select(.type=="anbox-images").token')
+
 
 ## Instance failed to start
 


### PR DESCRIPTION
# Documentation changes

This is a continuation of PR #355 to clarify better for charmed vs appliance deployment

# Review and preview

Have you reviewed and previewed your documentation updates?
Yes

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

N/A