### PR TITLE
Drop ams node controller charm entirely

### DIFF
--- a/explanation/security/charms.md
+++ b/explanation/security/charms.md
@@ -16,7 +16,6 @@ The following charms for Anbox Cloud make use of cryptographic technology for cr
 
 * [`ams`](https://charmhub.io/ams)
 * [`ams-lxd`](https://charmhub.io/ams-lxd)
-* [`ams-node-controller`](https://charmhub.io/ams-node-controller)
 * [`anbox-stream-gateway`](https://charmhub.io/anbox-stream-gateway)
 * [`anbox-stream-agent`](https://charmhub.io/anbox-stream-agent)
 * [`anbox-cloud-dashboard`](https://charmhub.io/anbox-cloud-dashboard)

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -76,9 +76,6 @@ applications:
   ams:
     options:
       ua_token: <your token>
-  ams-node-controller:
-    options:
-      ua_token: <your token>
   lxd:
     options:
       ua_token: <your token>
@@ -98,9 +95,6 @@ For the `anbox-cloud-core` bundle, the `ua.yaml` file should look like this:
 ```yaml
 applications:
   ams:
-    options:
-      ua_token: <your token>
-  ams-node-controller:
     options:
       ua_token: <your token>
   lxd:

--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -181,11 +181,10 @@ Finally after all the upgrades finish and the nodes are healthy, run:
 
 where `<node_name>` refers to the LXD node name stored within AMS.
 
-As a subordinate charm deployed alongside the LXD charm, and following the [deprecation of the node controller charm](https://documentation.ubuntu.com/anbox-cloud/reference/deprecation-notices/#node-controller-charm) in the Anbox Cloud 1.26.0 release, the node controller will no longer manage port forwarding for service exposure on Anbox instances.
+As a subordinate charm deployed alongside the LXD charm, and following the [deprecation of the node controller charm](https://documentation.ubuntu.com/anbox-cloud/reference/deprecation-notices/#node-controller-charm) in the Anbox Cloud 1.28.0 release is no longer supported, and has been removed from the release. Therefore, it should be removed from the deployment:
 
-For security reasons, any ports previously exposed by the node controller will be closed after upgrading it via:
-
-       juju refresh --channel=1.27/stable ams-node-controller
+       juju remove-relation ams-node-controller lxd
+       juju remove-application ams-node-controller --no-prompt
 
 If there is no need to expose services from Anbox instances, revokes the application's exposure to the public network after the AMS node controller is upgraded:
 


### PR DESCRIPTION
# Documentation changes

- Drop the reference of node-controller in the doc
- Polish upgrade guide for the removal of the node controller charm from the deployment

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

AC-3409