### PR TITLE
Clarify ready state for application

### DIFF
--- a/explanation/applications.md
+++ b/explanation/applications.md
@@ -25,6 +25,8 @@ The following table lists the different statuses that an application can have de
 | `error` | The application has encountered an error. |
 | `unknown` | A possible error occurred and the real state of the application cannot be determined. |
 
+The application status reflects the status of its latest application version.
+
 If you encounter the `error` or the `unknown` status, see if you can identify the base instance and troubleshoot using the instance logs (See {ref}`howto-view-instance-logs`). If you are still unable to figure out the issue, [file a bug](https://bugs.launchpad.net/anbox-cloud) with the {ref}`relevant instance logs <howto-view-instance-logs>`.
 
 


### PR DESCRIPTION
# Documentation changes

Clarify that an application stays in the ready state even if a new version is initializing.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

Contributes to [AC-4070](https://warthogs.atlassian.net/browse/AC-4070) and fixes [LP#2133867](https://bugs.launchpad.net/anbox-cloud/+bug/2133867)

[AC-4070]: https://warthogs.atlassian.net/browse/AC-4070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ