### PR TITLE
Exclude 404 and other unwanted URLS from sitemap

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -190,6 +190,14 @@ sitemap_url_scheme = "{link}"
 html_static_path = [".sphinx/_static"]
 templates_path = [".sphinx/_templates"]
 
+# Exclude unnecessary URLs for better indexing
+
+sitemap_excludes = [
+    "genindex/",
+    "404/",
+    "search/",
+]
+
 
 #############
 # Redirects #


### PR DESCRIPTION
# Documentation changes

This PR excludes the following unnecessary URLs from the sitemap, providing better indexing:

- https://documentation.ubuntu.com/anbox-cloud/genindex/
- https://documentation.ubuntu.com/anbox-cloud/404/
-https://documentation.ubuntu.com/anbox-cloud/search/

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
Yes

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

AC-3607