### PR TITLE
Revert "Update configuration for migrating to new domain"

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -179,7 +179,7 @@ slug = 'anbox-cloud'
 # Base URL of RTD hosted project
 # Include the trailing slash in the URL, it makes a difference
 
-html_baseurl = 'https://canonical.com/anbox-cloud/docs'
+html_baseurl = 'https://documentation.ubuntu.com/anbox-cloud/'
 
 # URL scheme; {link} is the default configuration
 


### PR DESCRIPTION
# Documentation changes

This reverts commit 02a368f3d7d1a14ced0041671418b0e4790e5d37 because the regex in the HA proxy configuration does not accept the '-' in 'anbox-cloud'. We need IS team's help to fix that.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]