### PR TITLE
feat: add docs for audience url while using auth0

### DIFF
--- a/howto/install-appliance/setup-oidc/auth0.md
+++ b/howto/install-appliance/setup-oidc/auth0.md
@@ -18,8 +18,9 @@ Auth0 is a flexible, drop-in solution to add authentication services to your app
     - Enable *Allow Refresh Token Rotation*.
     - Select *Save Changes*.
 
-1. Near the top of the *Settings* tab, locate the *Domain* field. Copy the value and prefix it with `https://`. This is your issuer URL.
+1. Copy the following values for the preseed YAML configuration:
+    - Near the top of the *Settings* tab, locate the *Domain* field, and prefix it with `https://`. This is your issuer URL.
+    - From the *Settings* tab, copy the *Client ID*.
+    - Select *Applications > APIs* and copy the *API Audience* value.
 
-1. From the *Settings* tab and copy the *Client ID*.
-
-1. {ref}`Configure the preseed YAML <howto-configure-oidc>` with the client ID and issuer URL values obtained in the previous steps.
+1. {ref}`Configure the preseed YAML <howto-configure-oidc>` with the issuer URL, client ID, and API audience URL values obtained in the previous steps.

--- a/howto/install-appliance/setup-oidc/configure-oidc.md
+++ b/howto/install-appliance/setup-oidc/configure-oidc.md
@@ -5,13 +5,18 @@ It is possible to configure OpenID Connect only when the appliance is initialize
 
 When you have the issuer URL and client ID, set the values in the preseed configuration:
 
+```{note}
+Auth0 additionally requires the audience value.
+```
+
 ```yaml
 $ cat preseed.yaml
 ....
 dashboard:
   oidc:
     issuer: https://my.auth.com
-    client_id: aff32f32ffwfsdfdsfdsg
+    client_id: example_client_id
+    audience: https://example.auth0.com/api/v2/ # for Auth0 only
 ```
 
 To start the initialization process with the preseed configuration, run:


### PR DESCRIPTION
# Documentation changes

- add audience url for when the access token will be used 

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.