### PR TITLE
Update configuration for migrating to new domain

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -179,7 +179,7 @@ slug = 'anbox-cloud'
 # Base URL of RTD hosted project
 # Include the trailing slash in the URL, it makes a difference
 
-html_baseurl = 'https://documentation.ubuntu.com/anbox-cloud/'
+html_baseurl = 'https://canonical.com/anbox-cloud/docs'
 
 # URL scheme; {link} is the default configuration
 


### PR DESCRIPTION
# Documentation changes

This PR is set the configuration to migrate our documentation from documentation.ubuntu.com/anbox-cloud/docs to canonical.com/anbox-cloud/docs


# Review and preview

Have you reviewed and previewed your documentation updates?
Yes

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

N/A