### PR TITLE
Remove node controller ports for appliance

### DIFF
--- a/reference/network-ports.md
+++ b/reference/network-ports.md
@@ -31,6 +31,7 @@ For the Anbox Cloud Appliance, ports are exposed only for accessing the Anbox Cl
 
 | Service               | Port(s)     | Protocol  | Exposed externally | Required | Description                            |
 |-----------------------|-------------|-----------|--------------------|----------|----------------------------------------|
+| LXD                   | 10000-11000 | UDP & TCP | yes                | no       | Instance service ports                 |
 | Coturn                | 5349        | UDP       | yes                | no       | STUN/TURN                              |
 | Coturn                | 60000-60100 | UDP       | yes                | no       | TURN relay ports                       |
 | UI and API            | 443         | TCP       | yes                | yes      | Reverse proxy providing access to UI and subset of API endpoints |

--- a/reference/network-ports.md
+++ b/reference/network-ports.md
@@ -31,7 +31,6 @@ For the Anbox Cloud Appliance, ports are exposed only for accessing the Anbox Cl
 
 | Service               | Port(s)     | Protocol  | Exposed externally | Required | Description                            |
 |-----------------------|-------------|-----------|--------------------|----------|----------------------------------------|
-| AMS node controller   | 10000-11000 | UDP & TCP | yes                | no       | Instance service ports                 |
 | Coturn                | 5349        | UDP       | yes                | no       | STUN/TURN                              |
 | Coturn                | 60000-60100 | UDP       | yes                | no       | TURN relay ports                       |
 | UI and API            | 443         | TCP       | yes                | yes      | Reverse proxy providing access to UI and subset of API endpoints |


### PR DESCRIPTION
# Documentation changes

The appliance no longer uses node controller. This PR removes the outdated information in documentation.

# Review and preview

Have you reviewed and previewed your documentation updates?
Yes

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

N/A