### PR TITLE
Use 1.26/stable as target channel for AAR in upgrade guide

### DIFF
--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -86,7 +86,7 @@ The Anbox Application Registry (AAR) can be upgraded independently of other serv
 
 Upgrade the registry:
 
-    juju refresh --channel=1.24/stable aar
+    juju refresh --channel=1.26/stable aar
 
 ### Upgrade control plane
 


### PR DESCRIPTION
    
Anbox Cloud 1.26 has been released for a while, but the upgrade guide
    still references the 1.24/stable channel for aar upgrades. Hence
updates the guide to use 1.26/stable as the target channel for aar.

# Documentation changes

[Summary of documentation updates]

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]