### PR TITLE
Use 1.26 channel for anbox cloud charm on upgrade guide

### DIFF
--- a/howto/monitor/landing.md
+++ b/howto/monitor/landing.md
@@ -148,7 +148,7 @@ The following steps describe a sample setup of COS. Adjust it for your environme
 6. Deploy the Anbox Cloud configuration charm for COS-specific dashboards and alerts:
 
    ```bash
-   juju deploy --channel=1.25/stable anbox-cloud-cos-configuration
+   juju deploy --channel=1.26/stable anbox-cloud-cos-configuration
    juju relate anbox-cloud-cos-configuration:grafana-dashboard grafana:grafana-dashboard
    ```
 

--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -98,10 +98,10 @@ If you don't run any of the services in a high availability configuration, upgra
 
 To upgrade all charms, run the following commands:
 
-    juju refresh --channel=1.25/stable anbox-cloud-dashboard
-    juju refresh --channel=1.25/stable anbox-stream-gateway
-    juju refresh --channel=1.25/stable anbox-stream-agent
-    juju refresh --channel=1.25/stable coturn
+    juju refresh --channel=1.26/stable anbox-cloud-dashboard
+    juju refresh --channel=1.26/stable anbox-stream-gateway
+    juju refresh --channel=1.26/stable anbox-stream-agent
+    juju refresh --channel=1.26/stable coturn
     juju refresh --channel=latest/stable nats
 
 ```{note}
@@ -114,7 +114,7 @@ Since the NATS charm has been overhauled to use the modern charm framework (Ops 
 
 Upgrade the AMS service independently of the other service components to ensure minimal down time:
 
-    juju refresh --channel=1.25/stable ams
+    juju refresh --channel=1.26/stable ams
 
 ### Upgrade LXD
 
@@ -162,7 +162,7 @@ where `5.0/stable` is the currently installed LXD snap channel. Not doing this m
 
 To start, upgrade the AMS LXD charm to the latest revision using:
 
-    juju refresh --channel=1.25/stable lxd
+    juju refresh --channel=1.26/stable lxd
 
 Upgrading the charm does not upgrade the LXD snap or any of the internal packages on the LXD node. After updating the charm, check which nodes have package updates available using:
 

--- a/howto/upgrade/upgrade-appliance.md
+++ b/howto/upgrade/upgrade-appliance.md
@@ -9,7 +9,7 @@ If you are on the `latest` track, upgrade to the newest snap version by running:
 
 Automatic updates may install the new version without manual intervention.
 
-For installations on a versioned track (e.g. 1.25), change the track explicitly with:
+For installations on a versioned track (e.g. 1.26), change the track explicitly with:
 
     sudo snap refresh --channel=1.26/stable anbox-cloud-appliance
 


### PR DESCRIPTION
# Documentation changes

Anbox Cloud 1.26 has been released for a while. Hence using the 1.26 , 
which is the latest channel in the upgrade guide.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]