### PR TITLE
chore(upgrade): pin charmed-etcd revision to 149

### DIFF
--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -71,7 +71,7 @@ Upgrade [self-signed-certificates](https://charmhub.io/self-signed-certificates)
 
 Upgrade [charmed-etcd](https://charmhub.io/charmed-etcd) operator:
 
-    juju refresh etcd --channel=3.6/stable --revision=144
+    juju refresh etcd --channel=3.6/stable --revision=149
 
 ```{note}
 For version Anbox Cloud 1.28.2 and earlier, deployments still use legacy charms. If you are upgrading from these older Anbox Cloud versions, use the following legacy revisions:


### PR DESCRIPTION
    
Following the release of new charmed-etcd revisions and snaps on the
3.6/stable channel, this change bumps the charmed-etcd revision to
149. This ensures alignment with the latest charm revisions on the
ubuntu@24.04 base.

# Documentation changes

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

https://warthogs.atlassian.net/browse/AC-4221