### PR TITLE
fix(howto): update "Access an Android instance" after ADB share overhaul [WD-24633]

### DIFF
--- a/howto/android/access-android-instance.md
+++ b/howto/android/access-android-instance.md
@@ -51,7 +51,7 @@ The output returns the command you need to run next from your host machine: `anb
 
 Copy this output. The `<connection_url>` is a presigned URL that establishes a single ADB connection — if multiple users attempt to use the same presigned URL, any existing ADB connection will be interrupted and only the last request succeeds.
 
-> If you are using the dashboard, locate your running instance and click *Connect ADB > Authorise* to get the command with the presigned URL.
+> If you are using the dashboard, locate your running instance and click *Connect ADB > Authorize* to create your first ADB share. After that, you can use the show/hide toggle in the ADB share table to display and copy the command with the presigned URL.
 
 Now, create the connection from the terminal of your host machine (where ADB is installed). Run:
 


### PR DESCRIPTION
# Documentation changes

Small reword of a dashboard-related section of the "Access an Android instance" how-to, following the recent overhaul to ADB share management in the dashboard.

Note that this should not be merged before the milestone release for ADB share management (which is 1.28).

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

WD-24633