### PR TITLE
fix(reference): reword the upgrade guide for the haproxy charm

### DIFF
--- a/reference/requirements.md
+++ b/reference/requirements.md
@@ -65,7 +65,7 @@ Charmed Anbox Cloud supports the following Ubuntu versions:
 ```{note}
 Currently, the Juju bundle uses Ubuntu 20.04 for the machine that runs a [HAProxy load balancer](https://charmhub.io/haproxy). However, all supported Anbox Cloud charms use Ubuntu 22.04 or 24.04. So if you are using a load balancer, you should manually upgrade the revision of your HAProxy charm.
 
-In the 1.26.1 release of Anbox Cloud, we plan to switch to the latest version of the HAProxy charm.
+In the 1.27.0 release of Anbox Cloud, we plan to switch to the latest version of the HAProxy charm.
 ```
 
 ### LXD


### PR DESCRIPTION
# Documentation changes

The following PR from anbox-cloud-charms repo

   https://github.com/canonical/anbox-cloud-charms/pull/602

was not backported to the 1.26 release series.

Hence update the target release version for the haproxy charm in the upgrade guide.

[Summary of documentation updates]

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]