### PR TITLE
Upgrade nats from 2/stable channel

### DIFF
--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -91,12 +91,12 @@ To upgrade all charms, run the following commands:
     juju refresh --channel=1.27/stable anbox-stream-gateway
     juju refresh --channel=1.27/stable anbox-stream-agent
     juju refresh --channel=1.27/stable coturn
-    juju refresh --channel=latest/stable nats
+    juju refresh --channel=2/stable nats
 
 ```{note}
 Since the NATS charm has been overhauled to use the modern charm framework (Ops Framework), a new charm source is needed to upgrade to its latest version. The charm source can be switched or replaced using the following command:
 
-    juju refresh nats --switch=nats  --channel=stable
+    juju refresh nats --switch=nats  --channel=2/stable
 ```
 
 ### Upgrade AMS


### PR DESCRIPTION
# Documentation changes

In the ugprade-anbox charpter, since 1.28 release, we're going to
use NATs charm from 2/stable channel, where comes with features like
  - relate with self-signed-certificate TLS charm
  - secret support

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]