### PR TITLE
Add issue template to avoid spam

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,43 @@
+name: Feedback
+description: Provide feedback on the Anbox Cloud documentation.
+title: "[Feedback]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Thank you for taking the time to fill out this feedback!**
+        We really appreciate your input, and it will help us improve the documentation.
+        Please provide an appropriate title at the top of this page.
+
+        ---
+  - type: input
+    id: page_url
+    attributes:
+      label: Page URL
+      description: Please enter the URL of the page you are referring to.
+      placeholder: https://documentation.ubuntu.com/anbox-cloud/
+    validations:
+      required: true
+  - type: checkboxes
+    id: content
+    attributes:
+      label: Select an option
+      description: Please let us know what issue you encountered with the documentation.
+      options:
+        - label: I found what I was looking for
+        - label: I couldn't find what I was looking for
+        - label: I found the information, but it was incorrect
+        - label: I found the information, but it was incomplete
+        - label: I found the information, but it was confusing
+        - label: I encountered a technical issue (e.g., broken link, image not loading)
+  - type: textarea
+    id: description
+    attributes:
+      label: Issue Description
+      description: |
+        Please provide a detailed description of the issue:
+        - What part of the documentation were you trying to use?
+        - What did you expect to happen, and what actually happened?
+        - Any error messages or screenshots you can provide would be very helpful.
+    validations:
+      required: true

--- a/.sphinx/_static/github_issue_links.js
+++ b/.sphinx/_static/github_issue_links.js
@@ -1,0 +1,24 @@
+// if we already have an onload function, save that one
+var prev_handler = window.onload;
+
+window.onload = function() {
+    // call the previous onload function
+    if (prev_handler) {
+        prev_handler();
+    }
+
+    const link = document.createElement("a");
+    link.classList.add("muted-link");
+    link.classList.add("github-issue-link");
+    link.text = "Give feedback";
+    // use the issue template in the .github/feedback.yml file
+    link.href = github_url + "/issues/new?template=feedback.yml";
+    link.target = "_blank";
+
+    const div = document.createElement("div");
+    div.classList.add("github-issue-link-container");
+    div.append(link)
+
+    const container = document.querySelector(".article-container > .content-icon-container");
+    container.prepend(div);
+};


### PR DESCRIPTION
# Documentation changes

This PR adds a predefined template for providing feedback via issues. This will avoid empty issues and spam created by bot and human spammers.

# Review and preview

Have you reviewed and previewed your documentation updates?
N/A

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID] N/A