### PR TITLE
feat: add how-to for instance publishing

### DIFF
--- a/howto/images/index.md
+++ b/howto/images/index.md
@@ -11,6 +11,7 @@ The following how-to guides are available for operations on images:
 :titlesonly:
 configure-image-server
 add-image
+publish-instance-as-image
 delete-image
 use-specific-release
 ```

--- a/howto/images/publish-instance-as-image.md
+++ b/howto/images/publish-instance-as-image.md
@@ -1,0 +1,85 @@
+(howto-publish-instance-as-image)=
+# Publish an instance as an image
+
+Publishing an instance as an image allows you to capture the current state of an instance, including any file system modifications, and create a reusable image from it. This is useful for creating custom base images with pre-installed software, configuration changes, or other modifications.
+
+Consider these best practices before publishing instances as images:
+
+* Remove any temporary files, logs, sensitive data before publishing the instance
+* Test the published image by launching an instance based on it and verifying all the modifications are working as intended.
+* Use meaningful names for your images to indicate the purpose and modifications they contain.
+
+## Publish an instance
+
+To publish an instance as an image, follow these steps:
+
+### Create and prepare an instance
+
+First, create a new instance from an existing image:
+
+    amc launch --name=test0 jammy:android15:amd64
+
+Wait until the instance is up and running. You can check the instance status with:
+
+    amc list
+
+### Modify the instance
+
+Make any modifications you want to include in the new image. For example, you can access the instance and modify files:
+
+    amc shell test0
+
+Inside the instance, you can install additional software, modify configuration files, add custom files or data and make any other changes you want in your snapshot.
+
+For example, install additional APT packages
+
+    sudo apt install -y adb
+
+Exit the instance shell when you're done.
+
+### Publish the instance
+
+Publish the instance as a new image:
+
+    amc publish test0 --name test --force
+
+The `--force` flag stops the instance automatically if it is still running. Without this flag, you must stop the instance manually before publishing.
+
+```{note}
+The publishing process can take some time depending on the size of the instance and the modifications made.
+```
+
+### Verify that the image was created
+
+Check that the instance is now stopped:
+
+    amc show test0
+
+Verify that the new image exists in the image list:
+
+    amc image ls
+
+You should see the `test` image in the output.
+
+### Test the published image
+
+Launch a new instance from the published image:
+
+    amc launch --name test1 test
+
+Once the instance is running, verify that your modifications are present:
+
+    amc shell test1
+
+Check for the test file you created earlier:
+
+    cat /tmp/test-file.txt
+
+You should see the content "This is a test modification", confirming that the file system modifications were preserved in the published image.
+
+## Related topics
+
+* {ref}`howto-create-instance`
+* {ref}`howto-stop-instance`
+* {ref}`howto-add-image`
+* {ref}`howto-delete-image`


### PR DESCRIPTION
# Documentation changes

This documents instance publishing as defined in [AC180](https://docs.google.com/document/d/1mMdhKC457kGbYaaQv8D9NArMhGQQ0UbXJf_6gOxP-rI/edit).

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

https://warthogs.atlassian.net/browse/AC-3828