### PR TITLE
Remove a13 and a12 from list of available images

### DIFF
--- a/reference/provided-images.md
+++ b/reference/provided-images.md
@@ -19,12 +19,6 @@ The following table lists supported images available on the official image serve
 | `jammy:aaos14:arm64`        | AAOS     | 14              | 22.04          | 1.24.0 |
 | `jammy:android14:amd64`     | AOSP     | 14              | 22.04          | 1.24.0 |
 | `jammy:android14:arm64`     | AOSP     | 14              | 22.04          | 1.24.0 |
-| `jammy:aaos13:amd64`        | AAOS     | 13              | 22.04          | 1.21.0 |
-| `jammy:aaos13:arm64`        | AAOS     | 13              | 22.04          | 1.21.0 |
-| `jammy:android13:amd64`     | AOSP     | 13              | 22.04          | 1.16.0 |
-| `jammy:android13:arm64`     | AOSP     | 13              | 22.04          | 1.16.0 |
-| `jammy:android12:amd64`     | AOSP     | 12              | 22.04          | 1.14.0 |
-| `jammy:android12:arm64`     | AOSP     | 12              | 22.04          | 1.14.0 |
 
 ## Support for Anbox Cloud images
 


### PR DESCRIPTION
# Documentation changes

Remove A13 and A12 since these are not available anymore.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,
1. Run `make spelling` and fix any spelling issues.
2. Run `make linkcheck` and fix any broken links.
3. Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

N/A