### PR TITLE
Recommend Juju 3.6 and list Juju 3.0 as minimum version

### DIFF
--- a/explanation/security/charms.md
+++ b/explanation/security/charms.md
@@ -37,9 +37,6 @@ juju list-secrets
 ```
 
 Currently, all Juju secrets are managed by the charms themselves, not by the model. This means you can view them, but you cannot rotate or remove them.
-```{note}
-Juju secrets are disabled in Anbox Cloud deployments based on Juju 2.9, as the secret feature is only available starting from Juju 3.0.
-```
 
 ### Use Juju secrets across model
 

--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -24,17 +24,6 @@ Read the release notes for your target version to learn about important changes 
 Check the [required Juju version](https://documentation.ubuntu.com/anbox-cloud/reference/requirements/#juju).
 If your deployment uses an earlier Juju version, you must upgrade your controller and all models first. See the [Juju documentation](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-models/#upgrade-a-model) for instructions on how to upgrade the Juju controller and all models to a newer Juju version.
 
-```{note}
-
-The following instructions assume that you're using Juju >= 3.1. If you're using Juju 2.9, you have to map the following commands:
-
-| Juju 3.x | Juju 2.9 |
-|----------|----------|
-| `juju refresh` | `juju upgrade-charm` |
-| `juju exec` | `juju run` |
-
-```
-
 ### Upgrade OS
 
 Before you run the upgrade of the charms, you should make sure all packages on the machines that are part of the deployment are up-to-date. To do so, run the following commands on each machine:

--- a/reference/deprecation-notices.md
+++ b/reference/deprecation-notices.md
@@ -11,7 +11,7 @@ The [AMS node controller charm](https://charmhub.io/ams-node-controller) is depr
 ## Juju 2.9
 *Deprecated in 1.25.1* ; *Unsupported in 1.27.0*
 
-Juju 2.9 is deprecated as of 1.25.1. Upgrade to Juju 3.0 instead. See [Juju upgrade documentation](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-your-deployment/upgrade-your-deployment/) for detailed instructions.
+Juju 2.9 is deprecated as of 1.25.1. Upgrade to Juju 3.6 instead. See [Juju upgrade documentation](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-your-deployment/upgrade-your-deployment/) for detailed instructions.
 
 For all new deployments, use the Juju snap from 3/stable or the latest/stable channel.
 

--- a/reference/requirements.md
+++ b/reference/requirements.md
@@ -79,15 +79,17 @@ Charmed Anbox Cloud requires LXD version >= 5.0.
 (sec-juju-version-requirements)=
 ### Juju
 
-The charmed Anbox Cloud requires [Juju 2.9 or later](https://juju.is/) to manage the different components and their dependencies. You can install Juju with the following command:
+The charmed Anbox Cloud requires a minimum of [Juju 3.0 or later](https://juju.is/) to manage the different components and their dependencies.
 
-    snap install --classic --channel=3.1/stable juju
+If you want to manage user secrets, use Juju 3.3 or later.
 
-If you wish to install a different version, replace `3.1` in the command with the desired version.
+We recommend using Juju 3.6, so that you will be using the latest version of Juju and can manage user secrets. See [Juju documentation](https://documentation.ubuntu.com/juju/latest/howto/manage-secrets/) for more information about managing secrets.
 
-To switch to the 2.9 series, use the following command:
+You can install Juju with the following command:
 
-    snap refresh --channel=2.9/stable juju
+    snap install --classic --channel=3.6/stable juju
+
+If you wish to install a different version, replace `3.6` in the command with the desired version.
 
 See the [Juju documentation](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-juju/#install-juju) for more information.
 


### PR DESCRIPTION
# Documentation changes

This PR drops Juju 2.9 support and adds Juju 3.0 as the minimum required version and Juju 3.6 as the recommended version.

# Review and preview

Have you reviewed and previewed your documentation updates?
Yes

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

AC-3552