### PR TITLE
fix(gh): use latest/stable for appliance installation

### DIFF
--- a/.github/workflows/update-api-specs.yaml
+++ b/.github/workflows/update-api-specs.yaml
@@ -11,14 +11,10 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-    - name: Determine base version
-      id: base_version
-      run: |
-        echo "value=$(cat .base_version)" >> "$GITHUB_OUTPUT"
     - name: Set up Anbox Cloud
       uses: canonical/anbox-cloud-github-action@dc99b94280cfcf44a86b62aeac25ba34f14725e0
       with:
-        channel: ${{ steps.base_version.outputs.value }}/stable
+        channel: latest/stable
     - name: Determine appliance version
       id: snap_version
       run: |


### PR DESCRIPTION
# Documentation changes

In order to keep API documentation in line with what we currently have released we use latest/stable instead of determining the version to use from the (currently incorrect) .base_version file.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

n/a