### PR TITLE
Add permission example for system app howto

### DIFF
--- a/howto/port/install-apk-system-app.md
+++ b/howto/port/install-apk-system-app.md
@@ -59,7 +59,17 @@ aam install-system-app \
   --package-name=<package_name>
 ```
 
-The values of the `package-name` and the `permissions` parameters must match the ones defined in the `AndroidManifest.xml` file of the Android project. If the app requires access to hidden Android APIs to function, add the `--access-hidden-api` parameter to the above command. Use `aam install-system-app --help` for details about this command.
+The values of the `package-name` and the `permissions` parameters must match the ones defined in the `AndroidManifest.xml` file of the Android project. For instance, if your `AndroidManifest.xml` contains the following system-level permissions:
+```xml
+...
+    <uses-permission android:name="android.permission.MANAGE_USB" />
+    <uses-permission android:name="android.permission.SET_TIME" />
+    <uses-permission android:name="android.permission.SET_TIME_ZONE" />
+...
+```
+Then, the `permissions` parameter must be: `android.permission.MANAGE_USB,android.permission.SET_TIME,android.permission.SET_TIME_ZONE`.
+
+If the app requires access to hidden Android APIs to function, add the `--access-hidden-api` parameter to the above command. Use `aam install-system-app --help` for details about this command.
 
 The final layout of the addon should look as follows:
 


### PR DESCRIPTION
# Documentation changes

Add a permission list example for the how to related to installed system apps. I needed to use aam and follow this howto recently, and I wasn't sure what the format for permissions was. This clarifies it greatly by introducing a simple example based on one of our test apps.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

Contributes to [AC-3548](https://warthogs.atlassian.net/browse/AC-3548).

[AC-3548]: https://warthogs.atlassian.net/browse/AC-3548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ