### PR TITLE
Fix the image publishing

### DIFF
--- a/howto/images/publish-instance-as-image.md
+++ b/howto/images/publish-instance-as-image.md
@@ -71,11 +71,12 @@ Once the instance is running, verify that your modifications are present:
 
     amc shell test1
 
-Check for the test file you created earlier:
+List Android devices within Anbox instance with adb:
 
-    cat /tmp/test-file.txt
+    adb devices
+    List of devices attached
+    emulator-5558   device
 
-You should see the content "This is a test modification", confirming that the file system modifications were preserved in the published image.
 
 ## Related topics
 


### PR DESCRIPTION
# Documentation changes

 Fix the way of detection the change of image after publishing

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]