### PR TITLE
Use correct `session share` command in documentation

### DIFF
--- a/howto/application/stream-application.md
+++ b/howto/application/stream-application.md
@@ -74,7 +74,7 @@ If you are running the appliance, use `anbox-cloud-appliance.gateway` for all ga
 
 You can share an authenticated session with another user by running:
 
-    anbox-stream-gateway share <session_id> --description="Grant access to xxx"
+    anbox-stream-gateway session share <session_id> --description="Grant access to xxx"
 
 Running this command generates a presigned URL for the session, that is valid for a specified duration.
 


### PR DESCRIPTION
# Documentation changes

Use the correct `session share` command in the documentation

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]