### PR TITLE
66 easyrsa

### DIFF
--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -77,8 +77,8 @@ As a first step, upgrade all infrastructure components. This includes deployed i
 
 Upgrade easyrsa:
 
-    juju refresh internal-ca --revision=66
-    juju refresh etcd-ca --revision=66
+    juju refresh internal-ca --channel=1.31/stable --revision=66
+    juju refresh etcd-ca --channel=1.31/stable --revision=66
 
 ### Upgrade application registry
 


### PR DESCRIPTION
# Documentation changes

Until now, we specify the revision and channel both in the bundles
```
etcd-ca:
  charm: easyrsa
  revision: 66
  channel: stable
  ...
```
However, this potentially introduced a breakage because Juju fetches
the latest resource revision from the channel rather than the compatible
resource revision corresponding to the charm's pinned revision.
Not specifying the channel in the juju refresh command risks breaking
the etcd-ca and internal-ca charms during upgrade.

Therefore, explicitly specify the 1.31/stable channel for the easyrsa
charm during upgrade.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

https://warthogs.atlassian.net/browse/AC-3523