### PR TITLE
Add a note for automatic even size adjustment for display size

### DIFF
--- a/howto/application/stream-application.md
+++ b/howto/application/stream-application.md
@@ -21,6 +21,11 @@ To further customize the streaming configuration, use the following arguments:
 For example, to create an instance with a 1080p resolution, a frame rate of 60 and a DPI of 120, run:
 
     amc launch --enable-streaming --display-size=1920x1080 --display-density=120 --fps=60 <application_id>
+
+```{note}
+If you provide a display width or height that is an odd number, Anbox will automatically adjust it to the nearest even number by increasing it by 1 for proper video encoding.
+```
+
 :::
 :::{tab-item} Dashboard
 :sync: dashboard

--- a/howto/instance/create-instance.md
+++ b/howto/instance/create-instance.md
@@ -98,6 +98,10 @@ If you want to to further customize the streaming configuration such as display 
 
     amc launch --enable-streaming --display-size=1920x1080 --display-density=120 --fps=60 ...
 
+```{note}
+If you provide a display width or height that is an odd number, Anbox will automatically adjust it to the nearest even number by increasing it by 1 for proper video encoding.
+```
+
 ## Launch an instance with a specific name
 
 *since 1.22.0*


### PR DESCRIPTION
# Documentation changes

With the recent change in anbox, we now automatically adjust the display
size if a display width or height that is an odd number for proper video encoding.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]