### PR TITLE
fix: add documentation for new log level option

### DIFF
--- a/reference/api-reference/anbox-https-api.md
+++ b/reference/api-reference/anbox-https-api.md
@@ -98,15 +98,48 @@ Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.
           "sensor_support",
           "tracing_support",
           "vhal_support"
+          "pprof",
+          "metrics",
+          "log_level",
+          "telephony"
         ],
         "api_status": "stable",       # API implementation status (one of, development, stable or deprecated)
-        "api_version": "1.0"          # The API version as a string
+        "api_version": "1.0",         # The API version as a string
+        "log_level": "info"
     },
     "status": "Success",
     "status_code": 200,
     "type": "sync"
 }
 ```
+
+#### PATCH
+
+ * Description: Update the server configuration
+ * Operation: sync
+ * Return: standard return value or standard error
+
+Input:
+
+```json
+{
+    "log_level": "warning"
+}
+```
+
+- Possible values for `log_level` are: `trace`, `debug`, `info`, `warning`, `error`, `fatal`
+
+Return value:
+
+```json
+{
+    "status": "Success",
+    "status_code": 200,
+    "type": "sync"
+}
+```
+
+Example: `curl -X PATCH --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0 --data '{"log_level":"warning"}'`:
 
 (sec-anbox-https-api-location)=
 ### `/1.0/location`


### PR DESCRIPTION
# Documentation changes

Document missing support to change the Anbox log level via the HTTP API

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

n/a