### PR TITLE
Add CPU compatibility requirement

### DIFF
--- a/reference/requirements.md
+++ b/reference/requirements.md
@@ -21,7 +21,7 @@ The later sections of this topic provide information about the supported Ubuntu 
 
 ### CPU Architecture compatibility
 
-Ensure that your deployment environment uses a CPU architecture officially supported by Android. Unsupported architectures are not compatible with Anbox Cloud and may lead to unexpected behavior or failure to run workloads. For a complete list of supported ABIs (Application Binary Interfaces), refer to the official Android documentation: https://developer.android.com/ndk/guides/abis.
+Ensure that your deployment environment uses a CPU architecture officially supported by Android. Unsupported architectures are not compatible with Anbox Cloud and using them in an Anbox Cloud deployment will lead to errors and unexpected behavior. For a complete list of supported ABIs (Application Binary Interfaces), refer to the official Android documentation: https://developer.android.com/ndk/guides/abis.
 
 ## Requirements for the appliance
 


### PR DESCRIPTION
# Documentation changes

This PR adds the supported Android ABIs as a requirement to Anbox Cloud. This change comes as an outcome to [this conversation](https://chat.canonical.com/canonical/pl/uci4sgwnubyg5qbs3xo3se65wr) about running Anbox Cloud on unsupported CPU architectures.

# Review and preview

Have you reviewed and previewed your documentation updates?
Yes

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

AC-3546