### PR TITLE
Fix copyright path for charms

### DIFF
--- a/reference/license-information.md
+++ b/reference/license-information.md
@@ -9,4 +9,4 @@ Anbox Cloud is built using multiple open source software components. This guide 
 | LXD images | Within the LXD image, <br/>`/usr/share/licenses` and `/usr/share/doc/*/copyright`. |
 | Android | In the LXD image instance, <br/> `/var/lib/anbox/android-system/system/etc/NOTICE.xml.gz` |
 | Snaps | `/snap/<SNAP_NAME>/current/` </br>Replace <SNAP_NAME> with the name of the Snap.|
-| Charms | In the instance where the charm is deployed, `/<path/to/charm>/COPYRIGHT` <br/> Replace `<path/to/charm>` with the path where the charm is deployed. Usually, the charm is deployed in `/var/lib/juju/agents/unit-*/charm`. |
+| Charms | In the instance where the charm is deployed, `/<path/to/charm>/copyright` <br/> Replace `<path/to/charm>` with the path where the charm is deployed. Usually, the charm is deployed in `/var/lib/juju/agents/unit-*/charm`. |


### PR DESCRIPTION
# Documentation changes

This PR fixes a minor discrepancy in the copyright path for charms

# Review and preview

Have you reviewed and previewed your documentation updates?
Yes

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

N/A