### PR TITLE
Embed videos instead of linking

### DIFF
--- a/explanation/anbox-cloud.md
+++ b/explanation/anbox-cloud.md
@@ -5,7 +5,17 @@ Anbox Cloud provides a rich software stack that enables you to run Android appli
 
 Anbox Cloud maintains a single Android system per instance, providing higher density and better performance per host while ensuring security and isolation of each instance. Depending on the target platform, payload, and desired application performance (for example, frame rate), Anbox Cloud can run more than 100 instances on a single machine.
 
-Watch [this video](https://youtu.be/P7md88WhOC0?si=eUGiQtQ-9uXmZOQu) to learn more about how you can deploy Anbox Cloud with charms.
+**Watch this video to learn more about Anbox Cloud deployment using charms:**
+
+```{raw} html
+<iframe width="640" height="360"
+        src="https://www.youtube.com/embed/P7md88WhOC0"
+        title="Deploying Anbox Cloud using charms"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen>
+</iframe>
+```
 
 (sec-variants)=
 ## Variants

--- a/howto/android/access-instance.md
+++ b/howto/android/access-instance.md
@@ -6,6 +6,18 @@ For certain scenarios, accessing an individual instance for debugging or develop
 - Using the `anbox-connect` command. This establishes secure Android Debug Bridge (ADB) connections.
 - Exposing the ADB service upon Anbox instance creation. This allows remote connections to instances over a network.
 
+**A video demonstration of how to use an ADB connection to debug an Android application with Android studio is available:**
+
+```{raw} html
+<iframe width="640" height="360"
+        src="https://www.youtube.com/embed/qsFF0eqj_JE"
+        title="Debug an Android application with Android studio"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen>
+</iframe>
+```
+
 ## Access the Android instance using `anbox-connect`
 
 Since the 1.23.0 release, Anbox Cloud allows users to create a secure ADB connection through the `anbox-connect` command without exposing the [ADB service](https://documentation.ubuntu.com/anbox-cloud/en/latest/howto/instance/expose-services/). This method is highly recommended for securely connecting to remote Android instances, offering a safe and efficient means of managing ADB connections.
@@ -56,8 +68,6 @@ On the *Instances* page, locate a running instance and click *Connect ADB* ( ![C
 After you authorize the connection, copy the `anbox-connect <connection_url>` provided.
 :::
 ::::
-
-Watch this [video](https://youtu.be/qsFF0eqj_JE) for a detailed demonstration of how to use an ADB connection to debug an Android application with Android studio.
 
 Each presigned URL can only be used to establish a single ADB connection. If multiple users attempt to use the same presigned URL, any existing ADB connection will be interrupted, to allow the new request to succeed.
 

--- a/howto/android/set-automotive-properties.md
+++ b/howto/android/set-automotive-properties.md
@@ -3,7 +3,17 @@
 
 This how-to guide explains the steps of how to set the automotive properties when using an AAOS application.
 
-> Watch the [video tutorial](https://www.youtube.com/watch?v=irx2ylMalos).
+**A video version of this guide is also available:**
+
+```{raw} html
+<iframe width="640" height="360"
+        src="https://www.youtube.com/embed/irx2ylMalos"
+        title="Set automotive properties using VHAL"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen>
+</iframe>
+```
 
 ## Prerequisites
 

--- a/howto/application/stream-application.md
+++ b/howto/application/stream-application.md
@@ -103,7 +103,17 @@ The *Logs* tabs allows you to view logs as you interact with your Android stream
 
 In the *Logs* tabs, you can toggle auto-scroll, pause and resume log messages, clear the logs, adjust the verbosity of the logs, search using free text search or regular expressions, and export the logs.
 
-For a detailed demonstration of the *Developer Tools* and their full capabilities, refer to: [Developer Tools](https://youtu.be/M1N8pfIUjOI?t=257&si=DJsoziD0NRTrLPff).
+**For a detailed demonstration of the *Developer Tools* and their full capabilities, see this video:**
+
+```{raw} html
+<iframe width="640" height="360"
+        src="https://www.youtube.com/embed/M1N8pfIUjOI?start=257"
+        title="Developer tools demonstration"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen>
+</iframe>
+```
 
 :::
 ::::

--- a/howto/instance/create-instance.md
+++ b/howto/instance/create-instance.md
@@ -2,7 +2,17 @@
 # How to create an instance
 To launch an application or an image, Anbox Cloud creates an instance for it. To create and launch an instance, you can use the Anbox Cloud dashboard or the CLI.
 
-> Check out [this video](https://youtu.be/nBUqb_Bnx2Y) that explains the differences between an instance created from an application vs an instance created from an image.
+**Check out this video that explains the differences between an instance created from an application vs an instance created from an image:**
+
+```{raw} html
+<iframe width="640" height="360"
+        src="https://www.youtube.com/embed/nBUqb_Bnx2Y"
+        title="Differentiate application based and image based instances"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen>
+</iframe>
+```
 
 ::::{tab-set}
 :::{tab-item} CLI

--- a/tutorial/create-test-virtual-device.md
+++ b/tutorial/create-test-virtual-device.md
@@ -7,7 +7,17 @@ By the end of this tutorial, we will be familiar with an {term}`Application` and
 
 This tutorial has two paths - you can use the CLI or the dashboard, depending on your learning goals. The CLI is more powerful and gives you access to all features of Anbox Cloud, while the dashboard is a simpler user interface. For this tutorial, it does not matter which path you choose.
 
-> A [video version](https://youtu.be/_F2hGlpe0OY) of this tutorial using the dashboard is also available.
+**A video version of this tutorial using the dashboard is also available:**
+
+```{raw} html
+<iframe width="640" height="360"
+        src="https://www.youtube.com/embed/_F2hGlpe0OY"
+        title="Create a virtual Android device"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen>
+</iframe>
+```
 
 ::::{tab-set}
 :::{tab-item} CLI

--- a/tutorial/installing-appliance.md
+++ b/tutorial/installing-appliance.md
@@ -9,7 +9,17 @@ Before beginning the tutorial, it is important to understand that:
 
 - Remember that installing the appliance will take over the entire instance, install packages and override existing components. For example, if you have existing LXD containers, installing and initializing the appliance could override any existing configuration.
 
-> A [video version](https://youtu.be/D9iEd88IYBs) of this tutorial is also available.
+**A video version of this tutorial is also available:**
+
+```{raw} html
+<iframe width="640" height="360"
+        src="https://www.youtube.com/embed/D9iEd88IYBs"
+        title="How to install Anbox Cloud Appliance"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen>
+</iframe>
+```
 
 ## Prerequisites
 


### PR DESCRIPTION
# Documentation changes

There was a concern that linked videos are easily lost in the amount of text we have on the documentation pages.
So this PR changes the video format to embedded videos using iframe rather than linking. Other options explored were the [sphinxcontrib.video extension](https://sphinxcontrib-video.readthedocs.io/en/latest/index.html). The extension didn't work well with the MysT aased markdown format.

When we explored this a while back, there was also a question of consent for embedded videos. I verified this with the Legal team that we don't have to ask for consent to share our own public videos and also that we don't have to ask for the readers to agree to YouTube's terms because that is built into their service.

# Review and preview

Have you reviewed and previewed your documentation updates?
Yes

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

N/A (ad-hoc request)