### PR TITLE
Clarify GPU slots usage

### DIFF
--- a/explanation/capacity-planning.md
+++ b/explanation/capacity-planning.md
@@ -56,7 +56,7 @@ When you launch an instance for an application, AMS reserves the number of GPU s
 ```{important}
 GPU slots are used to share GPUs among instances, but they do not impose limits on GPU usage. Therefore, increasing the number of required GPU slots for an application does not guarantee that more GPU resources are allocated to the corresponding application instances. For example, an intensive game that is configured to use one GPU slot might consume more GPU resources than a simple photo gallery app that is configured to use five GPU slots.
 
-The main purpose of GPU slots is to control the number of instances that are launched on a node that has a GPU installed, which reduces contention for GPU resources.
+There is a default number of GPU slots and GPU encoder slots configured depending on the GPU used but this can be changed. The main purpose of GPU slots is to control the number of instances that are launched on a node that has a GPU installed, which reduces contention for GPU resources.
 ```
 (sec-over-committing)=
 ## Over-committing resources

--- a/explanation/capacity-planning.md
+++ b/explanation/capacity-planning.md
@@ -56,7 +56,7 @@ When you launch an instance for an application, AMS reserves the number of GPU s
 ```{important}
 GPU slots are used to share GPUs among instances, but they do not impose limits on GPU usage. Therefore, increasing the number of required GPU slots for an application does not guarantee that more GPU resources are allocated to the corresponding application instances. For example, an intensive game that is configured to use one GPU slot might consume more GPU resources than a simple photo gallery app that is configured to use five GPU slots.
 
-There is a default number of GPU slots and GPU encoder slots configured depending on the GPU used but this can be changed. The main purpose of GPU slots is to control the number of instances that are launched on a node that has a GPU installed, which reduces contention for GPU resources.
+A [default number](https://documentation.ubuntu.com/anbox-cloud/reference/ams-configuration/#node-specific-configuration) of GPU slots and GPU encoder slots are configured depending on the GPU used but this value can be changed. The main purpose of GPU slots is to control the number of instances that are launched on a node that has a GPU installed, which reduces contention for GPU resources.
 ```
 (sec-over-committing)=
 ## Over-committing resources

--- a/howto/cluster/configure-nodes.md
+++ b/howto/cluster/configure-nodes.md
@@ -61,7 +61,9 @@ Use the following command to prevent the node from accepting new instances:
 
 GPU slots are used to share GPUs among instances. Each GPU-equipped cluster node is configured with a number of GPU slots and a number of GPU encoder slots. See {ref}`sec-node-configuration` for the default values that are used. Nodes without GPU are configured with 0 GPU slots and 0 GPU encoder slots.
 
-The number of available GPU slots per node depends on the number of Anbox instances with GPU and can be changed when creating an application or an instance. It is used only to manage and assign hardware resources. When using GPU encoding, the number of GPU slots per node is limited by the number of GPU encoder slots, i.e., the number of GPU slots cannot exceed the number of GPU encoder slots. When using software encoding, GPU slots can be more than the GPU encoder slots.
+The number of available GPU slots per node depends on the number of Anbox instances configured to use a GPU. This value can be changed when creating an application or an instance and is used only to manage and assign hardware resources.
+
+When using GPU encoding, for any GPU, the number of GPU slots per node is limited by the number of GPU encoder slots—that is, the number of GPU slots cannot exceed the number of GPU encoder slots. However, when using software encoding, the number of GPU slots can be more than the number of GPU encoder slots for a GPU.
 
 Use the following commands to change the number of GPU slots and GPU encoder slots for a node:
 

--- a/howto/cluster/configure-nodes.md
+++ b/howto/cluster/configure-nodes.md
@@ -61,6 +61,8 @@ Use the following command to prevent the node from accepting new instances:
 
 GPU slots are used to share GPUs among instances. Each GPU-equipped cluster node is configured with a number of GPU slots and a number of GPU encoder slots. See {ref}`sec-node-configuration` for the default values that are used. Nodes without GPU are configured with 0 GPU slots and 0 GPU encoder slots.
 
+The number of GPU slots assigned per node is arbitrary and can be changed when creating an application or an instance. It is used only to manage and assign hardware resources. When using GPU encoding, the number of GPU slots per node is limited by the number of GPU encoder slots, i.e., the number of GPU slots cannot exceed the number of GPU encoder slots. When using software encoding, GPU slots can be more than the GPU encoder slots.
+
 Use the following commands to change the number of GPU slots and GPU encoder slots for a node:
 
     amc node set <node> gpu-slots <number>

--- a/howto/cluster/configure-nodes.md
+++ b/howto/cluster/configure-nodes.md
@@ -61,7 +61,7 @@ Use the following command to prevent the node from accepting new instances:
 
 GPU slots are used to share GPUs among instances. Each GPU-equipped cluster node is configured with a number of GPU slots and a number of GPU encoder slots. See {ref}`sec-node-configuration` for the default values that are used. Nodes without GPU are configured with 0 GPU slots and 0 GPU encoder slots.
 
-The number of GPU slots assigned per node is arbitrary and can be changed when creating an application or an instance. It is used only to manage and assign hardware resources. When using GPU encoding, the number of GPU slots per node is limited by the number of GPU encoder slots, i.e., the number of GPU slots cannot exceed the number of GPU encoder slots. When using software encoding, GPU slots can be more than the GPU encoder slots.
+The number of available GPU slots per node depends on the number of Anbox instances with GPU and can be changed when creating an application or an instance. It is used only to manage and assign hardware resources. When using GPU encoding, the number of GPU slots per node is limited by the number of GPU encoder slots, i.e., the number of GPU slots cannot exceed the number of GPU encoder slots. When using software encoding, GPU slots can be more than the GPU encoder slots.
 
 Use the following commands to change the number of GPU slots and GPU encoder slots for a node:
 

--- a/scripts/ams-configuration.md.j2
+++ b/scripts/ams-configuration.md.j2
@@ -17,7 +17,7 @@ In a cluster setup, there are configuration items that can be customized for eac
 | Name<br/>*(Type, Default)* |  Description            |
 |--------------------------|-------------------------|
 {%- for key, node in nodes.items() %}
-| `{{ key }}`<br/>*({{ node.type }}, {{ node.default or "N/A"}})*{% if node.x_deprecated_since %}<br/>*(Deprecated in {{ node.x_deprecated_since }})*{% endif %}   | {{ node.description }} {% if node.x_docs_ref %} See {ref}`{{ node.x_docs_ref }}`. {% endif %}|
+| `{{ key }}`<br/>*({{ node.type }})*{% if node.x_deprecated_since %}<br/>*(Deprecated in {{ node.x_deprecated_since }})*{% endif %}   | {{ node.description }} {% if node.x_docs_ref %} See {ref}`{{ node.x_docs_ref }}`. {% endif %}|
 {%- endfor %}
 
 See {ref}`howto-configure-cluster-nodes` for instructions on how to set these configuration items.


### PR DESCRIPTION
# Documentation changes

This PR clarifies documentation around our GPU slots and GPU encoder slots assignment. The default values documented per GPU vendor will be corrected via https://github.com/canonical/ams/pull/1227

# Review and preview

Have you reviewed and previewed your documentation updates?
Yes

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

AC-3466