### PR TITLE
Remove outdated emugl feature flag

### DIFF
--- a/reference/feature-flags.md
+++ b/reference/feature-flags.md
@@ -89,15 +89,6 @@ To enable the Android container to use a custom Android ID, add the feature flag
 
 Once set, this feature flag will be considered by all newly launched instances.
 
-(sec-gl-async-swap)=
-## `emugl.enable_async_swap_support`
-
-*since 1.21.0*
-
-GL Async swap support is disabled by default for explicit signals of buffer swaps completion. To enable the GL async swap feature, add the feature flag `emugl.enable_async_swap_support` upon application creation. Once the async swap support is enabled, Anbox Cloud will use the host GL driver fence commands and file descriptors to synchronize the finished frames between the host and guest instead fully relying on the host GPU driver to do so. The environment variable `ANBOX_ASYNC_SWAP_ENABLED_PACKAGES` that accepts a comma-separated list of package names can be used to allow certain packages to use the GL async swap feature.
-
-Once set, this feature flag will be considered by all newly launched instances.
-
 ## `webrtc.enable_ice_logging`
 
 *since 1.20.2*


### PR DESCRIPTION
# Documentation changes

Since we have dropped the support for the emugl, listing the `emugl.enable_async_swap_support` feature flag makes no sense now. This PR removed the feature flag listing from our reference documentation.

# Review and preview

Have you reviewed and previewed your documentation updates?
Yes

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

N/A