### PR TITLE
feat: docuemnt changed OIDC preseed configuration

### DIFF
--- a/howto/anbox/control-ams-remotely.md
+++ b/howto/anbox/control-ams-remotely.md
@@ -95,7 +95,7 @@ You would have copied the issuer URL, client ID and audience API values when you
 
 To configure AMC to connect to the remote AMS:
 
-    amc remote add <your remote name> https://<IP address of the AMS machine>:8444 --auth-type oidc
+    amc remote add <your remote name> https://<IP address of the AMS machine>:8444 --auth-type
 
 ```{tip}
 If you haven't changed the port AMS is listening on, it's 8444 by default.

--- a/howto/setup-custom-idp/configure-oidc.md
+++ b/howto/setup-custom-idp/configure-oidc.md
@@ -12,22 +12,33 @@ Auth0 additionally requires the audience value.
 ```yaml
 $ cat preseed.yaml
 ....
-dashboard:
-  oidc:
-    issuer: https://my.auth.com
-    client_id: example_client_id
-    audience: https://example.auth0.com/api/v2/ # for Auth0 only
+oidc:
+  issuer: https://my.auth.com
+  client_id: example_client_id
+  audience: https://example.auth0.com/api/v2/ # for Auth0 only
 ```
 
 To start the initialization process with the preseed configuration, run:
 
     sudo anbox-cloud-appliance init --preseed < preseed.yaml
 
-When the initialization is complete, to register a new user, run:
+When the initialization is complete, to register a new user with the dashboard, run:
 
     sudo anbox-cloud-appliance dashboard register <email address>
 
 This prints a URL to complete the registration. Access that URL and complete the registration. Finally, log in to access the dashboard user interface.
+
+You can also register the same user with AMS to provide access to it via OIDC:
+
+    amc auth identity create oidc/<email address>
+
+In addition to creating the user you need to add it to a group to give permissions for access. To make the user an admin run:
+
+    amc auth identity group add <identity id> --groups admin
+
+Afterwards the user can access AMS by running
+
+    amc remote add test https://<address>:8444 --auth-type=oidc
 
 ## Related topics
 


### PR DESCRIPTION
# Documentation changes

We now allow configuring OIDC for both AMS and dashboard at the same time.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

https://warthogs.atlassian.net/browse/AC-3791