### PR TITLE
Schedule canonical/create-pull-request action updates on monday

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,15 @@
   ],
   "packageRules": [
     {
+      "description": "Schedule canonical/create-pull-request updates on the first day of each week to decrease noise.",
+      "matchPackageNames": [
+        "canonical/create-pull-request"
+      ],
+      "schedule": [
+        "on the first day of the week"
+      ]
+    },
+    {
       "groupName": "GitHub actions",
       "matchManagers": [
         "github-actions"


### PR DESCRIPTION
# Documentation changes

Schedule canonical/create-pull-request action updates on Monday to decrease noise.

# Review and preview

N/A

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

N/A