### PR TITLE
Fix manpage link to point to noble

### DIFF
--- a/howto/stream/exchange-oob-data.md
+++ b/howto/stream/exchange-oob-data.md
@@ -93,7 +93,7 @@ At the same time, a Unix domain socket is created under the `/run/user/1000/anbo
 - Receive data sent from a web client over the data channel and forward it to an Android application.
 - Receive data sent from an Android application and forward it to a web client over the data channel.
 
-To simulate data transmission between the Anbox runtime and the web client, you can use the [`socat`](https://manpages.ubuntu.com/manpages/bionic/man1/socat.1.html) command to connect the Unix domain socket and perform bidirectional asynchronous data sending and receiving:
+To simulate data transmission between the Anbox runtime and the web client, you can use the [`socat`](https://manpages.ubuntu.com/manpages/noble/man1/socat.1.html) command to connect the Unix domain socket and perform bidirectional asynchronous data sending and receiving:
 
 1. Install the `socat` package:
 


### PR DESCRIPTION
# Documentation changes

For some reason, all links pointing to versions older than jammy are not working anymore.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

N/A