### PR TITLE
fix(access-android-instance): adding back embedded YT video

### DIFF
--- a/howto/android/access-android-instance.md
+++ b/howto/android/access-android-instance.md
@@ -3,6 +3,18 @@
 
 As an Android application developer, you need access to the Android instance when developing and debugging applications. Depending on the kind of access you would like to the Android instance, you can use [anbox-connect](https://snapcraft.io/anbox-connect) to connect over the network from a remote machine or use {term}`anbox-shell` to connect from within the Anbox instance.
 
+Here's a video demonstration of how to access an Android instance securely using anbox-connect:
+
+```{raw} html
+<iframe width="640" height="360"
+        src="https://www.youtube.com/embed/bkmK2M9nlb4"
+        title="Debug an Android application with Android studio"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen>
+</iframe>
+```
+
 This guide uses the Anbox Cloud Appliance to demonstrate both ways of connecting to an Android instance. So if you don't have an existing Anbox Cloud deployment already, first {ref}`install the appliance <tut-installing-appliance>`.
 
 ## Private access: Connect to the Android instance using anbox-shell


### PR DESCRIPTION
# Documentation changes

Added back the embedded YouTube video for the connect ADB feature. See the Jira ticket below for the full context.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

https://warthogs.atlassian.net/browse/CMMNCTNS-4722