### PR TITLE
Bump dependency cooldown to 90 days

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
     ":ignoreUnstable",
     "group:allNonMajor"
   ],
-  "minimumReleaseAge": "7 days",
+  "minimumReleaseAge": "90 days",
   "minimumReleaseAgeBehaviour": "timestamp-optional",
   "prCreation": "not-pending",
   "packageRules": [


### PR DESCRIPTION
# Documentation changes

Bump dependency cooldown to 90 days to align with other repos.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

N/A