### PR TITLE
fix: inconsistent list markers across the docs

### DIFF
--- a/contribute/anbox-style-guide.md
+++ b/contribute/anbox-style-guide.md
@@ -11,26 +11,26 @@ Anbox Cloud documentation is written in a combination of MyST and Markdown synta
 
 ## General
 
-* Use inclusive language and assume a friendly tone rather than an overly formal one.
-* Use monospaced font for:
+- Use inclusive language and assume a friendly tone rather than an overly formal one.
+- Use monospaced font for:
   * Inline code and code blocks
   * File names
   * References to utilities/programs
   * File and directory paths
   * Command options
-* Avoid long sentences. If it is a complex statement, try and break it down into multiple sentences. While the Canonical copy style guide has guidance about hyphens when joining words, it does not elaborate much on prefixes.
-* Use bold and italics very sparingly. Use italics for user interface fields and bold for UI elements that call for action.
-* Use single spaces between sentences.
-* Use angle brackets to indicate variables.
-* All extra white space should be removed, especially at the end of lines.
-* Add a new line at the end of the file.
+- Avoid long sentences. If it is a complex statement, try and break it down into multiple sentences. While the Canonical copy style guide has guidance about hyphens when joining words, it does not elaborate much on prefixes.
+- Use bold and italics very sparingly. Use italics for user interface fields and bold for UI elements that call for action.
+- Use single spaces between sentences.
+- Use angle brackets to indicate variables.
+- All extra white space should be removed, especially at the end of lines.
+- Add a new line at the end of the file.
 
 ## Section titles
 
-* Insert a blank line after a section title.
-* Do not skip heading levels when creating sections.
-* Avoid using multiple section titles sequentially without any text between them.
-* Avoid manual HTML anchors, links to section titles can be picked up from the page-level table of contents.
+- Insert a blank line after a section title.
+- Do not skip heading levels when creating sections.
+- Avoid using multiple section titles sequentially without any text between them.
+- Avoid manual HTML anchors, links to section titles can be picked up from the page-level table of contents.
 
 ## Cross references
 
@@ -40,11 +40,11 @@ The target names must be unique for each page and topic.
 
 Anbox Cloud documentation adheres to the following convention when naming explicit targets:
 
-* Reference: `ref-xxx-yyy`
-* Explanation: `exp-xxx-yyy`
-* How-to guides: `howto-xxx-yyy`
-* Tutorials: `tut-xxx-yyy`
-* Section targets in any topic: `sec-xxx-yyy`
+- Reference: `ref-xxx-yyy`
+- Explanation: `exp-xxx-yyy`
+- How-to guides: `howto-xxx-yyy`
+- Tutorials: `tut-xxx-yyy`
+- Section targets in any topic: `sec-xxx-yyy`
 
 This helps in maintaining consistency in target naming and creating unique target names.
 
@@ -54,10 +54,10 @@ While admonishments can be useful to convey important information, they can be a
 
 Keeping the types of admonishments to a minimum could be simplistic and also reduce cognitive overload on the reader. Stick to the following types of admonishments:
 
-* Note
-* Important
-* Tip
-* Caution
+- Note
+- Important
+- Tip
+- Caution
 
 ## Language
 
@@ -73,27 +73,27 @@ Use hyphens when the starting letter of a word is in capital case or starts with
 
 **Examples:**
 
-* `Pre-employment`
-* `Preconfigure`
+- `Pre-employment`
+- `Preconfigure`
 
 ## Terminology
 
-* It’s always “Anbox Cloud Appliance” when used in full form and “appliance” when used generically.
-* Always use product name in full form with capitalization - "Anbox Cloud".
-* Within the context of Anbox Cloud, such as AMS, you can use the term "Anbox images" or "Anbox instances". When documenting about LXD images or containers that contain Anbox specific configuration from a big picture point of view,such as the architecture, use the term as "LXD images" or "LXD containers". When there is scope for ambiguity, elaborate and use as "LXD images with Anbox Cloud configuration".
-* Use *charmed deployment* vs *appliance* to differentiate the [variants](https://documentation.ubuntu.com/anbox-cloud/explanation/anbox-cloud/#variants) of Anbox Cloud.
-* Use *Upgrade* to denote a change that results in a different product version and *Update* for making changes to configuration or deployment but don't change the version of the product.
-* Use the term 'page' to describe the different pages of the web dashboard.
+- It’s always “Anbox Cloud Appliance” when used in full form and “appliance” when used generically.
+- Always use product name in full form with capitalization - "Anbox Cloud".
+- Within the context of Anbox Cloud, such as AMS, you can use the term "Anbox images" or "Anbox instances". When documenting about LXD images or containers that contain Anbox specific configuration from a big picture point of view,such as the architecture, use the term as "LXD images" or "LXD containers". When there is scope for ambiguity, elaborate and use as "LXD images with Anbox Cloud configuration".
+- Use *charmed deployment* vs *appliance* to differentiate the [variants](https://documentation.ubuntu.com/anbox-cloud/explanation/anbox-cloud/#variants) of Anbox Cloud.
+- Use *Upgrade* to denote a change that results in a different product version and *Update* for making changes to configuration or deployment but don't change the version of the product.
+- Use the term 'page' to describe the different pages of the web dashboard.
 Example: You can see all the instances you created on the *Instances* page.
 
 ## Images and screenshots
 
 While images and screenshots are very helpful in visual appeal and getting the message across to the readers, they can be hard to maintain and cause overhead if they change too often. So use images or screenshots only when they:
 
-* Do not change often requiring updates for every release.
-* Explain the concept better than text or it should strongly reinforce the concept explained in the text.
-* Add to the reader’s understanding rather than just providing a step by step visual of the user interface.
-* Break the monotony of continuous text information when trying to accomplish a tough procedure.
+- Do not change often requiring updates for every release.
+- Explain the concept better than text or it should strongly reinforce the concept explained in the text.
+- Add to the reader’s understanding rather than just providing a step by step visual of the user interface.
+- Break the monotony of continuous text information when trying to accomplish a tough procedure.
 
 Simple images can be made using an image editor of your choice or you can use [diagrams.net](https://www.drawio.com/).
 

--- a/explanation/aaos.md
+++ b/explanation/aaos.md
@@ -4,7 +4,7 @@
 Since the 1.21.0 release, in addition to providing images based on the Android Open Source Project (AOSP), Anbox Cloud also offers images based on the [Android Automotive OS (AAOS)](https://source.android.com/docs/automotive/start/what_automotive). These images help run Android in automotive infotainment systems at scale.
 
 ```{important}
-* The Anbox Cloud AAOS images are based on Android Automotive and *not* Android Auto. For understanding the differences between the two, see upstream documentation on [Android Automotive and Android Auto](https://source.android.com/docs/automotive/start/what_automotive#android-automotive-android-auto).
+- The Anbox Cloud AAOS images are based on Android Automotive and *not* Android Auto. For understanding the differences between the two, see upstream documentation on [Android Automotive and Android Auto](https://source.android.com/docs/automotive/start/what_automotive#android-automotive-android-auto).
 ```
 
 The [Vehicle Abstraction Layer (VHAL)](https://source.android.com/docs/automotive/vhal) enables Android Automotive to communicate with and control the different vehicle hardware controls.
@@ -17,4 +17,4 @@ Anbox Cloud offers an [Anbox-specific VHAL HIDL interface](https://github.com/ca
 
 ## Related topics
 
-* {ref}`ref-aosp-aaos`
+- {ref}`ref-aosp-aaos`

--- a/explanation/aar.md
+++ b/explanation/aar.md
@@ -11,18 +11,18 @@ An imported application is immutable and cannot be changed other than through th
 
 AMS can act in two different roles, `publisher` or `client` when working with an AAR. A single AMS instance can act either as a publisher or as a client, but not both.
 
-* `publisher`:
+- `publisher`:
 
     The `publisher` role allows both read and write access to the AAR. AMS instances registered as publishers act in `push` mode and are meant to push new applications and their updates to the AAR so that they can be consumed by regular read-only clients.
 
     We recommend that you have one `publisher` per architecture, for example, one for `amd64` and one for `arm64`. The publishers should not be used to host regular instances but only to manage applications. Regular users should be directed to AMS instances acting as clients.
 
-* `client`:
+- `client`:
 
     The `client` role allows only read access to the AAR. AMS instances registered as clients consume the applications pushed by the publishers.
 
 ## Related topics
 
-* {ref}`howto-deploy-aar`
-* {ref}`howto-configure-aar`
-* {ref}`howto-revoke-aar`
+- {ref}`howto-deploy-aar`
+- {ref}`howto-configure-aar`
+- {ref}`howto-revoke-aar`

--- a/explanation/addons.md
+++ b/explanation/addons.md
@@ -29,7 +29,7 @@ For base instances, if your addon needs additional tools and dependencies during
 
 ## Related topics
 
-* {ref}`exp-instances`
-* {ref}`howto-create-addon`
-* {ref}`howto-addons`
-* {ref}`ref-hooks`
+- {ref}`exp-instances`
+- {ref}`howto-create-addon`
+- {ref}`howto-addons`
+- {ref}`ref-hooks`

--- a/explanation/ams.md
+++ b/explanation/ams.md
@@ -54,6 +54,6 @@ If your client requires the AMS certificate, you can find it in `/var/snap/ams/c
 
 ## Related topics
 
-* {ref}`exp-aar`
-* {ref}`howto-access-ams-remote`
-* {ref}`ref-ams-configuration`
+- {ref}`exp-aar`
+- {ref}`howto-access-ams-remote`
+- {ref}`ref-ams-configuration`

--- a/explanation/anbox-cloud.md
+++ b/explanation/anbox-cloud.md
@@ -65,30 +65,30 @@ The core stack contains one or more Anbox subclusters, a Juju controller, and th
 
 Inside each Anbox subcluster, the following components are present:
 
-* **Anbox Management Service (AMS)** - AMS is the management tool for Anbox Cloud. It handles all aspects of the application and instance life cycle, including application and image update, while ensuring high density, performance, and fast startup times.
+- **Anbox Management Service (AMS)** - AMS is the management tool for Anbox Cloud. It handles all aspects of the application and instance life cycle, including application and image update, while ensuring high density, performance, and fast startup times.
 
   Users can connect to AMS via CLI or HTTP API calls on port 8444. AMS is installed as a snap on each of the control nodes and interacts with the instances, requesting and releasing resources as per demand.
 
-* **Anbox Management Client (AMC)**  - You can choose to install AMC on other machines to {ref}`control AMS remotely <howto-access-ams-remote>`, but it is generally installed together with AMS. A developer or system administrator will manage AMS through the command line interface (AMC) or through custom-built tools interacting with the AMS HTTP API.
+- **Anbox Management Client (AMC)**  - You can choose to install AMC on other machines to {ref}`control AMS remotely <howto-access-ams-remote>`, but it is generally installed together with AMS. A developer or system administrator will manage AMS through the command line interface (AMC) or through custom-built tools interacting with the AMS HTTP API.
 
-* **etcd** - etcd is the database that is used to store the data managed by AMS. It provides a reliable way to store data across a cluster of machines. It gracefully handles primary node selections when a network is split into subnets and will tolerate machine failure. For more information, see [etcd](https://etcd.io/).
+- **etcd** - etcd is the database that is used to store the data managed by AMS. It provides a reliable way to store data across a cluster of machines. It gracefully handles primary node selections when a network is split into subnets and will tolerate machine failure. For more information, see [etcd](https://etcd.io/).
 
-* **Control node** - Control node is the machine on which the AMS, AMC, and etcd are installed. These three components inside the control node make up the management layer of Anbox Cloud.
+- **Control node** - Control node is the machine on which the AMS, AMC, and etcd are installed. These three components inside the control node make up the management layer of Anbox Cloud.
 
 Each Anbox subcluster also has a number of LXD worker nodes that form a LXD cluster. Each LXD worker node runs the following components:
 
-* **LXD** - The LXD daemon spawns a number of LXD instances containing Anbox-related configuration. These instances provide an Ubuntu environment that uses the hardware of the LXD worker node, including CPUs, disks, networks, and if available, GPUs. Each LXD instance runs exactly one Android instance that the end user can access/stream.
+- **LXD** - The LXD daemon spawns a number of LXD instances containing Anbox-related configuration. These instances provide an Ubuntu environment that uses the hardware of the LXD worker node, including CPUs, disks, networks, and if available, GPUs. Each LXD instance runs exactly one Android instance that the end user can access/stream.
 
    ```{note}
    The term LXD instance means that they are LXD containers or virtual machines that contain configuration related to Anbox Cloud. Within the context of Anbox Cloud, the term Anbox Cloud images is used interchangeably with LXD images in the sense that they are LXD images containing specific configuration related to Anbox Cloud.
    ```
 
-* **AMS node controller** – The AMS node controller puts the appropriate firewall rules in place when an instance is started or stopped to control ingress and egress traffic.
+- **AMS node controller** – The AMS node controller puts the appropriate firewall rules in place when an instance is started or stopped to control ingress and egress traffic.
 
 Outside the Anbox subcluster, you have the following machines:
 
-* **Juju controller**, which controls how Anbox Cloud is deployed and managed.
-* **Anbox Application Registry (AAR)**, which provides a central repository for applications created on Anbox Cloud. Using an AAR is very useful for larger deployments involving multiple subclusters, in order to keep applications in sync. This component is not mandatory, but strongly recommended in a production deployment, to keep applications in sync across the different subclusters.
+- **Juju controller**, which controls how Anbox Cloud is deployed and managed.
+- **Anbox Application Registry (AAR)**, which provides a central repository for applications created on Anbox Cloud. Using an AAR is very useful for larger deployments involving multiple subclusters, in order to keep applications in sync. This component is not mandatory, but strongly recommended in a production deployment, to keep applications in sync across the different subclusters.
 
 ### Streaming stack
 
@@ -98,14 +98,14 @@ The diagram below depicts the streaming stack along with the core stack and user
 
 When the streaming stack is in use, each Anbox subcluster has the following additional components:
 
-* **TURN/STUN servers** - Servers that find the most optimal network path between a client and the application running on Anbox Cloud. The streaming stack provides secure STUN and TURN servers, but you can use public ones as well.
+- **TURN/STUN servers** - Servers that find the most optimal network path between a client and the application running on Anbox Cloud. The streaming stack provides secure STUN and TURN servers, but you can use public ones as well.
 
-* **Stream agent** - Serves as an entry point that the gateway can connect to to talk to the AMS of the Anbox subcluster.
+- **Stream agent** - Serves as an entry point that the gateway can connect to to talk to the AMS of the Anbox subcluster.
 
 You also need an additional machine to host the streaming stack control plane with the following components:
 
-* **Stream gateway** - The central component that connects clients with agents. Its role is to choose the best possible subcluster depending on the user location and server capacities.
-* **NATS** - A messaging system that the different components use to communicate. NATS is  responsible for the communication between the stream gateway and the stream agent. For more information, see [NATS protocol](https://docs.nats.io/reference/reference-protocols/nats-protocol).
+- **Stream gateway** - The central component that connects clients with agents. Its role is to choose the best possible subcluster depending on the user location and server capacities.
+- **NATS** - A messaging system that the different components use to communicate. NATS is  responsible for the communication between the stream gateway and the stream agent. For more information, see [NATS protocol](https://docs.nats.io/reference/reference-protocols/nats-protocol).
 
 You will be required to provide one or more frontend services. A frontend service authenticates the client with the stream gateway and can provide other functionality, such as, selecting a game.
 
@@ -157,11 +157,11 @@ If you are using the Anbox Cloud Appliance, you are prompted during the initiali
 
 The charmed Anbox Cloud variant provides two different Juju bundles:
 
-* The `anbox-cloud-core` bundle provides a minimized version of Anbox Cloud. This version is sufficient if you don't want to use the Anbox Cloud streaming stack.
+- The `anbox-cloud-core` bundle provides a minimized version of Anbox Cloud. This version is sufficient if you don't want to use the Anbox Cloud streaming stack.
 
   For more information, see the [charm page](https://charmhub.io/anbox-cloud-core).
 
-* The `anbox-cloud` bundle provides the full version of Anbox Cloud, including its streaming stack.
+- The `anbox-cloud` bundle provides the full version of Anbox Cloud, including its streaming stack.
 
   For more information, see the [charm page](https://charmhub.io/anbox-cloud).
 
@@ -175,4 +175,4 @@ If you don't need to stream the visual output of the Android containers, you can
 
 ## Related topics
 
-* {ref}`exp-instances`
+- {ref}`exp-instances`

--- a/explanation/application-streaming.md
+++ b/explanation/application-streaming.md
@@ -76,6 +76,6 @@ If you do not enable streaming when launching the instance, you cannot enable it
 
 ## Related topics
 
-* {ref}`sec-deploy-anbox-cloud-juju` (installs streaming stack)
-* [Signaling](https://web.dev/articles/webrtc-infrastructure)
-* {ref}`ref-codecs`
+- {ref}`sec-deploy-anbox-cloud-juju` (installs streaming stack)
+- [Signaling](https://web.dev/articles/webrtc-infrastructure)
+- {ref}`ref-codecs`

--- a/explanation/applications.md
+++ b/explanation/applications.md
@@ -7,8 +7,8 @@ Applications are one of the main objects managed by Anbox Management Service (AM
 
 To run on the Anbox Cloud platform, applications must fulfill the following requirements:
 
-* The application *should not* download any additional resources on regular startup to contribute to short startup times. If additional resources need to be downloaded, this can be done during the application bootstrap phase.
-* The application *must not* require the *Google Play services* to be available as Anbox Cloud does not include them.
+- The application *should not* download any additional resources on regular startup to contribute to short startup times. If additional resources need to be downloaded, this can be done during the application bootstrap phase.
+- The application *must not* require the *Google Play services* to be available as Anbox Cloud does not include them.
 
 If your application fulfills these requirements but you are still having issues running it on Anbox Cloud, file a [bug report](https://bugs.launchpad.net/anbox-cloud/+filebug).
 
@@ -34,8 +34,8 @@ If you encounter the `error` or the `unknown` status, see if you can identify th
 
 When creating an application from a directory, a tarball, or a zip archive, AMS will perform a bootstrap process, which builds the application and synchronizes it across all LXD nodes in the cluster. There are major benefits that the bootstrap process provides:
 
-* It enables AMS to launch an instance for an application without installing the APK every time.
-* It dramatically speeds up the startup time of a regular instance.
+- It enables AMS to launch an instance for an application without installing the APK every time.
+- It dramatically speeds up the startup time of a regular instance.
 
 Furthermore, an application is synchronized within the LXD cluster, which enables AMS to continue to work when nodes are being removed from the cluster through scaling down or lost from the cluster unexpectedly.
 
@@ -65,11 +65,11 @@ In general, the bootstrap process goes through the following steps in order:
 
 The bootstrap process fails if one or more of the following situations happen:
 
-* If one of the steps in the bootstrap process fails, AMS will interrupt the bootstrap process and hence the entire process fails. As a result, the status of the base instance will be set to `error` and the application status is set to `error` as well.
+- If one of the steps in the bootstrap process fails, AMS will interrupt the bootstrap process and hence the entire process fails. As a result, the status of the base instance will be set to `error` and the application status is set to `error` as well.
 
-* An application crash or ANR upon APK installation causes the bootstrap process to terminate abnormally and the application status is set to `error`.
+- An application crash or ANR upon APK installation causes the bootstrap process to terminate abnormally and the application status is set to `error`.
 
-* The bootstrap process is limited to a maximum duration of 15 minutes. If it takes longer, the bootstrap process is aborted and the instance status is set to `error`.
+- The bootstrap process is limited to a maximum duration of 15 minutes. If it takes longer, the bootstrap process is aborted and the instance status is set to `error`.
 
 When a base instance runs into an `error` status, you can find the issue by checking the error message with `amc show <instance ID>`:
 
@@ -99,14 +99,14 @@ When the application bootstrap succeeds, the base instance is automatically remo
 
 ## Related topics
 
-* {ref}`exp-addons`
-* {ref}`exp-resources-presets`
-* {ref}`tut-create-virtual-device`
-* {ref}`howto-create-application`
-* {ref}`howto-delete-application`
-* {ref}`howto-list-applications`
-* {ref}`howto-scale-down-cluster`
-* {ref}`howto-test-application`
-* {ref}`howto-update-application`
-* {ref}`howto-wait-for-application`
-* {ref}`ref-application-manifest`
+- {ref}`exp-addons`
+- {ref}`exp-resources-presets`
+- {ref}`tut-create-virtual-device`
+- {ref}`howto-create-application`
+- {ref}`howto-delete-application`
+- {ref}`howto-list-applications`
+- {ref}`howto-scale-down-cluster`
+- {ref}`howto-test-application`
+- {ref}`howto-update-application`
+- {ref}`howto-wait-for-application`
+- {ref}`ref-application-manifest`

--- a/explanation/capacity-planning.md
+++ b/explanation/capacity-planning.md
@@ -5,17 +5,17 @@ When planning your Anbox Cloud deployment, you should start by estimating how mu
 
 When estimating capacity, consider the following questions to better understand your requirements:
 
-* Application resources:
-    - How much CPU, memory and disk space does your application need?
-    - Will the application use hardware- or software-based video encoding?
-    - If the application uses hardware-based encoding, how much GPU capacity is needed?
-* CPU and memory:
-    - Does every instance need dedicated access to the CPU and memory, or can the capacity be shared between several instances?
-* Application:
-    - What type of application are you running?
-    - What frame rate and what resolution does your application need?
-    - How many instances will be running simultaneously?
-    - What would be the impact of not being able to serve all users?
+- Application resources:
+  * How much CPU, memory and disk space does your application need?
+  * Will the application use hardware- or software-based video encoding?
+  * If the application uses hardware-based encoding, how much GPU capacity is needed?
+- CPU and memory:
+  * Does every instance need dedicated access to the CPU and memory, or can the capacity be shared between several instances?
+- Application:
+  * What type of application are you running?
+  * What frame rate and what resolution does your application need?
+  * How many instances will be running simultaneously?
+  * What would be the impact of not being able to serve all users?
 
 ## Application resources
 
@@ -116,5 +116,5 @@ To avoid your cluster running out of resources even at peak loads, you must size
 
 ## Related topics
 
-* {ref}`exp-clustering`
-* {ref}`ref-application-manifest`
+- {ref}`exp-clustering`
+- {ref}`ref-application-manifest`

--- a/explanation/clustering.md
+++ b/explanation/clustering.md
@@ -41,4 +41,4 @@ See {ref}`howto-scale-up-cluster` and {ref}`howto-scale-down-cluster` for instru
 
 ## Related topics
 
-* {ref}`howto-manage-cluster`
+- {ref}`howto-manage-cluster`

--- a/explanation/index.md
+++ b/explanation/index.md
@@ -7,48 +7,48 @@ The explanatory and conceptual guides in this section provide a better understan
 
 Understand the underlying architecture of Anbox Cloud, its variants and how the different components of Anbox Cloud relate to each other.
 
-* {ref}`exp-anbox-cloud`
-* {ref}`exp-ams`
-* {ref}`exp-aar`
-* {ref}`exp-web-dashboard`
-* {ref}`exp-application-streaming`
-* {ref}`exp-rendering-architecture`
+- {ref}`exp-anbox-cloud`
+- {ref}`exp-ams`
+- {ref}`exp-aar`
+- {ref}`exp-web-dashboard`
+- {ref}`exp-application-streaming`
+- {ref}`exp-rendering-architecture`
 
 ## Working with Anbox Cloud
 
 Understand the different objects used in the product stack and how to use them to tune the performance of Anbox Cloud.
 
-* {ref}`exp-applications`
-* {ref}`exp-instances`
-* {ref}`exp-images`
-* {ref}`exp-nodes`
-* {ref}`exp-addons`
-* {ref}`AAOS <exp-aaos>`
-* {ref}`exp-platforms`
-* {ref}`exp-clustering`
+- {ref}`exp-applications`
+- {ref}`exp-instances`
+- {ref}`exp-images`
+- {ref}`exp-nodes`
+- {ref}`exp-addons`
+- {ref}`AAOS <exp-aaos>`
+- {ref}`exp-platforms`
+- {ref}`exp-clustering`
 
 ## Authentication and authorization
 
 Learn concepts of identities, groups and permissions in Anbox Cloud.
 
-* {ref}`exp-auth`
+- {ref}`exp-auth`
 
 ## Deploying Anbox Cloud
 
 Understand deployment configurations to plan your deployment.
 
-* {ref}`exp-production-planning`
-* {ref}`exp-capacity-planning`
-* {ref}`exp-rendering-graphics`
-* {ref}`exp-resources-presets`
-* {ref}`exp-custom-images`
-* {ref}`exp-performance`
+- {ref}`exp-production-planning`
+- {ref}`exp-capacity-planning`
+- {ref}`exp-rendering-graphics`
+- {ref}`exp-resources-presets`
+- {ref}`exp-custom-images`
+- {ref}`exp-performance`
 
 ## Security with Anbox Cloud
 
 Understand how you can deploy Anbox Cloud secure, the cryptography information used by various Anbox Cloud components.
 
-* {ref}`Security <exp-security>`
+- {ref}`Security <exp-security>`
 
 Also check out the {ref}`tutorials` for step-by-step instructions that help you get familiar with Anbox Cloud, the {ref}`how-to-guides` for instructions on how to achieve specific goals when using Anbox Cloud and the {ref}`reference` section for reference material.
 

--- a/explanation/instances.md
+++ b/explanation/instances.md
@@ -87,16 +87,16 @@ To check whether development mode is enabled, run `amc show <instance_ID>` or lo
 
 ## Related topics
 
-* {ref}`exp-addons`
-* [Platform plugin](https://canonical.github.io/anbox-cloud.github.com/latest/anbox-platform-sdk/)
-* {ref}`howto-access-instance`
-* {ref}`howto-backup-restore-application-data`
-* {ref}`howto-create-instance`
-* {ref}`howto-configure-geographic-location`
-* {ref}`howto-delete-instance`
-* {ref}`howto-expose-services`
-* {ref}`howto-list-instances`
-* {ref}`howto-start-instance`
-* {ref}`howto-stop-instance`
-* {ref}`howto-view-instance-logs`
-* {ref}`howto-wait-for-application`
+- {ref}`exp-addons`
+- [Platform plugin](https://canonical.github.io/anbox-cloud.github.com/latest/anbox-platform-sdk/)
+- {ref}`howto-access-instance`
+- {ref}`howto-backup-restore-application-data`
+- {ref}`howto-create-instance`
+- {ref}`howto-configure-geographic-location`
+- {ref}`howto-delete-instance`
+- {ref}`howto-expose-services`
+- {ref}`howto-list-instances`
+- {ref}`howto-start-instance`
+- {ref}`howto-stop-instance`
+- {ref}`howto-view-instance-logs`
+- {ref}`howto-wait-for-application`

--- a/explanation/performance.md
+++ b/explanation/performance.md
@@ -25,10 +25,10 @@ Generally, applications should use the smallest suitable resource preset. Howeve
 
 AMS has different modes to grant CPU access to an instance. The `cpu.limit_mode` configuration option can be used to change the mode. The possible modes are:
 
-* `scheduler` :
+- `scheduler` :
 
     This mode uses the LXD [`limits.cpu.allowance`](https://documentation.ubuntu.com/lxd/latest/reference/instance_options/#cpu-limits) configuration option to grant an instance a CPU time budget via the Linux CFS scheduler. See [CFS Bandwidth Control](https://www.kernel.org/doc/html/latest/scheduler/sched-bwc.html) for more details.
-* `pinning` :
+- `pinning` :
 
    This mode uses the LXD [`limits.cpu`](https://documentation.ubuntu.com/lxd/latest/reference/instance_options/#cpu-limits) configuration option to pin a set of CPU cores to an instance. LXD is responsible for allocating a specific number of cores to an instance and load-balancing all running instances on all available cores.
 
@@ -71,6 +71,6 @@ Also make sure to optimize the network path from the Anbox Cloud server to the c
 
 ## Related topics
 
-* {ref}`exp-capacity-planning`
-* {ref}`howto-run-benchmarks`
-* {ref}`ref-hooks`
+- {ref}`exp-capacity-planning`
+- {ref}`howto-run-benchmarks`
+- {ref}`ref-hooks`

--- a/explanation/platforms.md
+++ b/explanation/platforms.md
@@ -58,4 +58,4 @@ For example, to configure the platform for a display height of 1080p and 60 FPS,
 
 ## Related topics
 
-* {ref}`exp-platforms`
+- {ref}`exp-platforms`

--- a/explanation/production-planning.md
+++ b/explanation/production-planning.md
@@ -17,10 +17,10 @@ Anbox Cloud deployments require the Ubuntu operating system. You should consider
 
 Consider the following questions to decide your networking requirements:
 
-* In your deployment, how should your network structure and topology look like?
-* Do you need subnets? If yes, what is the range of the subnets that you want to define?
-* Do you require a virtual network and plan Juju spaces on top of it?
-* Where is your Anbox Application Registry (AAR) deployed? How will the AMS in other clusters connect to AAR? Define any peering requirements that you may have, based on the number of clusters you have and where AAR is deployed. To know more about AAR, see the following links:
+- In your deployment, how should your network structure and topology look like?
+- Do you need subnets? If yes, what is the range of the subnets that you want to define?
+- Do you require a virtual network and plan Juju spaces on top of it?
+- Where is your Anbox Application Registry (AAR) deployed? How will the AMS in other clusters connect to AAR? Define any peering requirements that you may have, based on the number of clusters you have and where AAR is deployed. To know more about AAR, see the following links:
   * {ref}`exp-aar`
   * {ref}`howto-deploy-aar`
   * {ref}`howto-configure-aar`
@@ -29,9 +29,9 @@ Consider the following questions to decide your networking requirements:
 
 Based on your safety protocols, think about where you would want to host your storage. Also, refer to the following links that will help you plan and calculate your storage needs:
 
-* {ref}`ref-requirements`
-* [etcd recommendations](https://etcd.io/docs/v3.5/op-guide/hardware/)
-* {ref}`exp-capacity-planning`
+- {ref}`ref-requirements`
+- [etcd recommendations](https://etcd.io/docs/v3.5/op-guide/hardware/)
+- {ref}`exp-capacity-planning`
 
 ## Scalability, High availability, and redundancy
 
@@ -73,11 +73,11 @@ Load balancing solutions can differ based on your deployment model. You should a
 
 Anbox Cloud is optimized to use only as much energy as is necessary for an operation to complete. When planning for a production deployment, think through the following questions about energy efficiency to choose the most optimum way possible for your specific requirements:
 
-* Does your hardware match the requirements for your use case?
-* What trade-offs does your requirement allow to improve energy efficiency? For example, is there a way to use a lower streaming resolution? Lowering the resolution will impact the streaming experience but where possible, it could be a trade-off between being energy efficient and the quality of the stream. This needs to be decided based on how you use Anbox Cloud.
-* Does your deployment use GPU encoding or CPU encoding?
-* What is the bandwidth consumption of your deployment and what are the factors that could make it more efficient?
-* Are you using the appropriate platform for your use case? For example, for automation use cases, `null` requires much less CPU usage than `webrtc` with GPU or CPU rendering. See {ref}`exp-platforms` for more information.
+- Does your hardware match the requirements for your use case?
+- What trade-offs does your requirement allow to improve energy efficiency? For example, is there a way to use a lower streaming resolution? Lowering the resolution will impact the streaming experience but where possible, it could be a trade-off between being energy efficient and the quality of the stream. This needs to be decided based on how you use Anbox Cloud.
+- Does your deployment use GPU encoding or CPU encoding?
+- What is the bandwidth consumption of your deployment and what are the factors that could make it more efficient?
+- Are you using the appropriate platform for your use case? For example, for automation use cases, `null` requires much less CPU usage than `webrtc` with GPU or CPU rendering. See {ref}`exp-platforms` for more information.
 
 ## Monitoring and metrics
 

--- a/explanation/rendering-architecture.md
+++ b/explanation/rendering-architecture.md
@@ -37,6 +37,6 @@ For AMD and Intel GPUs, Anbox Cloud uses Vulkan as API in the Android space and 
 
 ## Related topics
 
-* {ref}`ref-rendering-resources`
-* [SurfaceFlinger](https://source.android.com/docs/core/graphics/surfaceflinger-windowmanager)
-* [Wayland](https://wayland.freedesktop.org/)
+- {ref}`ref-rendering-resources`
+- [SurfaceFlinger](https://source.android.com/docs/core/graphics/surfaceflinger-windowmanager)
+- [Wayland](https://wayland.freedesktop.org/)

--- a/explanation/rendering-graphics.md
+++ b/explanation/rendering-graphics.md
@@ -32,5 +32,5 @@ To use instances without a GPU and still render graphical output,
 
 ## Related topics
 
-* {ref}`ref-rendering-resources`
-* {ref}`exp-rendering-architecture`
+- {ref}`ref-rendering-resources`
+- {ref}`exp-rendering-architecture`

--- a/explanation/resources.md
+++ b/explanation/resources.md
@@ -29,4 +29,4 @@ In addition to the `cpus`, `memory` and the `disk-size` requirements, if your ap
 
 ## Related topics
 
-* {ref}`ref-application-manifest`
+- {ref}`ref-application-manifest`

--- a/explanation/security/ams.md
+++ b/explanation/security/ams.md
@@ -3,9 +3,9 @@
 
 Anbox Management Service (AMS) is using cryptographic technology for:
 
-* TLS transport encryption
-* Mutual TLS based authentication
-* Token based authentication
+- TLS transport encryption
+- Mutual TLS based authentication
+- Token based authentication
 
 ## TLS transport encryption
 
@@ -29,6 +29,6 @@ Individual Anbox instances have access to a limited set of API endpoints exposed
 
 ## Packages used
 
-* [Go standard library](https://pkg.go.dev/std)
-* [`github.com/golang-jwt/jwt`](https://github.com/golang-jwt/jwt)
-* [OIDC](https://github.com/zitadel/oidc)
+- [Go standard library](https://pkg.go.dev/std)
+- [`github.com/golang-jwt/jwt`](https://github.com/golang-jwt/jwt)
+- [OIDC](https://github.com/zitadel/oidc)

--- a/explanation/security/anbox-runtime.md
+++ b/explanation/security/anbox-runtime.md
@@ -3,9 +3,9 @@
 
 The Anbox runtime (see {ref}`howto-anbox-runtime`) is using cryptographic technology for:
 
-* TLS transport encryption
-* Token based authentication
-* WebRTC
+- TLS transport encryption
+- Token based authentication
+- WebRTC
 
 ## TLS transport encryption
 
@@ -27,6 +27,6 @@ The security model and cryptographic use of WebRTC is described in [RFC8827](htt
 
 ## Packages used
 
-* [Go standard library](https://pkg.go.dev/std)
-* [OpenSSL](https://launchpad.net/ubuntu/+source/openssl/)
-* [`ca-certificates`](https://launchpad.net/ubuntu/+source/ca-certificates)
+- [Go standard library](https://pkg.go.dev/std)
+- [OpenSSL](https://launchpad.net/ubuntu/+source/openssl/)
+- [`ca-certificates`](https://launchpad.net/ubuntu/+source/ca-certificates)

--- a/explanation/security/charms.md
+++ b/explanation/security/charms.md
@@ -13,12 +13,12 @@ See [Security with Juju](https://documentation.ubuntu.com/juju/latest/user/expla
 
 The following charms for Anbox Cloud make use of cryptographic technology for creation of TLS certificates:
 
-* [`ams`](https://charmhub.io/ams)
-* [`ams-lxd`](https://charmhub.io/ams-lxd)
-* [`anbox-stream-gateway`](https://charmhub.io/anbox-stream-gateway)
-* [`anbox-stream-agent`](https://charmhub.io/anbox-stream-agent)
-* [`anbox-cloud-dashboard`](https://charmhub.io/anbox-cloud-dashboard)
-* [`lxd-integrator`](https://charmhub.io/lxd-integrator)
+- [`ams`](https://charmhub.io/ams)
+- [`ams-lxd`](https://charmhub.io/ams-lxd)
+- [`anbox-stream-gateway`](https://charmhub.io/anbox-stream-gateway)
+- [`anbox-stream-agent`](https://charmhub.io/anbox-stream-agent)
+- [`anbox-cloud-dashboard`](https://charmhub.io/anbox-cloud-dashboard)
+- [`lxd-integrator`](https://charmhub.io/lxd-integrator)
 
 When Anbox Cloud is deployed without the use of an external CA, the charms will generate self-signed certificates using the [cryptography](https://pypi.org/project/cryptography/) Python package. The private key used for signing has a size of 4096 bits.
 
@@ -28,7 +28,7 @@ When using a TLS charm (e.g. [self-signed-certificates](https://charmhub.io/self
 
 ### Packages used
 
-* [cryptography from PyPI](https://pypi.org/project/cryptography/)
+- [cryptography from PyPI](https://pypi.org/project/cryptography/)
 
 ## Juju secrets
 

--- a/explanation/security/dashboard.md
+++ b/explanation/security/dashboard.md
@@ -3,10 +3,10 @@
 
 The Anbox Cloud Dashboard (dashboard) is using cryptographic technology for:
 
-* TLS transport encryption
-* Registration of new users
-* User authentication
-* Mutual TLS based authentication
+- TLS transport encryption
+- Registration of new users
+- User authentication
+- Mutual TLS based authentication
 
 ## TLS transport encryption
 
@@ -48,6 +48,6 @@ The dashboard uses mutual TLS authentication to establish a trusted TLS communic
 
 ## Packages used
 
-* [PyJWT](https://github.com/jpadilla/pyjwt), supplied by [PyPI](https://pypi.org/project/PyJWT/)
-* [`python-jose`](https://github.com/mpdavis/python-jose/), supplied by [PyPI](https://pypi.org/project/python-jose/)
-* [OpenSSL](https://launchpad.net/ubuntu/+source/openssl/)
+- [PyJWT](https://github.com/jpadilla/pyjwt), supplied by [PyPI](https://pypi.org/project/PyJWT/)
+- [`python-jose`](https://github.com/mpdavis/python-jose/), supplied by [PyPI](https://pypi.org/project/python-jose/)
+- [OpenSSL](https://launchpad.net/ubuntu/+source/openssl/)

--- a/explanation/security/streaming-stack.md
+++ b/explanation/security/streaming-stack.md
@@ -14,9 +14,9 @@ See [A Study of WebRTC Security](https://webrtc-security.github.io/) for a detai
 
 Anbox Streaming Gateway is using cryptographic technology for:
 
-* TLS transport encryption
-* Mutual TLS based authentication
-* Token based authentication
+- TLS transport encryption
+- Mutual TLS based authentication
+- Token based authentication
 
 ### TLS transport encryption
 
@@ -32,17 +32,17 @@ Users can generate API tokens to authenticate with the HTTP API provided by the 
 
 ### Packages used
 
-* [Go standard library](https://pkg.go.dev/std)
-* [`gopkg.in/macaroon.v2`](https://gopkg.in/macaroon.v2)
+- [Go standard library](https://pkg.go.dev/std)
+- [`gopkg.in/macaroon.v2`](https://gopkg.in/macaroon.v2)
 
 (sec-security-crypto-stream-agent)=
 ## Cryptography used by the stream agent
 
 Anbox Streaming Agent is using cryptographic technology for:
 
-* TLS transport encryption
-* Mutual TLS based authentication
-* Token based authentication
+- TLS transport encryption
+- Mutual TLS based authentication
+- Token based authentication
 
 ### TLS transport encryption
 
@@ -62,5 +62,5 @@ For authentication purposes with the [Coturn TURN server](https://github.com/cot
 
 ### Packages used
 
-* [Go standard library](https://pkg.go.dev/std)
-* [`gopkg.in/macaroon.v2`](https://gopkg.in/macaroon.v2)
+- [Go standard library](https://pkg.go.dev/std)
+- [`gopkg.in/macaroon.v2`](https://gopkg.in/macaroon.v2)

--- a/explanation/web-dashboard.md
+++ b/explanation/web-dashboard.md
@@ -9,17 +9,17 @@ The dashboard comes pre-installed when you deploy the full version of Anbox Clou
 
 The dashboard allows multiple views and management of various objects such as applications, instances and nodes to some extent. The operations available from the dashboard may be limited as compared to the CLI, however if you are new to the CLI, the dashboard can be a friendlier start to Anbox Cloud.
 
-* Applications page - Allows creation, streaming and management of applications.
-* Instances page - Allows a detailed view of instances and the applications or images that they are created from, along with other options including management, streaming, connecting via Android Debug Bridge (ADB) for the instances.
-* Nodes page - Allows a list view of LXD nodes and their configuration details.
+- Applications page - Allows creation, streaming and management of applications.
+- Instances page - Allows a detailed view of instances and the applications or images that they are created from, along with other options including management, streaming, connecting via Android Debug Bridge (ADB) for the instances.
+- Nodes page - Allows a list view of LXD nodes and their configuration details.
 
 Apart from these views, the dashboard also allows you to work with the {ref}`exp-aar` and the {ref}`exp-ams`.
 
-* Registry page - Allows a list view of applications uploaded to the registry.
-* Configuration page - Allows you to edit the {ref}`ref-ams-configuration` attributes from the dashboard.
+- Registry page - Allows a list view of applications uploaded to the registry.
+- Configuration page - Allows you to edit the {ref}`ref-ams-configuration` attributes from the dashboard.
 
 ## Related topics
 
-* {ref}`tut-installing-appliance`
-* {ref}`howto-use-web-dashboard`
-* {ref}`howto-deploy-anbox-juju`
+- {ref}`tut-installing-appliance`
+- {ref}`howto-use-web-dashboard`
+- {ref}`howto-deploy-anbox-juju`

--- a/howto/aar/configure.md
+++ b/howto/aar/configure.md
@@ -146,7 +146,7 @@ Finally, reboot the AAR:
 
 ## Related topics
 
-* {ref}`exp-aar`
-* {ref}`howto-revoke-aar`
-* [Juju relations](https://documentation.ubuntu.com/juju/latest/user/reference/relation/)
-* [Juju cross model relations](https://documentation.ubuntu.com/juju/latest/user/reference/relation/#cross-model/)
+- {ref}`exp-aar`
+- {ref}`howto-revoke-aar`
+- [Juju relations](https://documentation.ubuntu.com/juju/latest/user/reference/relation/)
+- [Juju cross model relations](https://documentation.ubuntu.com/juju/latest/user/reference/relation/#cross-model/)

--- a/howto/aar/deploy.md
+++ b/howto/aar/deploy.md
@@ -121,6 +121,6 @@ Then update the AAR configuration via the charm configuration:
 
 ## Related topics
 
-* {ref}`exp-aar`
-* {ref}`howto-configure-aar`
-* {ref}`howto-revoke-aar`
+- {ref}`exp-aar`
+- {ref}`howto-configure-aar`
+- {ref}`howto-revoke-aar`

--- a/howto/aar/revoke.md
+++ b/howto/aar/revoke.md
@@ -16,6 +16,6 @@ This operation is irreversible. You cannot reverse a revocation or add the certi
 
 ## Related topics
 
-* {ref}`exp-aar`
-* {ref}`howto-configure-aar`
-* {ref}`howto-deploy-aar`
+- {ref}`exp-aar`
+- {ref}`howto-configure-aar`
+- {ref}`howto-deploy-aar`

--- a/howto/addons/create-addon.md
+++ b/howto/addons/create-addon.md
@@ -19,9 +19,9 @@ cat "$ADDON_DIR"/public_key.pem >> ~/.ssh/authorized_keys
 ```
 
 To create an addon, you must provide the Anbox Management Client (AMC) with either of the following:
-* The addon directory
-* A tarball containing the required addon file structure
-* A zip archive containing the required addon file structure
+- The addon directory
+- A tarball containing the required addon file structure
+- A zip archive containing the required addon file structure
 
 Let's look at an example for of an addon for enabling SSH access on a container.
 
@@ -129,7 +129,7 @@ Exposed ports usually start around port 10000. `amc ls` displays the export port
 
 ## Related topics
 
-* {ref}`exp-addons`
-* {ref}`howto-update-addons`
-* {ref}`howto-extend-application`
-* {ref}`ref-addon-manifest`
+- {ref}`exp-addons`
+- {ref}`howto-update-addons`
+- {ref}`howto-extend-application`
+- {ref}`ref-addon-manifest`

--- a/howto/addons/enable-addons-globally.md
+++ b/howto/addons/enable-addons-globally.md
@@ -19,4 +19,4 @@ Addons can delay the start of your applications. Therefore, keep them light.
 
 ## Related topics
 
-* {ref}`ref-application-manifest`
+- {ref}`ref-application-manifest`

--- a/howto/addons/migrate-addon.md
+++ b/howto/addons/migrate-addon.md
@@ -3,10 +3,10 @@
 
 Starting with Anbox Cloud 1.12, use the following new hooks instead of the deprecated ones:
 
-* Use `pre-start` instead of `install`
-* Use `pre-start` instead of `restore`
-* Use `post-start` instead of `prepare`
-* Use `post-stop` instead of `backup`
+- Use `pre-start` instead of `install`
+- Use `pre-start` instead of `restore`
+- Use `post-start` instead of `prepare`
+- Use `post-stop` instead of `backup`
 
 The new hooks run for **all** types of instances (containers and virtual machines). To execute a hook only for a regular or a base instance, use the `INSTANCE_TYPE` environment variable. This variable is set to either `base` or `regular`.
 

--- a/howto/anbox-runtime/develop-addon-devmode.md
+++ b/howto/anbox-runtime/develop-addon-devmode.md
@@ -33,9 +33,9 @@ You can test your addon hooks by running it inside the instance shell. For examp
 
 To troubleshoot issues within the instance, try either of the following options:
 
-* Run `amc logs <instance_id>` on the host to see the Anbox runtime logs.
-* Run `journalctl --no-pager` within the instance to view instance logs.
-* Restart the instance using `amc stop <instance_id>` and then `amc start <instance_id>`.
+- Run `amc logs <instance_id>` on the host to see the Anbox runtime logs.
+- Run `journalctl --no-pager` within the instance to view instance logs.
+- Restart the instance using `amc stop <instance_id>` and then `amc start <instance_id>`.
 
 ## Example: Launch an SSH-enabled container for remote development
 

--- a/howto/anbox-runtime/develop-platform-plugin.md
+++ b/howto/anbox-runtime/develop-platform-plugin.md
@@ -127,6 +127,6 @@ Use the `--vm` option to launch a VM instance.
 
 ## Related topics
 
-* {ref}`exp-addons`
-* {ref}`exp-instances`
-* {ref}`howto-create-addon`
+- {ref}`exp-addons`
+- {ref}`exp-instances`
+- {ref}`howto-create-addon`

--- a/howto/anbox/control-ams-remotely.md
+++ b/howto/anbox/control-ams-remotely.md
@@ -118,4 +118,4 @@ After this step, all invocations of the `amc` command use the new remote.
 
 ## Related topics
 
-* {ref}`exp-ams`
+- {ref}`exp-ams`

--- a/howto/application/create-application.md
+++ b/howto/application/create-application.md
@@ -131,12 +131,12 @@ An application can be created either in a VM or a container. Selecting one of th
 
 The *Configuration (optional)* section allows you to customize additional fields, including the following attributes:
 
-* {ref}`manifest version name <ref-application-manifest>`
-* {ref}`boot package <ref-application-manifest>`
-* {ref}`boot activity <ref-application-manifest>`
-* {ref}`tags <ref-application-manifest>`
-* {ref}`features <ref-feature-flags>`
-* {ref}`sec-application-manifest-watchdog`
+- {ref}`manifest version name <ref-application-manifest>`
+- {ref}`boot package <ref-application-manifest>`
+- {ref}`boot activity <ref-application-manifest>`
+- {ref}`tags <ref-application-manifest>`
+- {ref}`features <ref-feature-flags>`
+- {ref}`sec-application-manifest-watchdog`
 
 The switch *Customize manifest.yaml* at the bottom of the form allows to directly customize your application manifest with a YAML editor.
 
@@ -152,4 +152,4 @@ Once the status of the application switches to `ready`, the application is ready
 
 ## Related topics
 
-* {ref}`sec-application-bootstrap`
+- {ref}`sec-application-bootstrap`

--- a/howto/application/extend-application.md
+++ b/howto/application/extend-application.md
@@ -3,8 +3,8 @@
 
 You can extend an application either by adding hooks directly to the application or by creating an addon that includes one or more hooks and adding it to the application.
 
-* If you want to extend one application only, you should use application hooks. They are easy and quick to set up and do not require creating an addon.
-* If your extension contains common functionality that you want to share among multiple applications, you should create an addon that includes one or more hooks. You can then add the addon to all applications that should use the functionality.
+- If you want to extend one application only, you should use application hooks. They are easy and quick to set up and do not require creating an addon.
+- If your extension contains common functionality that you want to share among multiple applications, you should create an addon that includes one or more hooks. You can then add the addon to all applications that should use the functionality.
 
 For both options, you must create one or more hooks first. The options differ in how you add these hooks to your application.
 
@@ -187,5 +187,5 @@ The application will now execute the hook and you should see that, for example, 
 
 ## Related topics
 
-* {ref}`exp-addons`
-* {ref}`howto-create-addon`.
+- {ref}`exp-addons`
+- {ref}`howto-create-addon`.

--- a/howto/application/pass-custom-data.md
+++ b/howto/application/pass-custom-data.md
@@ -17,8 +17,8 @@ or the `--userdata-path` option, if you prefer all the custom data to be collate
 
     amc launch <app-name> .... --enable-streaming --userdata-path="my-user-data.json"
 
-* `--userdata` takes a string and stores the provided data in the `/var/lib/anbox/userdata` file in the instance.
-* `--userdata-path` takes a file name and copies the contents of the file to the `/var/lib/anbox/userdata` file in the instance.
+- `--userdata` takes a string and stores the provided data in the `/var/lib/anbox/userdata` file in the instance.
+- `--userdata-path` takes a file name and copies the contents of the file to the `/var/lib/anbox/userdata` file in the instance.
 
 In both cases, the `/var/lib/anbox/userdata` file will contain exactly the data that you provide. The data must be in string form (to send binary data, you must encode it as Base64 text). The size limit for the data is 10 KB.
 

--- a/howto/application/stream-application.md
+++ b/howto/application/stream-application.md
@@ -15,9 +15,9 @@ When the `--enable-streaming` option is specified, the Anbox Management Service 
 
 To further customize the streaming configuration, use the following arguments:
 
-* `--display-size`
-* `--display-density`
-* `--fps`
+- `--display-size`
+- `--display-density`
+- `--fps`
 
 For example, to create an instance with a 1080p resolution, a frame rate of 60 and a DPI of 120, run:
 
@@ -125,5 +125,5 @@ In the *Logs* tabs, you can toggle auto-scroll, pause and resume log messages, c
 
 ## Related topics
 
-* {ref}`tut-set-up-stream-client`
-* {ref}`howto-access-stream-gateway`
+- {ref}`tut-set-up-stream-client`
+- {ref}`howto-access-stream-gateway`

--- a/howto/application/test-application.md
+++ b/howto/application/test-application.md
@@ -57,8 +57,8 @@ Now you can connect to the remote machine via ADB with the following command:
 You should see output similar to the following:
 
 ```bash
-* daemon not running; starting now at tcp:5037
-* daemon started successfully
+- daemon not running; starting now at tcp:5037
+- daemon started successfully
 connected to localhost:10000
 ```
 

--- a/howto/application/update-application.md
+++ b/howto/application/update-application.md
@@ -97,11 +97,11 @@ In the guided form, you can customize most of the fields that are available duri
 
 Similar to the application creation process, you can unlock advanced customization capabilities by toggling the *Customize manifest.yaml* switch at the bottom of the page. Note that customizing the manifest or updating one of the following fields will create a new version of the application:
 
-* APK
-* {ref}`manifest version name <ref-application-manifest>`
-* {ref}`boot activity <ref-application-manifest>`
-* {ref}`features <ref-feature-flags>`
-* {ref}`sec-application-manifest-watchdog`
+- APK
+- {ref}`manifest version name <ref-application-manifest>`
+- {ref}`boot activity <ref-application-manifest>`
+- {ref}`features <ref-feature-flags>`
+- {ref}`sec-application-manifest-watchdog`
 
 When you click *Update*, you will be redirected either to the *Overview* tab of the application detail page - if the fields changed did not trigger a new version creation - or to the *Versions* tab of that page, when a new version of the application was created.
 

--- a/howto/dashboard/index.md
+++ b/howto/dashboard/index.md
@@ -51,5 +51,5 @@ To access the dashboard, go to `https://<your-machine-address>/`. The dashboard 
 
 ## Related topics
 
-* {ref}`exp-aar`
-* {ref}`exp-web-dashboard`
+- {ref}`exp-aar`
+- {ref}`exp-web-dashboard`

--- a/howto/images/publish-instance-as-image.md
+++ b/howto/images/publish-instance-as-image.md
@@ -5,9 +5,9 @@ Publishing an instance as an image allows you to capture the current state of an
 
 Consider these best practices before publishing instances as images:
 
-* Remove any temporary files, logs, sensitive data before publishing the instance
-* Test the published image by launching an instance based on it and verifying all the modifications are working as intended.
-* Use meaningful names for your images to indicate the purpose and modifications they contain.
+- Remove any temporary files, logs, sensitive data before publishing the instance
+- Test the published image by launching an instance based on it and verifying all the modifications are working as intended.
+- Use meaningful names for your images to indicate the purpose and modifications they contain.
 
 ## Publish an instance
 
@@ -100,7 +100,7 @@ Once the instance is running, visit the *Terminal* tab from its *Instance detail
 
 ## Related topics
 
-* {ref}`howto-create-instance`
-* {ref}`howto-stop-instance`
-* {ref}`howto-add-image`
-* {ref}`howto-delete-image`
+- {ref}`howto-create-instance`
+- {ref}`howto-stop-instance`
+- {ref}`howto-add-image`
+- {ref}`howto-delete-image`

--- a/howto/index.md
+++ b/howto/index.md
@@ -7,44 +7,44 @@ The *How-to* guides in this section give directions on how to achieve your goals
 
 Learn how to install, configure and upgrade Anbox Cloud.
 
-* {ref}`howto-install-anbox-cloud`
-* {ref}`howto-install-appliance`
-* {ref}`howto-upgrade`
+- {ref}`howto-install-anbox-cloud`
+- {ref}`howto-install-appliance`
+- {ref}`howto-upgrade`
 
 ## Using Anbox Cloud
 
 Learn about applications, instances and more in Anbox Cloud and how to use them.
 
-* {ref}`howto-manage-images`
-* {ref}`howto-manage-applications`
-* {ref}`howto-instance`
-* {ref}`howto-addons`
-* {ref}`howto-streaming`
-* {ref}`howto-port-android-apps`
-* {ref}`howto-use-web-dashboard`
-* {ref}`howto-Android`
-* {ref}`howto-simulate-incoming-sms`
+- {ref}`howto-manage-images`
+- {ref}`howto-manage-applications`
+- {ref}`howto-instance`
+- {ref}`howto-addons`
+- {ref}`howto-streaming`
+- {ref}`howto-port-android-apps`
+- {ref}`howto-use-web-dashboard`
+- {ref}`howto-Android`
+- {ref}`howto-simulate-incoming-sms`
 
 ## Managing Anbox Cloud
 
 Learn how to manage the different variants of Anbox Cloud, distribute the load of Anbox Cloud over several machines in a cluster, manage the Anbox Application Registry (AAR), and work with Anbox runtime.
 
-* {ref}`howto-manage-anbox`
-* {ref}`howto-manage-cluster`
-* {ref}`howto-aar`
-* {ref}`howto-anbox-runtime`
+- {ref}`howto-manage-anbox`
+- {ref}`howto-manage-cluster`
+- {ref}`howto-aar`
+- {ref}`howto-anbox-runtime`
 
 ## Monitoring Anbox Cloud
 
 Understand monitoring options for Anbox Cloud to further optimize your deployment.
 
-* {ref}`howto-monitor-anbox`
+- {ref}`howto-monitor-anbox`
 
 ## Troubleshooting Anbox Cloud
 
 Learn resolutions for common issues with Anbox Cloud and how to collect useful debugging information before reporting an issue.
 
-* {ref}`howto-ts-anbox-cloud`
+- {ref}`howto-ts-anbox-cloud`
 
 Also check out the {ref}`tutorials` for step-by-step instructions that help you get started with Anbox Cloud, as well as the {ref}`reference` and {ref}`explanation` sections for other helpful information.
 

--- a/howto/install-appliance/index.md
+++ b/howto/install-appliance/index.md
@@ -13,18 +13,18 @@ Also, see {ref}`ref-requirements` before you start your installation.
 
 The Anbox Cloud Appliance is currently available for the following cloud platforms:
 
-* {ref}`howto-install-appliance-aws`
+- {ref}`howto-install-appliance-aws`
 
 Other clouds are also supported, but the Anbox Cloud Appliance is not available from their application directories yet. Therefore, to install the appliance on such a cloud, install the Anbox Cloud Appliance snap on a cloud machine. See the following instructions:
 
-* For [Azure](https://azure.microsoft.com/) : {ref}`howto-install-appliance-azure`
-* For [Google Cloud](https://cloud.google.com/) : {ref}`howto-install-appliance-google-cloud`
+- For [Azure](https://azure.microsoft.com/) : {ref}`howto-install-appliance-azure`
+- For [Google Cloud](https://cloud.google.com/) : {ref}`howto-install-appliance-google-cloud`
 
 ## Supported CI/CD platforms
 
 The Anbox Cloud Appliance is currently available on the following CI/CD platforms:
 
-* {ref}`howto-install-appliance-github`
+- {ref}`howto-install-appliance-github`
 
 ```{toctree}
 :hidden:

--- a/howto/install-appliance/install-on-aws.md
+++ b/howto/install-appliance/install-on-aws.md
@@ -34,12 +34,12 @@ AWS supports running the Anbox Cloud Appliance both on [AWS Graviton](https://aw
   To use GPUs with AWS Graviton (Arm), you must select a [G5g instance](https://aws.amazon.com/de/ec2/instance-types/g5g/). This instance type might not be available in all regions.
   ```
 
-* Not all Android applications support the x86 ABI. Therefore, some applications can run only on Arm.
+- Not all Android applications support the x86 ABI. Therefore, some applications can run only on Arm.
 
 For detailed information about the offering, see the following pages on the AWS Marketplace:
 
-* [Anbox Cloud Appliance for AWS Graviton (Arm)](https://aws.amazon.com/marketplace/pp/prodview-aqmdt52vqs5qk)
-* [Anbox Cloud Appliance for x86](https://aws.amazon.com/marketplace/pp/prodview-3lx6xyaapstz4)
+- [Anbox Cloud Appliance for AWS Graviton (Arm)](https://aws.amazon.com/marketplace/pp/prodview-aqmdt52vqs5qk)
+- [Anbox Cloud Appliance for x86](https://aws.amazon.com/marketplace/pp/prodview-3lx6xyaapstz4)
 
 ### Hardware requirements
 
@@ -110,8 +110,8 @@ For reference, all required ports are documented in {ref}`ref-requirements`.
 
 The instance requires sufficient storage to work correctly. For optimal performance, we recommend the following setup:
 
-* A root disk with a minimum of 50 GB (required)
-* An additional EBS volume of at least 50 GB (strongly recommended)
+- A root disk with a minimum of 50 GB (required)
+- An additional EBS volume of at least 50 GB (strongly recommended)
 
 Anbox Cloud uses the additional volume exclusively to store all of its data, including its instances. Using a separate volume isolates it from the operating system, which increases performance. If no additional EBS volume is added, the Anbox Cloud Appliance automatically creates an image on the root disk, which is used to store any data. However, this is not recommended.
 
@@ -119,9 +119,9 @@ Anbox Cloud uses the additional volume exclusively to store all of its data, inc
 
 In this example, we use three storage volumes:
 
-* Volume 1 at `/dev/sda1` as root disk with a size of 50 GB
-* Volume 2 at `/dev/sdb` as EBS volume with a size of 100 GB
-* Volume 3, an ephemeral disk at `/dev/nvme0n1`, which is part of the `g4dn` instance and which is ignored by the Anbox Cloud Appliance
+- Volume 1 at `/dev/sda1` as root disk with a size of 50 GB
+- Volume 2 at `/dev/sdb` as EBS volume with a size of 100 GB
+- Volume 3, an ephemeral disk at `/dev/nvme0n1`, which is part of the `g4dn` instance and which is ignored by the Anbox Cloud Appliance
 
 If you don't have any specific requirements, we recommend choosing the same configuration.
 

--- a/howto/install-appliance/install-on-azure.md
+++ b/howto/install-appliance/install-on-azure.md
@@ -31,14 +31,14 @@ Check the hardware requirements listed in {ref}`sec-minimum-hardware-requirement
 
 In addition, make sure you have the following prerequisites:
 
-* An Ubuntu SSO account. If you don't have one yet, create it [here](https://login.ubuntu.com).
-* Your Ubuntu Pro token for an Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://canonical.com/anbox-cloud#get-in-touch). If you already have a valid Ubuntu Pro token, log in to [Ubuntu Pro](https://ubuntu.com/pro) to retrieve it.
+- An Ubuntu SSO account. If you don't have one yet, create it [here](https://login.ubuntu.com).
+- Your Ubuntu Pro token for an Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://canonical.com/anbox-cloud#get-in-touch). If you already have a valid Ubuntu Pro token, log in to [Ubuntu Pro](https://ubuntu.com/pro) to retrieve it.
 
 ```{caution}
   The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need an *Ubuntu Pro* subscription.
 ```
 
-* An Azure account that you use to create the virtual machine.
+- An Azure account that you use to create the virtual machine.
 
 Once you have the prerequisites, the first step is to create a virtual machine on which you can install the Anbox Cloud Appliance.
 
@@ -56,10 +56,10 @@ In the Quickstart Center, select **Deploy a virtual machine**. On the resulting 
 
 On the **Basics** tab of the virtual machine configuration, specify the required information. Several of the options are specific to how and where you want to deploy your virtual machine. In most cases you can keep the default values, but make sure to set the following configurations:
 
-* Select the latest supported Ubuntu image for the architecture that you want to use. The following instructions and screenshots use the Arm64 architecture.
-* Select a size that matches the hardware requirements(see {ref}`sec-minimum-hardware-requirements`). For example, select `Standard_D16ps_v5`, which has 16 vCPUs and 64 GB of RAM.
-* Change the user name of the administrator account to `ubuntu`.
-* Accept the defaults for the inbound port rules for now; these rules will be configured later in the setup process.
+- Select the latest supported Ubuntu image for the architecture that you want to use. The following instructions and screenshots use the Arm64 architecture.
+- Select a size that matches the hardware requirements(see {ref}`sec-minimum-hardware-requirements`). For example, select `Standard_D16ps_v5`, which has 16 vCPUs and 64 GB of RAM.
+- Change the user name of the administrator account to `ubuntu`.
+- Accept the defaults for the inbound port rules for now; these rules will be configured later in the setup process.
 
 ![Basics tab](/images/appliance-on-azure/azure_config-basics-co.png)
 

--- a/howto/install-appliance/install-on-github.md
+++ b/howto/install-appliance/install-on-github.md
@@ -5,8 +5,8 @@ For use within a [GitHub Action workflow](https://github.com/features/actions), 
 
 ## Prerequisites
 
-* A repository on GitHub which can host GitHub Action workflows
-* The token for your [Ubuntu Pro](https://ubuntu.com/pro) subscription
+- A repository on GitHub which can host GitHub Action workflows
+- The token for your [Ubuntu Pro](https://ubuntu.com/pro) subscription
 
 ## Create a new workflow
 

--- a/howto/install-appliance/install-on-google-cloud.md
+++ b/howto/install-appliance/install-on-google-cloud.md
@@ -13,9 +13,9 @@ Currently, Anbox Cloud requires support for 32-bit architecture. Since T2A ARM i
 
 Before starting the procedure,
 
-* Check the hardware requirements listed in {ref}`ref-requirements` for the Anbox Cloud Appliance.
-* Make sure that you have a Google Cloud account and a project on Google Cloud to create the virtual machine.
-* If you wish to use your own [Ubuntu Pro subscription](https://ubuntu.com/pro), ensure you have the Ubuntu Pro token for your Ubuntu Pro subscription. If you wish to use the Ubuntu Pro subscription offered by Google Cloud along with the virtual machine, skip this prerequisite.
+- Check the hardware requirements listed in {ref}`ref-requirements` for the Anbox Cloud Appliance.
+- Make sure that you have a Google Cloud account and a project on Google Cloud to create the virtual machine.
+- If you wish to use your own [Ubuntu Pro subscription](https://ubuntu.com/pro), ensure you have the Ubuntu Pro token for your Ubuntu Pro subscription. If you wish to use the Ubuntu Pro subscription offered by Google Cloud along with the virtual machine, skip this prerequisite.
 
 ## Virtual machine setup
 
@@ -27,10 +27,10 @@ Log in to [Google Cloud](https://console.cloud.google.com) and select the projec
 
 ### Configure basic settings
 
-* *Name* - Name of the virtual machine instance
-* *Labels* - Organizational labels to keep track of your resources on Google Cloud
-* *Region* and *Zone* - The geographic location where your resources are run and your data is stored
-* *Machine configuration*, *Series*, *Machine type* and *Display device* - Select a machine configuration that matches the hardware requirements. If your requirement includes GPUs, select the GPU-optimized machine configuration. For example, an NVIDIA L4 GPU. You can select the recommended preset machine type or define a custom type with additional cores and memory for an added cost.
+- *Name* - Name of the virtual machine instance
+- *Labels* - Organizational labels to keep track of your resources on Google Cloud
+- *Region* and *Zone* - The geographic location where your resources are run and your data is stored
+- *Machine configuration*, *Series*, *Machine type* and *Display device* - Select a machine configuration that matches the hardware requirements. If your requirement includes GPUs, select the GPU-optimized machine configuration. For example, an NVIDIA L4 GPU. You can select the recommended preset machine type or define a custom type with additional cores and memory for an added cost.
 
 Most of the configuration depends on your deployment and its location. For the settings that are not mentioned in this guide, you can choose to proceed with the default options or see [Google's documentation](https://docs.cloud.google.com/compute/docs/instances/create-start-instance) to customize your virtual machine on Google Cloud.
 

--- a/howto/install/deploy-bare-metal.md
+++ b/howto/install/deploy-bare-metal.md
@@ -7,8 +7,8 @@ This document guides you through the steps to install Anbox Cloud on a [manual c
 
 Before you start the installation, ensure that you have the required prerequisites:
 
-* At least three Ubuntu machines. See {ref}`sec-minimum-hardware-requirements` for details and recommendations.
-* Your Ubuntu Pro token for an Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://canonical.com/anbox-cloud#get-in-touch). If you already have a valid Ubuntu Pro token, log in to [Ubuntu Pro](https://ubuntu.com/pro) to retrieve it.
+- At least three Ubuntu machines. See {ref}`sec-minimum-hardware-requirements` for details and recommendations.
+- Your Ubuntu Pro token for an Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://canonical.com/anbox-cloud#get-in-touch). If you already have a valid Ubuntu Pro token, log in to [Ubuntu Pro](https://ubuntu.com/pro) to retrieve it.
 
   ```{caution}
   The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need an *Ubuntu Pro* subscription.
@@ -137,11 +137,11 @@ Now you can deploy Anbox Cloud. The deployment is entirely handled by Juju and d
 
 Choose between the available Juju bundles (see {ref}`sec-juju-bundles`):
 
-* For a minimized version of Anbox Cloud without the streaming stack, run the following command to deploy the `anbox-cloud-core` bundle:
+- For a minimized version of Anbox Cloud without the streaming stack, run the following command to deploy the `anbox-cloud-core` bundle:
 
         juju deploy anbox-cloud-core --overlay ua.yaml --map-machines 0=0,1=1
 
-* For the full version of Anbox Cloud, run the following command to deploy the `anbox-cloud` bundle:
+- For the full version of Anbox Cloud, run the following command to deploy the `anbox-cloud` bundle:
 
         juju deploy anbox-cloud --overlay ua.yaml --map-machines 0=0,1=1,2=2,3=3
 

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -13,12 +13,12 @@ There are differences between the charmed Anbox Cloud installation and the Anbox
 
 Before you start the installation, ensure that you have the required credentials and prerequisites:
 
-* A machine running a {ref}`supported Ubuntu version <ref-requirements>`.
-* Account credentials for one of the following public clouds:
+- A machine running a {ref}`supported Ubuntu version <ref-requirements>`.
+- Account credentials for one of the following public clouds:
   * [Amazon Web Services](https://aws.amazon.com/) (including AWS-China)
   * [Google Cloud platform](https://cloud.google.com/)
   * [Microsoft Azure](https://azure.microsoft.com/)
-* Your Ubuntu Pro token for an Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://canonical.com/anbox-cloud#get-in-touch). If you already have a valid Ubuntu Pro token, log in to [Ubuntu Pro website](https://ubuntu.com/pro) to retrieve it.
+- Your Ubuntu Pro token for an Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://canonical.com/anbox-cloud#get-in-touch). If you already have a valid Ubuntu Pro token, log in to [Ubuntu Pro website](https://ubuntu.com/pro) to retrieve it.
 
   ```{caution}
   The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need an Ubuntu Pro subscription.
@@ -118,11 +118,11 @@ To install Anbox Cloud, deploy the suitable Anbox Cloud bundle to the Juju model
 
 Choose between the available {ref}`sec-juju-bundles`:
 
-* For a minimized version of Anbox Cloud without the streaming stack, run the following command to deploy the `anbox-cloud-core` bundle:
+- For a minimized version of Anbox Cloud without the streaming stack, run the following command to deploy the `anbox-cloud-core` bundle:
 
         juju deploy anbox-cloud-core --overlay ua.yaml
 
-* For the full version of Anbox Cloud, run the following command to deploy the `anbox-cloud` bundle:
+- For the full version of Anbox Cloud, run the following command to deploy the `anbox-cloud` bundle:
 
         juju deploy anbox-cloud --overlay ua.yaml
 

--- a/howto/install/deploy-terraform.md
+++ b/howto/install/deploy-terraform.md
@@ -10,14 +10,14 @@ which is also in active development. There may be breaking changes in the future
 
 ## Prerequisites
 
-* A machine running a {ref}`supported Ubuntu version <ref-requirements>`.
-* Your Ubuntu Pro token for an Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://canonical.com/anbox-cloud#get-in-touch). If you already have a valid Ubuntu Pro token, log in to [Ubuntu Pro website](https://ubuntu.com/pro) to retrieve it.
+- A machine running a {ref}`supported Ubuntu version <ref-requirements>`.
+- Your Ubuntu Pro token for an Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://canonical.com/anbox-cloud#get-in-touch). If you already have a valid Ubuntu Pro token, log in to [Ubuntu Pro website](https://ubuntu.com/pro) to retrieve it.
 
   ```{caution}
   The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need an Ubuntu Pro subscription.
   ```
 
-* A Juju Controller bootstrapped and connected to your Juju Client (CLI). See {ref}`sec-setup-juju-controller` for information on how to setup a Juju Controller.
+- A Juju Controller bootstrapped and connected to your Juju Client (CLI). See {ref}`sec-setup-juju-controller` for information on how to setup a Juju Controller.
 
 ## Install Terraform
 

--- a/howto/install/use-ceph-storage.md
+++ b/howto/install/use-ceph-storage.md
@@ -13,11 +13,11 @@ The storage type must be configured at deployment time and cannot be changed aft
 
 Before configuring Ceph storage for Anbox Cloud, ensure that you have:
 
-* A machine running a {ref}`supported Ubuntu version <ref-requirements>`.
-* Juju 3.x installed (see {ref}`howto-deploy-anbox-juju` for installation instructions).
-* A Juju controller and model set up (see {ref}`sec-setup-juju-controller`).
-* Your Ubuntu Pro token (see {ref}`sec-attach-pro-subscription`).
-* One of the following Ceph deployment options:
+- A machine running a {ref}`supported Ubuntu version <ref-requirements>`.
+- Juju 3.x installed (see {ref}`howto-deploy-anbox-juju` for installation instructions).
+- A Juju controller and model set up (see {ref}`sec-setup-juju-controller`).
+- Your Ubuntu Pro token (see {ref}`sec-attach-pro-subscription`).
+- One of the following Ceph deployment options:
   * A [microceph](https://charmhub.io/microceph) deployment for testing or single-server setups.
   * A [ceph-mon](https://charmhub.io/ceph-mon) cluster for production deployments.
   * Access to an existing Ceph cluster via [ceph-proxy](https://charmhub.io/ceph-proxy).

--- a/howto/install/validate-deployment.md
+++ b/howto/install/validate-deployment.md
@@ -5,14 +5,14 @@ Anbox Cloud includes a test suite which allows the validation of an Anbox Cloud 
 
 The validation tests currently cover the following areas of an Anbox Cloud deployment:
 
-* AMS
+- AMS
   * Instance creation and deletion in different configurations
   * Expected images are present
   * Configuration is setup as expected
-* Anbox Stream Gateway API
+- Anbox Stream Gateway API
   * Session creation and deletion
   * Stress testing
-* Streaming
+- Streaming
   * Stream selected applications in different configurations from Anbox Cloud while ensuring performance is as expected
 
 ## Install Validation Tests
@@ -106,6 +106,6 @@ If you want to focus on a specific subset of the tests you can specify a focus f
 
 The following focus areas are available
 
-* `streaming`
-* `gateway`
-* `ams`
+- `streaming`
+- `gateway`
+- `ams`

--- a/howto/instance/backup-restore-application-data.md
+++ b/howto/instance/backup-restore-application-data.md
@@ -67,8 +67,8 @@ The resulting tarball file will include the following files:
 
 And exclude the following files:
 
-* Files with `jpeg` suffix below the folder `/sdcard/Android/data/com.canonical.candy/user_data`
-* Files with `cfg` suffix below the folder `/data/data/com.canonical.candy/new_level`
+- Files with `jpeg` suffix below the folder `/sdcard/Android/data/com.canonical.candy/user_data`
+- Files with `cfg` suffix below the folder `/data/data/com.canonical.candy/new_level`
 
 ## Related topics
 

--- a/howto/instance/configure-geographic-location.md
+++ b/howto/instance/configure-geographic-location.md
@@ -36,4 +36,4 @@ See {ref}`sec-anbox-https-api-location` for information on the PATCH method and 
 
 ## Related topics
 
-* {ref}`howto-addons`
+- {ref}`howto-addons`

--- a/howto/instance/copy-instance.md
+++ b/howto/instance/copy-instance.md
@@ -6,9 +6,9 @@ Copying an instance allows you to create a copy of an existing instance. This is
 
 Important considerations before copying instances:
 
-* Resource availability: Ensure the cluster has enough capacity (CPU, GPU, RAM) to host the new copy.
-* State awareness: Understand that a copied instance will inherit the file system state of the source.
-* Log isolation: When copying an instance in an error state, the new instance is a fresh clone and will not include logs from the source instance.
+- Resource availability: Ensure the cluster has enough capacity (CPU, GPU, RAM) to host the new copy.
+- State awareness: Understand that a copied instance will inherit the file system state of the source.
+- Log isolation: When copying an instance in an error state, the new instance is a fresh clone and will not include logs from the source instance.
 
 ## Copy an instance
 
@@ -23,9 +23,9 @@ To copy an instance, follow these steps:
 
 Before initializing a copy, verify the status of the source instance. A copy operation is permitted only if the instance is in one of the following states:
 
-* `Stopped`
-* `Running` (requires --force or interactive confirmation to stop the instance)
-* `Error` (requires --force or interactive confirmation to acknowledge logs will not be copied)
+- `Stopped`
+- `Running` (requires --force or interactive confirmation to stop the instance)
+- `Error` (requires --force or interactive confirmation to acknowledge logs will not be copied)
 
 Check the instance status with:
 
@@ -61,7 +61,7 @@ This is especially useful for ensuring high availability by manually distributin
 
 ## Related topics
 
-* {ref}`howto-create-instance`
-* {ref}`howto-start-instance`
-* {ref}`howto-stop-instance`
-* {ref}`howto-publish-instance-as-image`
+- {ref}`howto-create-instance`
+- {ref}`howto-start-instance`
+- {ref}`howto-stop-instance`
+- {ref}`howto-publish-instance-as-image`

--- a/howto/instance/create-instance.md
+++ b/howto/instance/create-instance.md
@@ -20,8 +20,8 @@ To launch an application or an image, Anbox Cloud creates an instance for it. To
 
 Depending on what you need, you can use the either of the following commands to create an instance for a registered application or an image.
 
-* `amc launch` creates and starts the instance.
-* `amc init` only creates the instance.
+- `amc launch` creates and starts the instance.
+- `amc init` only creates the instance.
 
 By default, the instance will run headless.
 
@@ -189,6 +189,6 @@ The instance details page also contains all the available actions including stre
 
 ## Related topics
 
-* {ref}`exp-application-streaming`
-* {ref}`exp-instances`
-* {ref}`howto-access-instance`
+- {ref}`exp-application-streaming`
+- {ref}`exp-instances`
+- {ref}`howto-access-instance`

--- a/howto/instance/restart-instance.md
+++ b/howto/instance/restart-instance.md
@@ -17,6 +17,6 @@ By default, the `amc restart` command waits 5 minutes for both stopping and star
 
 ## Related topics
 
-* {ref}`howto-create-instance`
-* {ref}`howto-start-instance`
-* {ref}`howto-stop-instance`
+- {ref}`howto-create-instance`
+- {ref}`howto-start-instance`
+- {ref}`howto-stop-instance`

--- a/howto/instance/start-instance.md
+++ b/howto/instance/start-instance.md
@@ -25,5 +25,5 @@ Starting an instance that has stopped with an error status is is not allowed. Do
 
 ## Related topics
 
-* {ref}`howto-create-instance`
-* {ref}`howto-stop-instance`
+- {ref}`howto-create-instance`
+- {ref}`howto-stop-instance`

--- a/howto/port/index.md
+++ b/howto/port/index.md
@@ -3,12 +3,12 @@
 
 When porting an Android app to Anbox Cloud (usually in the form of an APK), there are a few issues that might cause your app to not function properly:
 
-* Missing dependencies, most importantly to Google Play services. Google Play services are not supported by Anbox Cloud, and apps that require Google Play services can therefore not be ported to Anbox Cloud.
-* Missing runtime permissions. See {ref}`howto-grant-runtime-permissions` for instructions on how to grant the required permissions.
-* Mismatched architecture. See {ref}`howto-choose-apk-architecture` for information on which architecture you should choose.
-* App size. See {ref}`howto-exchange-oob-data` for instructions on how to port large APKs.
-* Strict watchdog restrictions. See {ref}`howto-configure-watchdog` if you want to turn the watchdog off for debugging or configure it to not trigger for specific apps.
-* Install an APK as a system app. See {ref}`howto-install-apk-system-app` if you want to install a user app as a system app running in an Android container.
+- Missing dependencies, most importantly to Google Play services. Google Play services are not supported by Anbox Cloud, and apps that require Google Play services can therefore not be ported to Anbox Cloud.
+- Missing runtime permissions. See {ref}`howto-grant-runtime-permissions` for instructions on how to grant the required permissions.
+- Mismatched architecture. See {ref}`howto-choose-apk-architecture` for information on which architecture you should choose.
+- App size. See {ref}`howto-exchange-oob-data` for instructions on how to port large APKs.
+- Strict watchdog restrictions. See {ref}`howto-configure-watchdog` if you want to turn the watchdog off for debugging or configure it to not trigger for specific apps.
+- Install an APK as a system app. See {ref}`howto-install-apk-system-app` if you want to install a user app as a system app running in an Android container.
 
 ```{toctree}
 :hidden:

--- a/howto/setup-custom-idp/configure-oidc.md
+++ b/howto/setup-custom-idp/configure-oidc.md
@@ -38,5 +38,5 @@ The user can also access AMS by running
 
 ## Related topics
 
-* {ref}`tut-installing-appliance`
-* {ref}`howto-use-web-dashboard`
+- {ref}`tut-installing-appliance`
+- {ref}`howto-use-web-dashboard`

--- a/howto/stream/access-stream-gateway.md
+++ b/howto/stream/access-stream-gateway.md
@@ -9,8 +9,8 @@ Similar to the Anbox Management Service (AMS), the stream gateway exposes its AP
 
 To access the stream gateway,
 
-* The gateway's HTTP API must be exposed. This is the default configuration.
-* All calls to the stream gateway must be authenticated. Authentication takes the form of a single token per client that you must embed in your requests. A token is associated to a *service account*, has a limited lifetime, and can be revoked at any time.
+- The gateway's HTTP API must be exposed. This is the default configuration.
+- All calls to the stream gateway must be authenticated. Authentication takes the form of a single token per client that you must embed in your requests. A token is associated to a *service account*, has a limited lifetime, and can be revoked at any time.
 
 ### Creating a token
 
@@ -61,7 +61,7 @@ Type `anbox-stream-gateway --help` to list all commands.
 
 ## Related topics
 
-* {ref}`exp-application-streaming`
-* {ref}`exp-ams`
-* {ref}`tut-set-up-stream-client`
-* {ref}`sec-streaming-sdk`
+- {ref}`exp-application-streaming`
+- {ref}`exp-ams`
+- {ref}`tut-set-up-stream-client`
+- {ref}`sec-streaming-sdk`

--- a/howto/stream/enable-client-side-video-upscaling.md
+++ b/howto/stream/enable-client-side-video-upscaling.md
@@ -51,6 +51,6 @@ When using a custom fragment shader in WebGL, you need to manage the following p
 
 ## Related topics
 
-* {ref}`exp-application-streaming`
-* {ref}`tut-set-up-stream-client`
-* {ref}`sec-streaming-sdk`
+- {ref}`exp-application-streaming`
+- {ref}`tut-set-up-stream-client`
+- {ref}`sec-streaming-sdk`

--- a/howto/stream/exchange-oob-data.md
+++ b/howto/stream/exchange-oob-data.md
@@ -190,7 +190,7 @@ If an instance is running on Android 14 or later, enabling the out-of-band v2 fe
 
 There are two ways to access the `org.anbox.webrtc.IDataProxyService` binder service from an Android application:
 
-* If you develop the application with Android studio, you can access the service by using Android's reflection API.
+- If you develop the application with Android studio, you can access the service by using Android's reflection API.
 
     ```
     IBinder getDataProxyService() {

--- a/howto/stream/integrate-virtual-keyboard.md
+++ b/howto/stream/integrate-virtual-keyboard.md
@@ -6,8 +6,8 @@ The Anbox Streaming SDK enables developers to build a hybrid mobile application 
 
 You can use Anbox WebView to quickly integrate a client-side virtual keyboard feature into your mobile application. This client-side virtual keyboard can send text to the Android container on the fly when typing:
 
-* When the text editor of the application in the instance gains focus, the client-side virtual keyboard pops up, and it disappears when the focus moves away.
-* When typing on the client-side virtual keyboard, the input text is sent to the Android container and displayed in the running application.
+- When the text editor of the application in the instance gains focus, the client-side virtual keyboard pops up, and it disappears when the focus moves away.
+- When typing on the client-side virtual keyboard, the input text is sent to the Android container and displayed in the running application.
 
 The following steps provide general instructions for integrating the client-side virtual keyboard feature into an Android application. See {ref}`sec-customizing-the-virtual-keyboard` for additional implementation options.
 
@@ -77,8 +77,8 @@ Adding the following JavaScript code snippet builds up a communication tunnel be
 
 You can take advantage of the interfaces that the Anbox WebView exposes to provide your own implementation of a client-side virtual keyboard that customizes:
 
-* Input text processing
-* Handling of state changes of the virtual keyboard
+- Input text processing
+- Handling of state changes of the virtual keyboard
 
 1. Set up the listener to the activity for which you want to capture the text input events from the virtual keyboard or monitor its visibility changes during streaming.
 

--- a/howto/troubleshoot/index.md
+++ b/howto/troubleshoot/index.md
@@ -44,8 +44,8 @@ If you have the [`juju-crashdump` plugin](https://github.com/juju/juju-crashdump
 
 A Juju crash dump may include the following debugging information:
 
-* Additional information provided by the Anbox Cloud charms
-* Information about any instances that crashed
+- Additional information provided by the Anbox Cloud charms
+- Information about any instances that crashed
 
 Use the following command to generate a crash dump:
 

--- a/howto/troubleshoot/troubleshoot-dashboard-issues.md
+++ b/howto/troubleshoot/troubleshoot-dashboard-issues.md
@@ -11,8 +11,8 @@ Streaming can fail when there are not enough resources to start a streaming sess
 
 Try the following actions:
 
-* Verify if you have sufficient resources for instance/application creation. See {ref}`exp-capacity-planning` for more information.
-* Check if all the nodes are in `unschedulable` mode. See {ref}`sec-node-configuration` for more information.
+- Verify if you have sufficient resources for instance/application creation. See {ref}`exp-capacity-planning` for more information.
+- Check if all the nodes are in `unschedulable` mode. See {ref}`sec-node-configuration` for more information.
 
 ## Session does not start
 
@@ -35,8 +35,8 @@ An instance can end up with an error status due to various reasons. It may not a
 
 The error message tooltip can give you a starting point for identifying the issue. Some reasons for an instance to go into error status could be:
 
-* Insufficient resources. Refer to {ref}`exp-capacity-planning`.
-* Occasionally, access to Ubuntu archives could be a problem when creating an application. As an immediate workaround, you could disable the security update by running `amc config set instance.security_updates false` or explicitly set `amc config set instance.api_mirror <mirror_address>` to configure an instance to use a different APT mirror. See {ref}`ref-ams-configuration` for more details.
+- Insufficient resources. Refer to {ref}`exp-capacity-planning`.
+- Occasionally, access to Ubuntu archives could be a problem when creating an application. As an immediate workaround, you could disable the security update by running `amc config set instance.security_updates false` or explicitly set `amc config set instance.api_mirror <mirror_address>` to configure an instance to use a different APT mirror. See {ref}`ref-ams-configuration` for more details.
 
 If the reason for the instance failure is not obvious from the error message, check the *Logs* tab for more information.
 
@@ -46,8 +46,8 @@ If the reason for the instance failure is not obvious from the error message, ch
 
 Logs are unavailable for an instance when:
 
-* The instance is not in error status.
-* Occasionally, the instance could have ended up with an error status due to insufficient resources but there are no log files because the application bootstrap process succeeded.
+- The instance is not in error status.
+- Occasionally, the instance could have ended up with an error status due to insufficient resources but there are no log files because the application bootstrap process succeeded.
 
 Normally, the logs are available if the instance is in an error state. If the instance is in the error state and yet there are no logs available, check if you have enough resources. See {ref}`exp-capacity-planning` for more information.
 

--- a/howto/troubleshoot/view-logs.md
+++ b/howto/troubleshoot/view-logs.md
@@ -69,11 +69,11 @@ This is the default for any Juju model. It indicates that the machine log level 
 
 The logging levels, from most verbose to least verbose, are as follows:
 
-* `TRACE`
-* `DEBUG`
-* `INFO`
-* `WARNING`
-* `ERROR`
+- `TRACE`
+- `DEBUG`
+- `INFO`
+- `WARNING`
+- `ERROR`
 
 The logging level can be set like this:
 

--- a/howto/upgrade/index.md
+++ b/howto/upgrade/index.md
@@ -26,5 +26,5 @@ In a production environment, this update behavior might cause problems in some c
 - Different nodes of an Anbox Cloud or LXD cluster might end up running different snap versions.
 
 To prevent such problems, use either of the following methods:
-* Define maintenance windows in which your systems can be updated without interrupting operations. See [Managing updates](https://snapcraft.io/docs/managing-updates) in the snap documentation for information on how to control snap updates on your systems.
-* Configure a [Snap Store Proxy](https://ubuntu.com/enterprise-store/docs/) to control which snaps are served to the machines that use the proxy. In particular, you can use the proxy to [override snap revisions](https://ubuntu.com/enterprise-store/docs/). In this method, you have full control over when snaps are updated.
+- Define maintenance windows in which your systems can be updated without interrupting operations. See [Managing updates](https://snapcraft.io/docs/managing-updates) in the snap documentation for information on how to control snap updates on your systems.
+- Configure a [Snap Store Proxy](https://ubuntu.com/enterprise-store/docs/) to control which snaps are served to the machines that use the proxy. In particular, you can use the proxy to [override snap revisions](https://ubuntu.com/enterprise-store/docs/). In this method, you have full control over when snaps are updated.

--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -51,11 +51,11 @@ You can find a list of all charm, snap, bundle and Debian package versions for e
 
 Before you run the `juju refresh` command to upgrade the charms, there are a few points you should know:
 
-* If you don't run Anbox Cloud in a high availability configuration, upgrading the charms will cause a short down time of individual service components during the process.
-* Starting with the 1.21 release, the NATS charm has been switched from its [older version](https://charmhub.io/nats-charmers-nats) to a [newer version](https://charmhub.io/nats) on Charmhub. This switch does not have any breaking changes from a user's perspective but since the framework of the charm has been overhauled, the upgrade to the new charm would require users to `switch` the charm's source while refreshing/updating the charm.
-* Starting with the 1.22 release, the `anbox-stream-agent` charm has a new relation `client` which can be used to register new clients for the Anbox Stream Agent. This new relation is used by the new AMS charm to create stream-enabled instances using the `--enable-streaming` option. For deployments using the bundles from or after 1.22 release, the relation is created automatically. For users upgrading from older versions of Anbox Cloud, the relation needs to be manually created using `juju relate anbox-stream-agent:client ams:agent` after upgrading both the `ams` and the `anbox-stream-agent` charms to 1.22.
-* If you want to deploy a particular revision of a charm, you can do so by adding `--revision=<rev>` to the `juju upgrade-charm` command.
-* For any of the charm upgrades, you can watch the upgrade status by running `juju status`.
+- If you don't run Anbox Cloud in a high availability configuration, upgrading the charms will cause a short down time of individual service components during the process.
+- Starting with the 1.21 release, the NATS charm has been switched from its [older version](https://charmhub.io/nats-charmers-nats) to a [newer version](https://charmhub.io/nats) on Charmhub. This switch does not have any breaking changes from a user's perspective but since the framework of the charm has been overhauled, the upgrade to the new charm would require users to `switch` the charm's source while refreshing/updating the charm.
+- Starting with the 1.22 release, the `anbox-stream-agent` charm has a new relation `client` which can be used to register new clients for the Anbox Stream Agent. This new relation is used by the new AMS charm to create stream-enabled instances using the `--enable-streaming` option. For deployments using the bundles from or after 1.22 release, the relation is created automatically. For users upgrading from older versions of Anbox Cloud, the relation needs to be manually created using `juju relate anbox-stream-agent:client ams:agent` after upgrading both the `ams` and the `anbox-stream-agent` charms to 1.22.
+- If you want to deploy a particular revision of a charm, you can do so by adding `--revision=<rev>` to the `juju upgrade-charm` command.
+- For any of the charm upgrades, you can watch the upgrade status by running `juju status`.
 
   At any point during the upgrade process, proceed to the next step only when the current step has completed successfully and all units in the `juju status` output are marked as **active**.
 

--- a/reference/addon-manifest.md
+++ b/reference/addon-manifest.md
@@ -12,5 +12,5 @@ The following table lists the valid keys in an addon manifest:
 
 ## Related topics
 
-* {ref}`howto-create-addon`
-* {ref}`howto-addons`
+- {ref}`howto-create-addon`
+- {ref}`howto-addons`

--- a/reference/api-reference/anbox-https-api.md
+++ b/reference/api-reference/anbox-https-api.md
@@ -23,8 +23,8 @@ Feature additions are done without breaking backward compatibility only result i
 
 There are two standard return types:
 
-* Standard return value
-* Error
+- Standard return value
+- Error
 
 ### Standard return value
 
@@ -61,7 +61,7 @@ HTTP code must be one of 400 or 500.
 
 ## API structure
 
-* {ref}`sec-anbox-https-api-1.0`
+- {ref}`sec-anbox-https-api-1.0`
   * {ref}`sec-anbox-https-api-location`
   * {ref}`sec-anbox-https-api-camera`
     * {ref}`sec-anbox-https-api-cameradata`
@@ -79,11 +79,11 @@ HTTP code must be one of 400 or 500.
 ### `/1.0/`
 #### GET
 
-* Description: Server configuration
-* Operation: sync
-* Steps:
-    - Fetch general information of the server
-* Return: Dict representing server state
+- Description: Server configuration
+- Operation: sync
+- Steps:
+  * Fetch general information of the server
+- Return: Dict representing server state
 
 Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0 | jq .`:
 
@@ -114,9 +114,9 @@ Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.
 
 #### PATCH
 
-* Description: Update the server configuration
-* Operation: sync
-* Return: standard return value or standard error
+- Description: Update the server configuration
+- Operation: sync
+- Return: standard return value or standard error
 
 Input:
 
@@ -144,9 +144,9 @@ Example: `curl -X PATCH --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.
 ### `/1.0/location`
 #### GET
 
-* Description: Get location status
-* Operation: sync
-* Return: Current location status
+- Description: Get location status
+- Operation: sync
+- Return: Current location status
 
 ```{note}
 After enabling the location endpoint, any location updates provided via the [Anbox Platform API](https://canonical.github.io/anbox-cloud.github.com/latest/anbox-platform-sdk/) won't be processed by Anbox until the location endpoint is disabled again.
@@ -167,9 +167,9 @@ After enabling the location endpoint, any location updates provided via the [Anb
 
 #### POST
 
-* Description: Activate or deactivate location updates
-* Operation: sync
-* Return: standard return value or standard error
+- Description: Activate or deactivate location updates
+- Operation: sync
+- Return: standard return value or standard error
 
 ```{note}
 Location updates must be activated before posting any location data to Anbox via the `PATCH` method.  If location updates are disabled, requests to provide updates to the Anbox HTTP API will fail.
@@ -187,9 +187,9 @@ Return value for `curl -s -X POST --unix-socket /run/user/1000/anbox/sockets/api
 
 #### PATCH
 
-* Description: Provide location update to be forwarded to Android
-* Operation: sync
-* Return: standard return value or standard error
+- Description: Provide location update to be forwarded to Android
+- Operation: sync
+- Return: standard return value or standard error
 
 ```{note}
 The latitude or longitude of geographic coordinates can be expressed in [decimal degree](https://en.wikipedia.org/wiki/Decimal_degrees) form (WGS84 data format) as shown below in the example or in an NMEA-based data format as [`ddmm.mm`](https://en.wikipedia.org/wiki/Geographic_coordinate_conversion) (d refers to degrees, m refers to minutes). Specify the format by setting the `format` field to either `"wgs84"` or `"nmea"`. If the field is omitted, its value defaults to `"wgs84"`. No matter which format you use, northern latitudes or eastern longitudes are positive, southern latitudes or western longitudes are negative.
@@ -213,14 +213,14 @@ Input:
 }
 ```
 
-* "latitude" and "longitude" indicate the Latitude and Longitude of geographic coordinates.
+- "latitude" and "longitude" indicate the Latitude and Longitude of geographic coordinates.
 
-* "altitude" indicates Altitude in meters.
-* "time" indicates the current time in millisecond since 1970-01-01 00:00:00 UTC.
-* "speed" indicates speed in meters per second.
-* "bearing" indicates magnetic heading in degrees.
-* "format" indicates the location format and is an optional value.
-* "horizontal_accuracy" and "vertical_accuracy" indicate the horizontal and vertical accuracy in meters and are optional.
+- "altitude" indicates Altitude in meters.
+- "time" indicates the current time in millisecond since 1970-01-01 00:00:00 UTC.
+- "speed" indicates speed in meters per second.
+- "bearing" indicates magnetic heading in degrees.
+- "format" indicates the location format and is an optional value.
+- "horizontal_accuracy" and "vertical_accuracy" indicate the horizontal and vertical accuracy in meters and are optional.
 
 Return value:
 
@@ -237,9 +237,9 @@ Return value:
 
 #### GET
 
-* Description: Get camera basic information
-* Operation: sync
-* Return: Current camera basic information
+- Description: Get camera basic information
+- Operation: sync
+- Return: Current camera basic information
 
  Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0/camera | jq .`:
 
@@ -263,10 +263,10 @@ Return value:
 
 #### POST
 
-* Description: Activate or deactivate camera data updates.
+- Description: Activate or deactivate camera data updates.
     Whenever uploading a static image or streaming video content to display it in Anbox,  you need to enable the camera support first in Anbox.
-* Operation: sync
-* Return: standard return value or standard error
+- Operation: sync
+- Return: standard return value or standard error
 
  Return value for `curl -s -X POST --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0/camera --data '{"enable":true}' | jq .`:
 
@@ -292,10 +292,10 @@ To determine if the camera is enabled, run the following query:
 
 #### POST
 
-* Description: Upload a static image to Anbox
+- Description: Upload a static image to Anbox
  After a camera is enabled,  a static image (only JPEG format is supported by far) can be uploaded to Anbox as camera data.
-* Operation: sync
-* Return: standard return value or standard error
+- Operation: sync
+- Return: standard return value or standard error
 
 Return value for `curl -s --unix-socket /run/user/1000/anbox/sockets/api.unix -X POST s/1.0/camera/data --data-binary @/<jpeg image path> | jq .`:
 
@@ -317,9 +317,9 @@ Irrespective of whether the screen orientation is in landscape or portrait, the 
 
 #### DELETE
 
-* Description: Delete the uploaded static image
-* Operation: sync
-* Return: standard return value or standard error
+- Description: Delete the uploaded static image
+- Operation: sync
+- Return: standard return value or standard error
 
 Return value for `curl --unix-socket /run/user/1000/anbox/sockets/api.unix -X DELETE s/1.0/camera/data`:
 
@@ -368,9 +368,9 @@ ffmpeg -r 10 -i test.mp4 -vf format=rgba -s 1280x720 -f rawvideo -r 25 - | nc -N
 
 #### GET
 
-* Description: Get sensors’ status and supported sensors by Anbox
-* Operation: sync
-* Return: Current sensors’ status and supported sensors by Anbox
+- Description: Get sensors’ status and supported sensors by Anbox
+- Operation: sync
+- Return: Current sensors’ status and supported sensors by Anbox
 
 Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0/sensors | jq .`:
 
@@ -408,9 +408,9 @@ Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.
 
 #### POST
 
-* Description: Activate or deactivate sensor updates
-* Operation: sync
-* Return: standard return value or standard error
+- Description: Activate or deactivate sensor updates
+- Operation: sync
+- Return: standard return value or standard error
 
 ```{note}
 Sensor updates must be activated before posting any sensor data to Anbox via the `PATCH` method.  If sensor updates are disabled, requests to provide updates to the Anbox HTTP API will fail.
@@ -428,10 +428,10 @@ Return value for `curl -s -X POST --unix-socket /run/user/1000/anbox/sockets/api
 
 #### PATCH
 
-* Description: Update sensor data to be forwarded to Android.
+- Description: Update sensor data to be forwarded to Android.
     The API accepts a JSON array-based sensor data to be forwarded to Android
-* Operation: sync
-* Return: standard return value or standard error
+- Operation: sync
+- Return: standard return value or standard error
 
 Return value for `curl -s --unix-socket /run/user/1000/anbox/sockets/api.unix -X PATCH s/1.0/sensors --data '[{"type": "acceleration", "x": 0.3, "y":-0.1, "z": 0.1},{"type": "pressure", "value": 1.0}]' | jq .`:
 
@@ -469,9 +469,9 @@ Issuing GET method to sensor endpoint can check the current active sensors in th
 
 #### GET
 
-* Description: Get tracing status
-* Operation: sync
-* Return: Current tracing status
+- Description: Get tracing status
+- Operation: sync
+- Return: Current tracing status
 
 Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0/tracing  | jq .`:
 
@@ -488,9 +488,9 @@ Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.
 
 #### POST
 
-* Description: Activate or deactivate tracing in Anbox
-* Operation: sync
-* Return: standard return value or standard error
+- Description: Activate or deactivate tracing in Anbox
+- Operation: sync
+- Return: standard return value or standard error
 
 Return value for `curl -s -X POST --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0/tracing --data '{"enable":true}' | jq .`:
 
@@ -529,9 +529,9 @@ You can pull that file from the instance and import it to [Perfetto Trace Viewer
 
 #### GET
 
-* Description: Get information about the current platform that Anbox uses
-* Operation: sync
-* Return: Information about the current Anbox platform
+- Description: Get information about the current platform that Anbox uses
+- Operation: sync
+- Return: Information about the current Anbox platform
 
 Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0/platform | jq .`:
 
@@ -551,9 +551,9 @@ Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.
 
 #### PATCH
 
-* Description: Update one or more configuration items of the platform currently used by Anbox
-* Operation: sync
-* Return: Standard return value or standard error
+- Description: Update one or more configuration items of the platform currently used by Anbox
+- Operation: sync
+- Return: Standard return value or standard error
 
 Return value for `curl -s --unix-socket /run/user/1000/anbox/sockets/api.unix -X PATCH s/1.0/platform --data '{"config":{"rtc_log":true}}' | jq .`:
 
@@ -583,9 +583,9 @@ Platform | Field name       | Available since   | JSON type | Access | Default v
 
 #### DELETE
 
-* Description: Reset one or more configuration items of the platform to their default values
-* Operation: sync
-* Return: Standard return value or standard error
+- Description: Reset one or more configuration items of the platform to their default values
+- Operation: sync
+- Return: Standard return value or standard error
 
 Return value for `curl -s --unix-socket /run/user/1000/anbox/sockets/api.unix -X DELETE s/1.0/platform --data '{"configs":["stream_video_bitrate_min_kbps"]}' | jq .`:
 
@@ -610,10 +610,10 @@ endpoint will fail with a 500 error code on non-automotive Anbox images.
 
 #### GET `1.0/vhal/{prop_id}/{area_id}`
 
-* Description: Get a VHAL property value
-* Operation: sync
-* Return: Current value for requested property
-* Parameters:
+- Description: Get a VHAL property value
+- Operation: sync
+- Return: Current value for requested property
+- Parameters:
   * `prop_id`: Property identifier. Can be given in decimal, octal or hexadecimal format.
   * `area_id`: Valid area identifier for the property. Can be omitted for global properties. Can be given in decimal, octal, or hexadecimal format.
   * Some properties require additional data for getting their values. See [OBD2_FREEZE_FRAME](https://cs.android.com/android/platform/superproject/+/android10-release:hardware/interfaces/automotive/vehicle/2.0/types.hal;l=2061-2089) for an example. This additional data must be passed as JSON in the request body. The values must be set in the fields `int32_values`, `int64_values`, `float_values`, `bytes`, or `string_value`.
@@ -663,9 +663,9 @@ enumeration:
 
 #### PUT
 
-* Description: Set a VHAL property to a new value
-* Operation: sync
-* Return: standard return value or standard error
+- Description: Set a VHAL property to a new value
+- Operation: sync
+- Return: standard return value or standard error
 
 Example input:
 
@@ -720,9 +720,9 @@ non-automotive Anbox images.
 
 #### GET
 
-* Description: Get all VHAL property configurations
-* Operation: sync
-* Return: Current VHAL property configurations
+- Description: Get all VHAL property configurations
+- Operation: sync
+- Return: Current VHAL property configurations
 
 Example shortened return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0/vhal/config | jq .`:
 
@@ -786,10 +786,10 @@ See the [VHAL property configuration](https://source.android.com/docs/automotive
 
 #### GET `1.0/vhal/config/{prop_id},...,{prop_id}`
 
-* Description: Get request VHAL property configurations
-* Operation: sync
-* Return: Current configuration for requested properties
-* Parameters:
+- Description: Get request VHAL property configurations
+- Operation: sync
+- Return: Current configuration for requested properties
+- Parameters:
   * `prop_id`: Property identifier(s). Can be given in decimal, octal or hexadecimal format. Can be given multiple times to query for the configuration of more than one property. If queried multiple times, property IDs must be separated by commas.
 
 Example return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0/config/0x11100101 | jq .`:
@@ -825,9 +825,9 @@ See the [VHAL property configuration](https://source.android.com/docs/automotive
 ### `/1.0/metrics`
 #### GET
 
-* Description: Get metrics in Prometheus output data format
-* Operation: sync
-* Return: Current metrics in Prometheus output data format
+- Description: Get metrics in Prometheus output data format
+- Operation: sync
+- Return: Current metrics in Prometheus output data format
 
  Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0/metrics`:
 
@@ -845,9 +845,9 @@ anbox_vulkan_buffer_memory_size_total 78370816
 ### `/1.0/telephony`
 #### GET
 
-* Description: Get telephony status
-* Operation: sync
-* Return: Current telephony status
+- Description: Get telephony status
+- Operation: sync
+- Return: Current telephony status
 
 Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0/telephony  | jq .`:
 
@@ -866,9 +866,9 @@ Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.
 
 #### POST
 
-* Description: Simulate an incoming SMS message that Android can process.
-* Operation: sync
-* Return: standard return value or standard error
+- Description: Simulate an incoming SMS message that Android can process.
+- Operation: sync
+- Return: standard return value or standard error
 
 Return value for `curl -s -X POST --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0/telephony/sms --data '{"number": "+1234567", "message": "Hello world!"}' | jq .`:
 

--- a/reference/application-manifest.md
+++ b/reference/application-manifest.md
@@ -195,10 +195,10 @@ Each item (file or folder) declared in the `extra-data` field of the manifest YA
 
 For security reasons, the target location of the files and directories listed in the `extra-data` section is restricted to a few specific locations in the Android file system. These are:
 
-* `/sdcard/Android/obb/<apk-package-name>`
-* `/sdcard/Android/data/<apk-package-name>`
-* `/data/app/<apk-package-name>`
-* `/data/data/<apk-package-name>`
+- `/sdcard/Android/obb/<apk-package-name>`
+- `/sdcard/Android/data/<apk-package-name>`
+- `/data/app/<apk-package-name>`
+- `/data/data/<apk-package-name>`
 
 The manifest and extra data in our example are placed next to the application package, which must be named `app.apk`:
 

--- a/reference/deprecation-notices.md
+++ b/reference/deprecation-notices.md
@@ -67,7 +67,7 @@ Legacy charms, specifically the [`etcd`](https://charmhub.io/etcd) and the [`eas
 
 Starting from 1.29.0, all new Anbox Cloud deployments must use modernized operator charms to replace their legacy counterparts. Specifically:
 
-* [charmed-etcd](https://charmhub.io/charmed-etcd) to replace `etcd`
-* [self-signed-certificates](https://charmhub.io/self-signed-certificates) to replace `easy-rsa`
+- [charmed-etcd](https://charmhub.io/charmed-etcd) to replace `etcd`
+- [self-signed-certificates](https://charmhub.io/self-signed-certificates) to replace `easy-rsa`
 
 This transition provides a two-year migration window before legacy charms become completely unsupported. Anbox Cloud 1.34.2 will be the last release that supports deployments using legacy charms. Starting from Anbox Cloud 1.35.0, Anbox Cloud deployments will exclusively support modernized charms.

--- a/reference/feature-flags.md
+++ b/reference/feature-flags.md
@@ -84,9 +84,9 @@ To enable the Android container to use a custom Android ID, add the feature flag
   `anbox.custom_android_id.<index>=<package_name>:<android_id>`
   ```
 
-* The `<index>` is a number in the range from 0 to 126, which allows you to have multiple overrides for different packages. If the same `<package_name>` with the different `<android_id>` is given for multiple system properties `anbox.custom_android_id.<index>`, the Android ID read from the system property which has the highest suffixing index that will be used in the end.
-* The `<package_name>` is the package name of the application.
-* The `<android_id>` is a unique ID that represents the Android ID for the targeting application. It must be at least 16 characters in length.
+- The `<index>` is a number in the range from 0 to 126, which allows you to have multiple overrides for different packages. If the same `<package_name>` with the different `<android_id>` is given for multiple system properties `anbox.custom_android_id.<index>`, the Android ID read from the system property which has the highest suffixing index that will be used in the end.
+- The `<package_name>` is the package name of the application.
+- The `<android_id>` is a unique ID that represents the Android ID for the targeting application. It must be at least 16 characters in length.
 
 Once set, this feature flag will be considered by all newly launched instances.
 

--- a/reference/index.md
+++ b/reference/index.md
@@ -7,49 +7,49 @@ The reference guides in this section provide additional information about using 
 
 Learn about Anbox Cloud releases, the product roadmap, deprecations, supported product versions and component versions.
 
-* {ref}`ref-release-notes`
-* {ref}`ref-deprecation-notes`
-* {ref}`ref-component-versions`
+- {ref}`ref-release-notes`
+- {ref}`ref-deprecation-notes`
+- {ref}`ref-component-versions`
 
 ## Usage
 
 Understand the difference aspects of using Anbox Cloud such as requirements, supported features, provided SDKs, images, APIs, available network ports for communication, extending Anbox Cloud through addons and hooks.
 
-* {ref}`ref-requirements`
-* {ref}`Anbox Cloud images <ref-provided-images>`
-* {ref}`ref-rendering-resources`
-* {ref}`ref-codecs`
-* {ref}`ref-android-features`
-* {ref}`ref-compatibility-considerations`
-* {ref}`AOSP vs AAOS images <ref-aosp-aaos>`
-* {ref}`ref-sdks`
-* {ref}`ref-network-ports`
-* {ref}`ref-addon-manifest`
-* {ref}`ref-hooks`
+- {ref}`ref-requirements`
+- {ref}`Anbox Cloud images <ref-provided-images>`
+- {ref}`ref-rendering-resources`
+- {ref}`ref-codecs`
+- {ref}`ref-android-features`
+- {ref}`ref-compatibility-considerations`
+- {ref}`AOSP vs AAOS images <ref-aosp-aaos>`
+- {ref}`ref-sdks`
+- {ref}`ref-network-ports`
+- {ref}`ref-addon-manifest`
+- {ref}`ref-hooks`
 
 ## Authorization
 
 Different levels of entitlements that can be assigned at a global level and at a resource level
 
-* {ref}`ref-auth`
+- {ref}`ref-auth`
 
 ## Configuration
 
 Know the configuration options that can be defined for various components of Anbox Cloud.
 
-* {ref}`Appliance preseed configuration <ref-appliance-preseed-config>`
-* {ref}`ref-ams-configuration`
-* {ref}`ref-ams-instance-configuration`
-* {ref}`Appliance configuration <ref-appliance-configuration>`
-* {ref}`ref-application-manifest`
-* {ref}`ref-feature-flags`
-* {ref}`ref-webrtc`
+- {ref}`Appliance preseed configuration <ref-appliance-preseed-config>`
+- {ref}`ref-ams-configuration`
+- {ref}`ref-ams-instance-configuration`
+- {ref}`Appliance configuration <ref-appliance-configuration>`
+- {ref}`ref-application-manifest`
+- {ref}`ref-feature-flags`
+- {ref}`ref-webrtc`
 
 ## API reference
 
 Learn about the APIs provided by Anbox Cloud.
 
-* {ref}`ref-api`
+- {ref}`ref-api`
   * [AMS HTTP API](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/ams-api/)
   * [Anbox HTTPS API](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/anbox-https-api/)
   * [Anbox Platform API](https://canonical.github.io/anbox-cloud.github.com/latest/anbox-platform-sdk/)
@@ -59,27 +59,27 @@ Learn about the APIs provided by Anbox Cloud.
 
 Learn about the commands and their usage for the Anbox Management Client (AMC) and the Anbox Cloud Appliance.
 
-* [AMC commands](./cmd-ref/amc/ams.amc.md)
-* [Appliance commands](./cmd-ref/appliance/anbox-cloud-appliance.md)
+- [AMC commands](./cmd-ref/amc/ams.amc.md)
+- [Appliance commands](./cmd-ref/appliance/anbox-cloud-appliance.md)
 
 ## Performance
 
 Learn about the available metrics and benchmarks for measuring performance.
 
-* {ref}`ref-prometheus-metrics`
-* {ref}`ref-performance-benchmarks`
+- {ref}`ref-prometheus-metrics`
+- {ref}`ref-performance-benchmarks`
 
 ## Security
 
 Learn about our security policies and about the fixes we have provided for vulnerabilities.
 
-* {ref}`ref-security-notices`
-* {ref}`ref-security-policy`
+- {ref}`ref-security-notices`
+- {ref}`ref-security-policy`
 
 ## Other
 
-* {ref}`ref-license-information`
-* {ref}`ref-glossary`
+- {ref}`ref-license-information`
+- {ref}`ref-glossary`
 
 Also check out the {ref}`tutorials` for step-by-step instructions that help you get familiar with Anbox Cloud, the {ref}`how-to-guides` for instructions on how to achieve specific goals when using Anbox Cloud and the {ref}`explanation` section for background information.
 

--- a/reference/release-notes/1.0.0.md
+++ b/reference/release-notes/1.0.0.md
@@ -5,23 +5,23 @@ orphan: true
 
 ## New features & improvements
 
-* First official stable release of the Anbox Cloud stack
-* Simple deployment via Juju in a single command on any cloud (public, private or bare metal)
-* Dedicated management service for container orchestration, managing the entire life cycle of Android applications in Anbox Cloud
-* Rich REST API to talk to the management service
-* Automatic container scheduling and cluster resource management
-* Optimized containers for performance, scalability and high density
-* Based on Android 7.1.2
-* Platform SDK to allow development of custom platform plugins to integrate with existing or new streaming solutions
-* Golang SDK to allow easy use of the management service REST API
-* Support for addons to extend the content of the container images
-* Support for hooks inside the container images (e.g. restore/backup of user data)
-* Rich online documentation
-* Metrics collection support via Telegraf, Prometheus and Grafana
-* High availability support for the management service
-* Support for x86 and Arm64
-* Enabled for binary translation of AArch32 on AArch64 only systems
-* OpenGL ES 3.x support
+- First official stable release of the Anbox Cloud stack
+- Simple deployment via Juju in a single command on any cloud (public, private or bare metal)
+- Dedicated management service for container orchestration, managing the entire life cycle of Android applications in Anbox Cloud
+- Rich REST API to talk to the management service
+- Automatic container scheduling and cluster resource management
+- Optimized containers for performance, scalability and high density
+- Based on Android 7.1.2
+- Platform SDK to allow development of custom platform plugins to integrate with existing or new streaming solutions
+- Golang SDK to allow easy use of the management service REST API
+- Support for addons to extend the content of the container images
+- Support for hooks inside the container images (e.g. restore/backup of user data)
+- Rich online documentation
+- Metrics collection support via Telegraf, Prometheus and Grafana
+- High availability support for the management service
+- Support for x86 and Arm64
+- Enabled for binary translation of AArch32 on AArch64 only systems
+- OpenGL ES 3.x support
 
 ## Bug fixes
 
@@ -29,4 +29,4 @@ None
 
 ## Known issues
 
-* A few applications freeze after some time and stop rendering. A reason is not known yet and the issue is being investigated.
+- A few applications freeze after some time and stop rendering. A reason is not known yet and the issue is being investigated.

--- a/reference/release-notes/1.0.1.md
+++ b/reference/release-notes/1.0.1.md
@@ -5,5 +5,5 @@ orphan: true
 
 ## Bug fixes
 
-* Applications are not freezing anymore when using OpenGL ES >= 2.x extensively
-* AArch32 support is now properly detected on AArch64 only machines
+- Applications are not freezing anymore when using OpenGL ES >= 2.x extensively
+- AArch32 support is now properly detected on AArch64 only machines

--- a/reference/release-notes/1.1.0.md
+++ b/reference/release-notes/1.1.0.md
@@ -5,21 +5,21 @@ orphan: true
 
 ## New features & improvements
 
-* The Anbox container is now based on Ubuntu 18.04 LTS
-* Experimental support for an application registry which serves as a central repository of applications for multiple Anbox Cloud deployments
-* Updated Android 7.x with all [security patches](https://source.android.com/security/bulletin) as of Jan 5 2019
-* Added GPU support to allow hardware accelerated rendering and video encoding/decoding
-* Various improvements to container startup time and overall performance
-* Improved AMS SDK (Go)
-* Support for “raw” containers (containers without installed applications)
-* The container scheduler now accounts for container disk requirements
-* AMS exposes additional metrics (containers per app, ...)
-* Anbox Platform SDK ABI version is marked as stable
-* Containers logs can be retrieved via the REST API and command line tools
-* Extended instance types (a6.3, a8.3, a10.3)
-* Binder support is now based on the new binderfs coming with Linux 5.0
-* AMS can now run on Arm64 machines
-* Example platform plugin with software rendering and VNC support
+- The Anbox container is now based on Ubuntu 18.04 LTS
+- Experimental support for an application registry which serves as a central repository of applications for multiple Anbox Cloud deployments
+- Updated Android 7.x with all [security patches](https://source.android.com/security/bulletin) as of Jan 5 2019
+- Added GPU support to allow hardware accelerated rendering and video encoding/decoding
+- Various improvements to container startup time and overall performance
+- Improved AMS SDK (Go)
+- Support for “raw” containers (containers without installed applications)
+- The container scheduler now accounts for container disk requirements
+- AMS exposes additional metrics (containers per app, ...)
+- Anbox Platform SDK ABI version is marked as stable
+- Containers logs can be retrieved via the REST API and command line tools
+- Extended instance types (a6.3, a8.3, a10.3)
+- Binder support is now based on the new binderfs coming with Linux 5.0
+- AMS can now run on Arm64 machines
+- Example platform plugin with software rendering and VNC support
 
 ## Known issues
 

--- a/reference/release-notes/1.1.1.md
+++ b/reference/release-notes/1.1.1.md
@@ -5,5 +5,5 @@ orphan: true
 
 ## Bug fixes
 
-* Anbox was taking an incorrect display size from platform plugins and failed to initialize EGL rendering context.
-* The Anbox container now always dumps system log files when an error occurred.
+- Anbox was taking an incorrect display size from platform plugins and failed to initialize EGL rendering context.
+- The Anbox container now always dumps system log files when an error occurred.

--- a/reference/release-notes/1.10.0.md
+++ b/reference/release-notes/1.10.0.md
@@ -53,11 +53,11 @@ Applications can now be managed from the Anbox Cloud Dashboard. The feature was 
 
 ### Other
 
-* If a container has multiple service endpoints defined, allocation of node ports is now quicker. For containers with a high number of service endpoints (100+) the startup time was delayed by more than 70 seconds and is now down to a couple of seconds at maximum.
+- If a container has multiple service endpoints defined, allocation of node ports is now quicker. For containers with a high number of service endpoints (100+) the startup time was delayed by more than 70 seconds and is now down to a couple of seconds at maximum.
 
-* A `juju crashdump` now collects additional debug information from LXD and AMS about available containers, addons, applications and cluster configuration
+- A `juju crashdump` now collects additional debug information from LXD and AMS about available containers, addons, applications and cluster configuration
 
-* The LLVMpipe software renderer used by Anbox as part of the `swrast` and `webrtc` platforms is now limited in the number of threads it creates for rendering to the number of vCPUs which are assigned to the container. This helps to improve its efficiency and adjusts performance to match the assigned vCPUs.
+- The LLVMpipe software renderer used by Anbox as part of the `swrast` and `webrtc` platforms is now limited in the number of threads it creates for rendering to the number of vCPUs which are assigned to the container. This helps to improve its efficiency and adjusts performance to match the assigned vCPUs.
 
 ## Deprecations
 
@@ -80,33 +80,33 @@ The [Juju bundles](https://charmhub.io/?q=anbox+cloud+bundles) for Anbox Cloud a
 
 ## Known Issues
 
-* With 1.10.0 Juju 2.9 is not yet fully supported. It is recommended to stick to Juju 2.8 until explicit support for Juju 2.9 is added and called out in the release notes.
+- With 1.10.0 Juju 2.9 is not yet fully supported. It is recommended to stick to Juju 2.8 until explicit support for Juju 2.9 is added and called out in the release notes.
 
 ## Bug Fixes
 
-* LP #1883526 NATs reconnects quite often on a LXD deployment
-* LP #1912172 WebRTC platform freezes forever on peer connection release
-* LP #1885708 AMS fails to start on deploy
-* LP #1920999 IP addresses of LXD containers used by the appliance change after a reboot
-* LP #1921835 On systems with multiple NVIDIA GPUs Anbox fails to start with WebRTC platform
-* LP #1922208 `juju config lxd images_compression_algorithm` does not work
-* LP #1923204 Handle Juju timeout error
-* LP #1923300 Shader compilation error in Android 11 because of missing GL_OES_EGL_image_external in `swrast`/WebRTC
-* LP #1924234 Failed to trigger action even if the proper actions were given
-* LP #1924891 Appliance CF template misses AWS regions
-* LP #1925121 The incompatible CUDA libraries were installed when deploying Anbox Cloud on a NVIDIA GPU supported environment
-* LP #1926113 AMS is still leaking file descriptors when constantly scaling LXD cluster
-* LP #1926696 Currently synchronized images never show up in `amc image ls`
-* LP #1905747 Check for Debian package before attempting to remove it
-* LP #1915139 Grafana dashboard doesn't provide Regions selector
-* LP #1915297 Dashboard fails to install on fresh 1.9.0 deployment
-* LP #1920930 Appliance status page is missing favicon
-* LP #1923205 Appliance status page shows incorrect year 2020
-* LP #1924931 Android 11: `android.app.cts.SystemFeaturesTest#testCameraFeatures` fails
-* LP #1885112 Anbox reports incorrect path for ANR and tombstones
-* LP #1904414 Stream gateway fails to stop if gateway wasn't installed
-* LP #1914433 images.version_lockstep value is printed as a string instead of a boolean in `amc config show`
-* LP #1915803 `amc ls --format=json` returns `null` on an empty list, would have expected `[]`
+- LP #1883526 NATs reconnects quite often on a LXD deployment
+- LP #1912172 WebRTC platform freezes forever on peer connection release
+- LP #1885708 AMS fails to start on deploy
+- LP #1920999 IP addresses of LXD containers used by the appliance change after a reboot
+- LP #1921835 On systems with multiple NVIDIA GPUs Anbox fails to start with WebRTC platform
+- LP #1922208 `juju config lxd images_compression_algorithm` does not work
+- LP #1923204 Handle Juju timeout error
+- LP #1923300 Shader compilation error in Android 11 because of missing GL_OES_EGL_image_external in `swrast`/WebRTC
+- LP #1924234 Failed to trigger action even if the proper actions were given
+- LP #1924891 Appliance CF template misses AWS regions
+- LP #1925121 The incompatible CUDA libraries were installed when deploying Anbox Cloud on a NVIDIA GPU supported environment
+- LP #1926113 AMS is still leaking file descriptors when constantly scaling LXD cluster
+- LP #1926696 Currently synchronized images never show up in `amc image ls`
+- LP #1905747 Check for Debian package before attempting to remove it
+- LP #1915139 Grafana dashboard doesn't provide Regions selector
+- LP #1915297 Dashboard fails to install on fresh 1.9.0 deployment
+- LP #1920930 Appliance status page is missing favicon
+- LP #1923205 Appliance status page shows incorrect year 2020
+- LP #1924931 Android 11: `android.app.cts.SystemFeaturesTest#testCameraFeatures` fails
+- LP #1885112 Anbox reports incorrect path for ANR and tombstones
+- LP #1904414 Stream gateway fails to stop if gateway wasn't installed
+- LP #1914433 images.version_lockstep value is printed as a string instead of a boolean in `amc config show`
+- LP #1915803 `amc ls --format=json` returns `null` on an empty list, would have expected `[]`
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.10.1.md
+++ b/reference/release-notes/1.10.1.md
@@ -8,15 +8,15 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New Features & Improvements
 
-* Properly shut down containers when they are still writing to a ZFS dataset.
-* Android security updates for May 2021 (see [here](https://source.android.com/security/bulletin/2021-05-01) for more information)
+- Properly shut down containers when they are still writing to a ZFS dataset.
+- Android security updates for May 2021 (see [here](https://source.android.com/security/bulletin/2021-05-01) for more information)
 
 ## Bugs
 
-* LP #1926695 Task reaper fails to deleted container because of "target is busy"
-* LP #1927234 `Sysctl` settings for new LXD nodes are not applied
-* LP #1927910 Public status endpoint of the appliance returns internal endpoints without authentication
-* LP #1927342 `wifi-service.odex` is marked as imported but is not found for Android 11
+- LP #1926695 Task reaper fails to deleted container because of "target is busy"
+- LP #1927234 `Sysctl` settings for new LXD nodes are not applied
+- LP #1927910 Public status endpoint of the appliance returns internal endpoints without authentication
+- LP #1927342 `wifi-service.odex` is marked as imported but is not found for Android 11
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.10.2.md
+++ b/reference/release-notes/1.10.2.md
@@ -11,23 +11,23 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New Features & Improvements
 
-* Android security updates for June 2021 (see [here](https://source.android.com/security/bulletin/2021-06-01) for more information)
-* WebView based on [upstream 90.0.4430.91 release](https://chromereleases.googleblog.com/2021/06/chrome-for-android-update.html)
-* Android System UI can now be enabled for applications via a new feature flag `enable_system_ui`
+- Android security updates for June 2021 (see [here](https://source.android.com/security/bulletin/2021-06-01) for more information)
+- WebView based on [upstream 90.0.4430.91 release](https://chromereleases.googleblog.com/2021/06/chrome-for-android-update.html)
+- Android System UI can now be enabled for applications via a new feature flag `enable_system_ui`
 
 ## Bugs
 
-* LP #1924715 System gets blocked by `sensorservice` not responding
-* LP #1926397 Appliance bootstrap log is missing output of various commands
-* LP #1926694 Metrics reported by AMS are incorrect
-* LP #1929031 Failed bootstrap doesn't terminate container
-* LP #1930079 camera service crashed from time to time when executing spread tests
-* LP #1930282 Enable `vertical_accuracy` and `horizontal_accuracy` configurable for GPS data
-* LP #1931202 Gateway fails to join just created session
-* LP #1928719 Tombstone is detected twice
-* LP #1929005 Gallery2 application crashed when editing an picture
-* LP #1929151 Appliance storage size is wrong and doesn't reflect the value of snap config `storage.size`  
-* LP #1928703 Silence spammy `eglMakeCurrent` debug message
+- LP #1924715 System gets blocked by `sensorservice` not responding
+- LP #1926397 Appliance bootstrap log is missing output of various commands
+- LP #1926694 Metrics reported by AMS are incorrect
+- LP #1929031 Failed bootstrap doesn't terminate container
+- LP #1930079 camera service crashed from time to time when executing spread tests
+- LP #1930282 Enable `vertical_accuracy` and `horizontal_accuracy` configurable for GPS data
+- LP #1931202 Gateway fails to join just created session
+- LP #1928719 Tombstone is detected twice
+- LP #1929005 Gallery2 application crashed when editing an picture
+- LP #1929151 Appliance storage size is wrong and doesn't reflect the value of snap config `storage.size`  
+- LP #1928703 Silence spammy `eglMakeCurrent` debug message
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.10.3.md
+++ b/reference/release-notes/1.10.3.md
@@ -9,14 +9,14 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New Features & Improvements
 
-* Android security updates for July 2021 (see [here](https://source.android.com/security/bulletin/2021-07-01) for more information)
-* WebView based on [upstream 91.0.4472.134 release](https://chromereleases.googleblog.com/2021/06/chrome-for-android-update_0579445428.html)
+- Android security updates for July 2021 (see [here](https://source.android.com/security/bulletin/2021-07-01) for more information)
+- WebView based on [upstream 91.0.4472.134 release](https://chromereleases.googleblog.com/2021/06/chrome-for-android-update_0579445428.html)
 
 ## Bugs
 
-* LP #1933195 Sensor device doesn't handle sync and guest_sync commands
-* LP #1932362 [appliance] public address of the LXD node in AMS is not set
-* LP #1934877 A wrong main activity was used for some APKs
+- LP #1933195 Sensor device doesn't handle sync and guest_sync commands
+- LP #1932362 [appliance] public address of the LXD node in AMS is not set
+- LP #1934877 A wrong main activity was used for some APKs
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.11.0.md
+++ b/reference/release-notes/1.11.0.md
@@ -78,9 +78,9 @@ New deployments created with 1.11 will use a larger network subnet (/20 instead 
 
 ### Other
 
-* NVIDIA driver is updated to the recently released 470 series which includes performance improvements and bug fixes to allow scaling to higher number of Anbox containers
-* Android WebView has been updated to [92.0.4515.115](https://chromereleases.googleblog.com/2021/07/chrome-for-android-update_0571163522.html)
-* The `aam` tool now supports a `--output` option for both the `backup` and `restore` command. This allows storing a backup inside a directory instead of a tarball and reading it back from a directory as well.
+- NVIDIA driver is updated to the recently released 470 series which includes performance improvements and bug fixes to allow scaling to higher number of Anbox containers
+- Android WebView has been updated to [92.0.4515.115](https://chromereleases.googleblog.com/2021/07/chrome-for-android-update_0571163522.html)
+- The `aam` tool now supports a `--output` option for both the `backup` and `restore` command. This allows storing a backup inside a directory instead of a tarball and reading it back from a directory as well.
 
 ## Known Issues
 
@@ -88,28 +88,28 @@ None
 
 ## Bug Fixes
 
-* LP #1926148 Anbox Session crashed when running with null platform (Angle EGL/GL drivers)
-* LP #1927313 Fail to launch more than 44 containers on two NVIDIA GPUs
-* LP #1936345 Appliance fails to bootstrap when NIC is on a /22 network
-* LP #1936799 text should be instantly shown up in the input edit widget when it's sent from the client side virtual keyboard
-* LP #1936835 Audio processing is enabled in WebRTC
-* LP #1936934 Ensure Ubuntu user is allowed to talk to LXD
-* LP #1937005 AMS crashed when updating an image with the same fingerprint
-* LP #1938118 A refresh container that was launched from an application contains `tombstone_00` file
-* LP #1938288 Outbound audio stream remains after microphone is disabled
-* LP #1938533 Appliance bootstrap fails too late when LXD is not setup by us
-* LP #1938701 Trailing slash is causing problems
-* LP #1913597 AMS enable people to remove last version of an addon
-* LP #1926702 Image architecture is not taken from simplestreams in AMS
-* LP #1930935 Anbox Cloud dashboard fails at install hook
-* LP #1933489 Camera is not connected after rejoin
-* LP #1935809 Appliance init command can be run again while the appliance is initializing
-* LP #1936171 Missing `ISoundTriggerHw` in Android 11 images
-* LP #1936801 Support to run hooks after Anbox session is fully up and running
-* LP #1937266 Websocket connect to gateway fails with "Invalid UTF-8 sequence in header value" on iOS
-* LP #1913425 Provide an informative message when removing a certificate by running `amc config trust remove`
-* LP #1913560 Image version deletion only supports to perform the operation with image id
-* LP #1919136 [AMS] `hasImageWithIDOrName` uses app cache
+- LP #1926148 Anbox Session crashed when running with null platform (Angle EGL/GL drivers)
+- LP #1927313 Fail to launch more than 44 containers on two NVIDIA GPUs
+- LP #1936345 Appliance fails to bootstrap when NIC is on a /22 network
+- LP #1936799 text should be instantly shown up in the input edit widget when it's sent from the client side virtual keyboard
+- LP #1936835 Audio processing is enabled in WebRTC
+- LP #1936934 Ensure Ubuntu user is allowed to talk to LXD
+- LP #1937005 AMS crashed when updating an image with the same fingerprint
+- LP #1938118 A refresh container that was launched from an application contains `tombstone_00` file
+- LP #1938288 Outbound audio stream remains after microphone is disabled
+- LP #1938533 Appliance bootstrap fails too late when LXD is not setup by us
+- LP #1938701 Trailing slash is causing problems
+- LP #1913597 AMS enable people to remove last version of an addon
+- LP #1926702 Image architecture is not taken from simplestreams in AMS
+- LP #1930935 Anbox Cloud dashboard fails at install hook
+- LP #1933489 Camera is not connected after rejoin
+- LP #1935809 Appliance init command can be run again while the appliance is initializing
+- LP #1936171 Missing `ISoundTriggerHw` in Android 11 images
+- LP #1936801 Support to run hooks after Anbox session is fully up and running
+- LP #1937266 Websocket connect to gateway fails with "Invalid UTF-8 sequence in header value" on iOS
+- LP #1913425 Provide an informative message when removing a certificate by running `amc config trust remove`
+- LP #1913560 Image version deletion only supports to perform the operation with image id
+- LP #1919136 [AMS] `hasImageWithIDOrName` uses app cache
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.11.1.md
+++ b/reference/release-notes/1.11.1.md
@@ -9,16 +9,16 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Android security updates for August 2021 (see [Android Security Bulletin - August 2021](https://source.android.com/security/bulletin/2021-08-01) for more information)
+- Android security updates for August 2021 (see [Android Security Bulletin - August 2021](https://source.android.com/security/bulletin/2021-08-01) for more information)
 
 ## Bugs
 
-* LP #1939277 `lxc-attach` fails on sendfile with EINVAL on 5.11
-* LP #1938877 Native crash occurred when creating an application from Android 11 after finishing application bootstrap
-* LP #1939274 Anbox crashes after "Failed to put memory protection in place"
-* LP #1939666 Bootstrap fails because of missing `/dev/fd0`
-* LP #1939129 The `anbox-stream-sdk.js` file is missing from Android WebView based projects
-* LP #1938901 Appliance upgrade fails with Juju 2.9.x
+- LP #1939277 `lxc-attach` fails on sendfile with EINVAL on 5.11
+- LP #1938877 Native crash occurred when creating an application from Android 11 after finishing application bootstrap
+- LP #1939274 Anbox crashes after "Failed to put memory protection in place"
+- LP #1939666 Bootstrap fails because of missing `/dev/fd0`
+- LP #1939129 The `anbox-stream-sdk.js` file is missing from Android WebView based projects
+- LP #1938901 Appliance upgrade fails with Juju 2.9.x
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.11.2.md
+++ b/reference/release-notes/1.11.2.md
@@ -9,21 +9,21 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Android security updates for September 2021 (see [Android Security Bulletin - September 2021](https://source.android.com/security/bulletin/2021-09-01) for more information)
-* Android WebView has been updated to [93.0.4577.82](https://chromereleases.googleblog.com/2021/09/chrome-for-android-update.html)
-* The AMS node controller now synchronizes its internal state to disk more often to avoid getting out of sync with the actual running containers across restarts
-* Client-side virtual keyboard is now supported on Android 11
-* The default instance type of an application in the dashboard is now selected based on the available GPU support
+- Android security updates for September 2021 (see [Android Security Bulletin - September 2021](https://source.android.com/security/bulletin/2021-09-01) for more information)
+- Android WebView has been updated to [93.0.4577.82](https://chromereleases.googleblog.com/2021/09/chrome-for-android-update.html)
+- The AMS node controller now synchronizes its internal state to disk more often to avoid getting out of sync with the actual running containers across restarts
+- Client-side virtual keyboard is now supported on Android 11
+- The default instance type of an application in the dashboard is now selected based on the available GPU support
 
 ## Bugs
 
-* LP #1938761 Anbox WebView lost focus for unknown reasons and causes client side virtual keyboard hidden in the end
-* LP #1940807 Failed to launch Anbox sessions with WebRTC platform (`drm` backend)
-* LP #1940853 `anbox-cloud-dashboard-51` charm fails to deploy
-* LP #1942677 Audio/Video recording is broken on Anbox `swrast` platform
-* AC-304 Dashboard reports "Could not get response from Anbox Stream Gateway"
-* AC-303 Dashboard lists non active images in application form
-* AC-342 Connecting second ADB server breaks existing one
+- LP #1938761 Anbox WebView lost focus for unknown reasons and causes client side virtual keyboard hidden in the end
+- LP #1940807 Failed to launch Anbox sessions with WebRTC platform (`drm` backend)
+- LP #1940853 `anbox-cloud-dashboard-51` charm fails to deploy
+- LP #1942677 Audio/Video recording is broken on Anbox `swrast` platform
+- AC-304 Dashboard reports "Could not get response from Anbox Stream Gateway"
+- AC-303 Dashboard lists non active images in application form
+- AC-342 Connecting second ADB server breaks existing one
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.11.3.md
+++ b/reference/release-notes/1.11.3.md
@@ -9,16 +9,16 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Android security updates for October 2021 (see [Android Security Bulletin - October 2021](https://source.android.com/security/bulletin/2021-10-01) for more information)
-* Android WebView has been updated to [94.0.4606.80](https://chromereleases.googleblog.com/2021/10/chrome-for-android-update.html)
-* The shared memory transport used for the `null` platform is now disabled by default for increased stability
-* ANGLE libraries used for `null` platform are updated to increase stability and cause Anbox to not crash in certain situations
+- Android security updates for October 2021 (see [Android Security Bulletin - October 2021](https://source.android.com/security/bulletin/2021-10-01) for more information)
+- Android WebView has been updated to [94.0.4606.80](https://chromereleases.googleblog.com/2021/10/chrome-for-android-update.html)
+- The shared memory transport used for the `null` platform is now disabled by default for increased stability
+- ANGLE libraries used for `null` platform are updated to increase stability and cause Anbox to not crash in certain situations
 
 ## Bugs
 
-* AC-321 Deploying multiple AMS units at the same time causes problems
-* AC-343 ANDROID_EMU_* extensions are visible for Android applications
-* AC-384 Fix steam view in the dashboard
+- AC-321 Deploying multiple AMS units at the same time causes problems
+- AC-343 ANDROID_EMU_* extensions are visible for Android applications
+- AC-384 Fix steam view in the dashboard
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.11.5.md
+++ b/reference/release-notes/1.11.5.md
@@ -17,7 +17,7 @@ n/a
 
 ## Bugs
 
-* AC-662 Android containers fail to start on Linux 5.13.x
+- AC-662 Android containers fail to start on Linux 5.13.x
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.12.0.md
+++ b/reference/release-notes/1.12.0.md
@@ -45,22 +45,22 @@ Containers can now be tagged on launch. The tags are just for informational purp
 
 ## Known issues
 
-* The Android 12 image currently comes without a functioning WebView. The WebView will become functional with the 1.12.1 release.
+- The Android 12 image currently comes without a functioning WebView. The WebView will become functional with the 1.12.1 release.
 
 ## Bug fixes
 
-* AC-467 AMS fails to import image with multiple instances
-* AC-174 LP #1927233 `anbox-stream-gateway-lb` has no open ports when deployed via Juju 2.9
-* AC-293 Anbox leaks after `CtsGraphicsTestCases` has finished
-* AC-294 WebRTC platform crashes on `glDeleteTextures`
-* AC-446 Container fails to start: This operation can't be canceled
-* AC-453 Dashboard charm fails to deploy
-* AC-466 AMC application set fails with `argument cpu is invalid`
-* AC-501 A kernel crash occurred in `virt_wifi` kernel module
-* AC-502 Grafana fails in dashboard-relation-joined
-* AC-504 LXD nodes fail to be added if relation hook is run before AMS is configured
-* LP #1922918 LXD charm crashes with TypeError in `count_lxd_nodes_in_cluster`
-* LP #1926118 Using invalid UA token causes hook error instead of proper error
+- AC-467 AMS fails to import image with multiple instances
+- AC-174 LP #1927233 `anbox-stream-gateway-lb` has no open ports when deployed via Juju 2.9
+- AC-293 Anbox leaks after `CtsGraphicsTestCases` has finished
+- AC-294 WebRTC platform crashes on `glDeleteTextures`
+- AC-446 Container fails to start: This operation can't be canceled
+- AC-453 Dashboard charm fails to deploy
+- AC-466 AMC application set fails with `argument cpu is invalid`
+- AC-501 A kernel crash occurred in `virt_wifi` kernel module
+- AC-502 Grafana fails in dashboard-relation-joined
+- AC-504 LXD nodes fail to be added if relation hook is run before AMS is configured
+- LP #1922918 LXD charm crashes with TypeError in `count_lxd_nodes_in_cluster`
+- LP #1926118 Using invalid UA token causes hook error instead of proper error
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.12.1.md
+++ b/reference/release-notes/1.12.1.md
@@ -9,17 +9,17 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Improved graphics stability on Arm64 machines with NVIDIA GPUs
+- Improved graphics stability on Arm64 machines with NVIDIA GPUs
 
 ## Bugs
 
-* AC-472 A native crash occurred to `webview.apk` after upgrading it to 94.0.4606.80
-* AC-505 WebRTC platform crashes in `rtc::SocketDispatcher`
-* AC-503 CUDA resources are not correctly freed
-* AC-508 Units in stats overlay are incorrect
-* AC-545 Find patch in Mesa which fixes the crash
-* AC-553 no Audio output after rejoining a session
-* AC-555 Telegraf fails to run iptables commands
+- AC-472 A native crash occurred to `webview.apk` after upgrading it to 94.0.4606.80
+- AC-505 WebRTC platform crashes in `rtc::SocketDispatcher`
+- AC-503 CUDA resources are not correctly freed
+- AC-508 Units in stats overlay are incorrect
+- AC-545 Find patch in Mesa which fixes the crash
+- AC-553 no Audio output after rejoining a session
+- AC-555 Telegraf fails to run iptables commands
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.12.2.md
+++ b/reference/release-notes/1.12.2.md
@@ -9,19 +9,19 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Anbox container termination time was shortened by improving internal timeouts
-* Explicit CUDA context selection on NVIDIA GPUs avoids cross-GPU usage of a single container
-* Android security updates for December 2021 (see [Android Security Bulletin - December 2021](https://source.android.com/security/bulletin/2021-12-01) for more information)
-* Android WebView has been updated to [96.0.4664.45](https://chromereleases.googleblog.com/2021/11/stable-channel-update-for-desktop.html)
+- Anbox container termination time was shortened by improving internal timeouts
+- Explicit CUDA context selection on NVIDIA GPUs avoids cross-GPU usage of a single container
+- Android security updates for December 2021 (see [Android Security Bulletin - December 2021](https://source.android.com/security/bulletin/2021-12-01) for more information)
+- Android WebView has been updated to [96.0.4664.45](https://chromereleases.googleblog.com/2021/11/stable-channel-update-for-desktop.html)
 
 ## Bugs
 
-* AC-313 Dashboard: self signed certificate cause web browser to print a warning
-* AC-402 Accessing the appliance via the public AWS IP address rather than DNS name breaks streaming
-* AC-408 Improve appliance upgrade message
-* AC-496 Coturn charm doesn't detect changed public address after machine stop / start on AWS
-* AC-578 Settings app crashes when clicking on "Connected Devices"
-* AC-580 Android 12: Unhandled netlink message warnings in system log
+- AC-313 Dashboard: self signed certificate cause web browser to print a warning
+- AC-402 Accessing the appliance via the public AWS IP address rather than DNS name breaks streaming
+- AC-408 Improve appliance upgrade message
+- AC-496 Coturn charm doesn't detect changed public address after machine stop / start on AWS
+- AC-578 Settings app crashes when clicking on "Connected Devices"
+- AC-580 Android 12: Unhandled netlink message warnings in system log
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.12.3.md
+++ b/reference/release-notes/1.12.3.md
@@ -9,19 +9,19 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Android security updates for January 2022 (see [Android Security Bulletin - January 2022](https://source.android.com/security/bulletin/2022-01-01) for more information)
-* Android WebView has been updated to [96.0.4664.45](https://chromereleases.googleblog.com/2021/11/stable-channel-update-for-desktop.html)
+- Android security updates for January 2022 (see [Android Security Bulletin - January 2022](https://source.android.com/security/bulletin/2022-01-01) for more information)
+- Android WebView has been updated to [96.0.4664.45](https://chromereleases.googleblog.com/2021/11/stable-channel-update-for-desktop.html)
 
 ## Bugs
 
-* AC-649 Don't return an error if `JoinSession` is called without a body
-* AC-648 Dashboard ends up with no certificates
-* AC-644 LP#1955986 Application version got stuck to "initializing" when changing an application attribute via `amc application set`
-* AC-627 GPU ends up with zero slots when added after initial node creation
-* AC-625 `nvidia_drm` kernel module isn't loaded after appliance upgrade
-* AC-277 LP #1922889: The `system.log` and `android.log` are missing and not collected by AMS when the container ran into an error
-* AC-621 Anbox shutdown freezes in `anbox::webrtc::metrics::TelegrafBackend::~TelegrafBackend`
-* AC-559 SurfaceFlinger fails to start at times
+- AC-649 Don't return an error if `JoinSession` is called without a body
+- AC-648 Dashboard ends up with no certificates
+- AC-644 LP#1955986 Application version got stuck to "initializing" when changing an application attribute via `amc application set`
+- AC-627 GPU ends up with zero slots when added after initial node creation
+- AC-625 `nvidia_drm` kernel module isn't loaded after appliance upgrade
+- AC-277 LP #1922889: The `system.log` and `android.log` are missing and not collected by AMS when the container ran into an error
+- AC-621 Anbox shutdown freezes in `anbox::webrtc::metrics::TelegrafBackend::~TelegrafBackend`
+- AC-559 SurfaceFlinger fails to start at times
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.12.4.md
+++ b/reference/release-notes/1.12.4.md
@@ -17,7 +17,7 @@ None.
 
 ## Bugs
 
-* AC-657 Traefik listens on port 8080 for incoming API requests
+- AC-657 Traefik listens on port 8080 for incoming API requests
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.12.5.md
+++ b/reference/release-notes/1.12.5.md
@@ -17,11 +17,11 @@ n/a
 
 ## Bugs
 
-* AC-676 Launching containers on a specific node fails with "node not found"
-* AC-671 Application that was signed with a custom system image can't access hidden APIs
-* AC-667 Multi touch is not working when streaming from WebRTC platform
-* AC-663 Latest Firefox doesn't render in 1.12.x
-* AC-662 Android containers fail to start on Linux 5.13.x
+- AC-676 Launching containers on a specific node fails with "node not found"
+- AC-671 Application that was signed with a custom system image can't access hidden APIs
+- AC-667 Multi touch is not working when streaming from WebRTC platform
+- AC-663 Latest Firefox doesn't render in 1.12.x
+- AC-662 Android containers fail to start on Linux 5.13.x
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.13.0.md
+++ b/reference/release-notes/1.13.0.md
@@ -24,8 +24,8 @@ Direct rendering supports OpenGL ES up to version 3.2 depending on driver and ha
 
 ### Other
 
-* Android security updates for February 2022 (see [Android Security Bulletin - February 2022](https://source.android.com/security/bulletin/2022-02-01) for more information)
-* Android WebView has been updated to [98.0.4758.101](https://chromereleases.googleblog.com/2022/02/chrome-for-android-update_0839135123.html)
+- Android security updates for February 2022 (see [Android Security Bulletin - February 2022](https://source.android.com/security/bulletin/2022-02-01) for more information)
+- Android WebView has been updated to [98.0.4758.101](https://chromereleases.googleblog.com/2022/02/chrome-for-android-update_0839135123.html)
 
 ## Known issues
 
@@ -33,58 +33,58 @@ n/a
 
 ## Bug fixes
 
-* AC-732 Anbox session(WebRTC platform) crashed when reconnecting the signaler(stream gateway)
-* AC-731 Stream SDK: `getId()` returns invalid ID
-* AC-727 Cast player: add implementation for `canonicalLogout`
-* AC-726 The AAM inject-system-signature exited with an error when injecting system signature from an APK comes with none default RSA and SF files
-* AC-724 LXD cluster looses its `ams0` storage pool when node failed to get added to the cluster
-* AC-719 Anbox session aborted due to stack smashing detected
-* AC-715 [Doc] Fix "Deploy on bare metal"
-* AC-712 Android crash in Mesa on not allowed `sched_getaffinity syscall`
-* AC-710 node-controller: add health check for LXD event listener
-* AC-709 AMS charm attempts to use the service before it is ready which fails HA deployment
-* AC-707 gateway-multiple-clients deploys charm from charm store rather than the local one
-* AC-706 AMS becomes stuck and doesn't process objects after leadership handover
-* AC-703 Node remains marked as online even if it is removed from the LXD cluster
-* AC-698 Android prints `glUtilsParamSize: unknow param 0x0000826d` when running `deqp` tests
-* AC-697 Application versions are not correctly handled when two versions share the same image
-* AC-696 NewPipe fails to load some videos
-* AC-695 Audio recording app cannot playback m4a recordings
-* AC-694 BombSquad has artifacts at start because of invalid gyro
-* AC-692 Image alias of app version sharing image with another version is not removed
-* AC-690 Plex fails to reach server
-* AC-688 NewPipe fails to load any video
-* AC-686 Weather app fails to connect to the internet
-* AC-685 Recorder app crashes when saving the recording
-* AC-683 Streaming restart is delayed unnecessarily by a second
-* AC-682 Container shuts down when peer connection switches into failed state
-* AC-681 Can't stream video from NewPipe application
-* AC-680 Android log is spammed with `glUtilsParamSize unknown param` warning when running Firefox
-* AC-673 Android reports "Native format mismatch" error when running with Mesa and `swrast`
-* AC-670 Android crashes with dangling file descriptor in Mesa
-* AC-664 Application watchdog was triggered in some cases when enabling the virtual keyboard
-* AC-656 Deleting an instance fails with FormatException
-* AC-655 Resuming instances fails with "instance is still active"
-* AC-653 spread/multiple-gateway-clients broken when using `ua_source`
-* AC-652 Remove deprecated `enable_dev_ui` option
-* AC-651 Anbox crashes in `IOStream::read`
-* AC-637 AMS Cannot Use AAR And Push Application To S3 : `EntityTooLarge`
-* AC-621 Anbox shutdown freezes in `anbox::webrtc::metrics::TelegrafBackend::~TelegrafBackend`
-* AC-620 Anbox session does not generate crashdump on crash
-* AC-600 Anbox leaks memory on NVIDIA GPUs
-* AC-586 Android 10 fails to boot up
-* AC-579 BPF support is enabled but should not
-* AC-577 Android 12 aborts in SurfaceFlinger with direct rendering on AMD GPUs
-* AC-574 Only restart Coturn when necessary
-* AC-567 Node controller leaves old iptables rules
-* AC-565 camera-support:`swrast` test case fails with serious error
-* AC-559 SurfaceFlinger fails to start at times
-* AC-558 Anbox crashes in `glBindFramebuffer` or `swrast`
-* AC-540 Race in the gateway signaler
-* AC-490 Fix documentation on scaling down
-* AC-473 Addons are not listed in the output of `amc application ls` for the bootstrapping application
-* AC-405 Collector logs many "Previous status (…) for container .. differs from cache" errors
-* AC-396 `amc benchmark` removes containers it hasn't created
+- AC-732 Anbox session(WebRTC platform) crashed when reconnecting the signaler(stream gateway)
+- AC-731 Stream SDK: `getId()` returns invalid ID
+- AC-727 Cast player: add implementation for `canonicalLogout`
+- AC-726 The AAM inject-system-signature exited with an error when injecting system signature from an APK comes with none default RSA and SF files
+- AC-724 LXD cluster looses its `ams0` storage pool when node failed to get added to the cluster
+- AC-719 Anbox session aborted due to stack smashing detected
+- AC-715 [Doc] Fix "Deploy on bare metal"
+- AC-712 Android crash in Mesa on not allowed `sched_getaffinity syscall`
+- AC-710 node-controller: add health check for LXD event listener
+- AC-709 AMS charm attempts to use the service before it is ready which fails HA deployment
+- AC-707 gateway-multiple-clients deploys charm from charm store rather than the local one
+- AC-706 AMS becomes stuck and doesn't process objects after leadership handover
+- AC-703 Node remains marked as online even if it is removed from the LXD cluster
+- AC-698 Android prints `glUtilsParamSize: unknow param 0x0000826d` when running `deqp` tests
+- AC-697 Application versions are not correctly handled when two versions share the same image
+- AC-696 NewPipe fails to load some videos
+- AC-695 Audio recording app cannot playback m4a recordings
+- AC-694 BombSquad has artifacts at start because of invalid gyro
+- AC-692 Image alias of app version sharing image with another version is not removed
+- AC-690 Plex fails to reach server
+- AC-688 NewPipe fails to load any video
+- AC-686 Weather app fails to connect to the internet
+- AC-685 Recorder app crashes when saving the recording
+- AC-683 Streaming restart is delayed unnecessarily by a second
+- AC-682 Container shuts down when peer connection switches into failed state
+- AC-681 Can't stream video from NewPipe application
+- AC-680 Android log is spammed with `glUtilsParamSize unknown param` warning when running Firefox
+- AC-673 Android reports "Native format mismatch" error when running with Mesa and `swrast`
+- AC-670 Android crashes with dangling file descriptor in Mesa
+- AC-664 Application watchdog was triggered in some cases when enabling the virtual keyboard
+- AC-656 Deleting an instance fails with FormatException
+- AC-655 Resuming instances fails with "instance is still active"
+- AC-653 spread/multiple-gateway-clients broken when using `ua_source`
+- AC-652 Remove deprecated `enable_dev_ui` option
+- AC-651 Anbox crashes in `IOStream::read`
+- AC-637 AMS Cannot Use AAR And Push Application To S3 : `EntityTooLarge`
+- AC-621 Anbox shutdown freezes in `anbox::webrtc::metrics::TelegrafBackend::~TelegrafBackend`
+- AC-620 Anbox session does not generate crashdump on crash
+- AC-600 Anbox leaks memory on NVIDIA GPUs
+- AC-586 Android 10 fails to boot up
+- AC-579 BPF support is enabled but should not
+- AC-577 Android 12 aborts in SurfaceFlinger with direct rendering on AMD GPUs
+- AC-574 Only restart Coturn when necessary
+- AC-567 Node controller leaves old iptables rules
+- AC-565 camera-support:`swrast` test case fails with serious error
+- AC-559 SurfaceFlinger fails to start at times
+- AC-558 Anbox crashes in `glBindFramebuffer` or `swrast`
+- AC-540 Race in the gateway signaler
+- AC-490 Fix documentation on scaling down
+- AC-473 Addons are not listed in the output of `amc application ls` for the bootstrapping application
+- AC-405 Collector logs many "Previous status (…) for container .. differs from cache" errors
+- AC-396 `amc benchmark` removes containers it hasn't created
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.13.1.md
+++ b/reference/release-notes/1.13.1.md
@@ -9,27 +9,27 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Android security updates for March 2022 (see [Android Security Bulletin - March 2022](https://source.android.com/security/bulletin/2022-03-01) for more information)
-* Android WebView has been updated to [99.0.4844.58](https://chromereleases.googleblog.com/2022/03/stable-channel-update-for-desktop.html)
+- Android security updates for March 2022 (see [Android Security Bulletin - March 2022](https://source.android.com/security/bulletin/2022-03-01) for more information)
+- Android WebView has been updated to [99.0.4844.58](https://chromereleases.googleblog.com/2022/03/stable-channel-update-for-desktop.html)
 
 ## Bugs
 
-* AC-786 Anbox crashes while a Wayland resource is released
-* AC-780 Appliance fails to deploy when monitoring is disabled
-* AC-777 The command `anbox-cloud-appliance gateway account create <account>` returned a slice of bytes in the output
-* AC-773 Redundant services fields displayed in the output of `amc show <container_id>`
-* AC-768 Coturn has 2x `external-ip` entries
-* AC-763 Task failed to be marked as failed when context has expired/got canceled
-* AC-762 AMS fails to cancel container start/stop operations as they cannot be canceled
-* AC-759 Stored artifacts have incorrect permissions
-* AC-758 AMS consumes too much memory during application creation
-* AC-746 The `hwservicemanager` can't find  `android.hardware.vibrator@1.0::IVibrator/default` in either framework or device manifest
-* AC-739 Dashboard fails to load when application failed
-* AC-738 The scaling of the video frame that is captured from the camera is incorrect
-* AC-717 SDK: `experimental.disableBrowserBlock` is not properly verified and not taken into account
-* AC-713 Immersive mode confirmation dialog keeps popping up
-* AC-705 AMS suddenly increases memory consumption and causes OOM kill
-* AC-704 Mesa shader cache directory isn't accessible
+- AC-786 Anbox crashes while a Wayland resource is released
+- AC-780 Appliance fails to deploy when monitoring is disabled
+- AC-777 The command `anbox-cloud-appliance gateway account create <account>` returned a slice of bytes in the output
+- AC-773 Redundant services fields displayed in the output of `amc show <container_id>`
+- AC-768 Coturn has 2x `external-ip` entries
+- AC-763 Task failed to be marked as failed when context has expired/got canceled
+- AC-762 AMS fails to cancel container start/stop operations as they cannot be canceled
+- AC-759 Stored artifacts have incorrect permissions
+- AC-758 AMS consumes too much memory during application creation
+- AC-746 The `hwservicemanager` can't find  `android.hardware.vibrator@1.0::IVibrator/default` in either framework or device manifest
+- AC-739 Dashboard fails to load when application failed
+- AC-738 The scaling of the video frame that is captured from the camera is incorrect
+- AC-717 SDK: `experimental.disableBrowserBlock` is not properly verified and not taken into account
+- AC-713 Immersive mode confirmation dialog keeps popping up
+- AC-705 AMS suddenly increases memory consumption and causes OOM kill
+- AC-704 Mesa shader cache directory isn't accessible
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.13.2.md
+++ b/reference/release-notes/1.13.2.md
@@ -9,8 +9,8 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Android security updates for April 2022 (see [Android Security Bulletin - April 2022](https://source.android.com/security/bulletin/2022-04-01) for more information)
-* Android WebView has been updated to [100.0.4896.79](https://chromereleases.googleblog.com/2022/04/chrome-for-android-update.html)
+- Android security updates for April 2022 (see [Android Security Bulletin - April 2022](https://source.android.com/security/bulletin/2022-04-01) for more information)
+- Android WebView has been updated to [100.0.4896.79](https://chromereleases.googleblog.com/2022/04/chrome-for-android-update.html)
 
 ## Addons - hook timeout
 
@@ -30,17 +30,17 @@ The JavaScript Anbox Streaming SDK now provides a  `rotate()` method to tell the
 
 ## Bugs
 
-* AC-830 On a multi GPU system default number of slots is split across all GPUs
-* AC-829 AMS leaks ports for already removed containers
-* AC-828 Changing the parent image of an application in AMS returns with error
-* AC-811 Anbox `hwcomposer` crashes on highly loaded system with `wl_abort`
-* AC-809 Empty device name is shown up when running `adb shell getevent`
-* AC-788 DrArm is showing just a black screen
-* AC-782 Add support for missing GL parameter sizes
-* AC-765 Minetest crashes on 1.13.0 with SEGV in Anbox
-* AC-725 A segfault occurred from the WebRTC stack during the Anbox session runtime
-* AC-646 1.12 hooks: $CONTAINER_TYPE is empty for regular containers
-* AC-827 Failed to create an arm64 based application when Anbox Cloud deployment is capable with multiple architectures
+- AC-830 On a multi GPU system default number of slots is split across all GPUs
+- AC-829 AMS leaks ports for already removed containers
+- AC-828 Changing the parent image of an application in AMS returns with error
+- AC-811 Anbox `hwcomposer` crashes on highly loaded system with `wl_abort`
+- AC-809 Empty device name is shown up when running `adb shell getevent`
+- AC-788 DrArm is showing just a black screen
+- AC-782 Add support for missing GL parameter sizes
+- AC-765 Minetest crashes on 1.13.0 with SEGV in Anbox
+- AC-725 A segfault occurred from the WebRTC stack during the Anbox session runtime
+- AC-646 1.12 hooks: $CONTAINER_TYPE is empty for regular containers
+- AC-827 Failed to create an arm64 based application when Anbox Cloud deployment is capable with multiple architectures
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.14.0.md
+++ b/reference/release-notes/1.14.0.md
@@ -61,13 +61,13 @@ If you want to turn it back on, set the following configuration option on the LX
 
 ### Other
 
-* Made the NVIDIA 510.x driver series the default.
-* Implemented syscall interception through LXC `seccomp` notification support. This enables Anbox to handle different syscalls like `setpriority` or `sched_set_scheduler` for processes inside the Android container.
-* Unified the pointer input model by using pointer events to handle mouse and touch events.
-* Switched the memory allocator from `glibc` (the default) to `tcmalloc`, to decrease the memory footprint and optimize the memory consumption for the Anbox session.
-* Added Android security updates for May 2022 (see [Android Security Bulletin - May 2022](https://source.android.com/security/bulletin/2022-05-01) for more information).
-* Updated Android WebView to [101.0.4951.41](https://chromereleases.googleblog.com/2022/04/stable-channel-update-for-desktop_26.html).
-* Updated Anbox Cloud to default to the 5.0 LTS release of LXD for all new deployments. The 4.0 release of LXD remains supported, so existing deployments can continue to use 4.0.
+- Made the NVIDIA 510.x driver series the default.
+- Implemented syscall interception through LXC `seccomp` notification support. This enables Anbox to handle different syscalls like `setpriority` or `sched_set_scheduler` for processes inside the Android container.
+- Unified the pointer input model by using pointer events to handle mouse and touch events.
+- Switched the memory allocator from `glibc` (the default) to `tcmalloc`, to decrease the memory footprint and optimize the memory consumption for the Anbox session.
+- Added Android security updates for May 2022 (see [Android Security Bulletin - May 2022](https://source.android.com/security/bulletin/2022-05-01) for more information).
+- Updated Android WebView to [101.0.4951.41](https://chromereleases.googleblog.com/2022/04/stable-channel-update-for-desktop_26.html).
+- Updated Anbox Cloud to default to the 5.0 LTS release of LXD for all new deployments. The 4.0 release of LXD remains supported, so existing deployments can continue to use 4.0.
 
 ## Known issues
 
@@ -75,19 +75,19 @@ n/a
 
 ## Bug fixes
 
-* AC-877 Fix the bugs of JS SDK after the recent refactor
-* AC-867 Android 12 image ships `com.android.emulator.multidisplay`
-* AC-836 `vkcube` crashes without support for `HAL_PIXEL_FORMAT_RGBA_1010102`
-* AC-835 Memory leaks happened to Anbox session process after a container running for a long time
-* AC-833 Anbox host not set in `/etc/hosts` in Android 12
-* AC-832 Android CTS tests report `/proc` isn't mounted with `hidepid=2`
-* AC-821 CTS test cases for system features fail
-* AC-814 AMS dashboard doesn't load on the Appliance
-* AC-810 Failing gateway docs build fails and doesn't stop CI from succeeding
-* AC-741 End touch/mouse events when leaving the SDK container
-* AC-699 `dEQP-GLES3.functional.texture.shadow.cube.linear.greater_or_equal_depth24_stencil8` fails on `swrast`
-* AC-693 SDK is broken on iOS on 4G only
-* AC-548 Colors with direct software rendering in scrcpy are incorrect
+- AC-877 Fix the bugs of JS SDK after the recent refactor
+- AC-867 Android 12 image ships `com.android.emulator.multidisplay`
+- AC-836 `vkcube` crashes without support for `HAL_PIXEL_FORMAT_RGBA_1010102`
+- AC-835 Memory leaks happened to Anbox session process after a container running for a long time
+- AC-833 Anbox host not set in `/etc/hosts` in Android 12
+- AC-832 Android CTS tests report `/proc` isn't mounted with `hidepid=2`
+- AC-821 CTS test cases for system features fail
+- AC-814 AMS dashboard doesn't load on the Appliance
+- AC-810 Failing gateway docs build fails and doesn't stop CI from succeeding
+- AC-741 End touch/mouse events when leaving the SDK container
+- AC-699 `dEQP-GLES3.functional.texture.shadow.cube.linear.greater_or_equal_depth24_stencil8` fails on `swrast`
+- AC-693 SDK is broken on iOS on 4G only
+- AC-548 Colors with direct software rendering in scrcpy are incorrect
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.14.1.md
+++ b/reference/release-notes/1.14.1.md
@@ -9,22 +9,22 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Android security updates for June 2022 (see [Android Security Bulletin - June 2022](https://source.android.com/security/bulletin/2022-06-01) for more information)
-* Android WebView has been updated to [102.0.5005.78](https://chromereleases.googleblog.com/2022/05/chrome-for-android-update_28.html)
-* The Android system app installation process now supports the [APK Signature Scheme v2](https://source.android.com/security/apksigning/v2). See {ref}`howto-install-apk-system-app` for more information on the installation process.
+- Android security updates for June 2022 (see [Android Security Bulletin - June 2022](https://source.android.com/security/bulletin/2022-06-01) for more information)
+- Android WebView has been updated to [102.0.5005.78](https://chromereleases.googleblog.com/2022/05/chrome-for-android-update_28.html)
+- The Android system app installation process now supports the [APK Signature Scheme v2](https://source.android.com/security/apksigning/v2). See {ref}`howto-install-apk-system-app` for more information on the installation process.
 
 ## Bugs
 
-* AC-930 AMS doesn't retry stripping a container when LXD returns not matching ETag
-* AC-936 AMS is misbehaving when LXD cluster fails to process requests
-* AC-929 Node controller doesn't start due to missing route utility
-* AC-928 Use the `ip` command rather than `ifconfig` to parse the IP address of the network device in Anbox container
-* AC-917 Anbox inside jammy images doesn't start on the jammy 5.15 kernel
-* AC-913 Dashboard ended up to a blank screen when stopping a session at times
-* AC-909 AAR leaves `aar_upload_*` files in `/tmp`
-* AC-905 Images are not synchronized on 1.14 appliance
-* AC-818 Show Android boot animation properly
-* LP #1971945 Anbox Cloud WebRTC handshake failed error
+- AC-930 AMS doesn't retry stripping a container when LXD returns not matching ETag
+- AC-936 AMS is misbehaving when LXD cluster fails to process requests
+- AC-929 Node controller doesn't start due to missing route utility
+- AC-928 Use the `ip` command rather than `ifconfig` to parse the IP address of the network device in Anbox container
+- AC-917 Anbox inside jammy images doesn't start on the jammy 5.15 kernel
+- AC-913 Dashboard ended up to a blank screen when stopping a session at times
+- AC-909 AAR leaves `aar_upload_*` files in `/tmp`
+- AC-905 Images are not synchronized on 1.14 appliance
+- AC-818 Show Android boot animation properly
+- LP #1971945 Anbox Cloud WebRTC handshake failed error
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.14.2.md
+++ b/reference/release-notes/1.14.2.md
@@ -9,16 +9,16 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Included Android security updates for July 2022 (see [Android Security Bulletin - July 2022](https://source.android.com/security/bulletin/2022-07-01) for more information).
-* Updated Android WebView to [103.0.5060.71](https://chromereleases.googleblog.com/2022/07/chrome-for-android-update.html).
-* [Join URLs](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/gateway-api/#/session/handle-join-session) handed out by the Anbox Stream Gateway to the Anbox container instances will now not expire anymore. This allows sessions to run forever, if needed.
-* The Anbox Cloud Appliance now supports deploying behind a HTTP proxy through the `--proxy` argument available for the `anbox-cloud-appliance init` command.
+- Included Android security updates for July 2022 (see [Android Security Bulletin - July 2022](https://source.android.com/security/bulletin/2022-07-01) for more information).
+- Updated Android WebView to [103.0.5060.71](https://chromereleases.googleblog.com/2022/07/chrome-for-android-update.html).
+- [Join URLs](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/gateway-api/#/session/handle-join-session) handed out by the Anbox Stream Gateway to the Anbox container instances will now not expire anymore. This allows sessions to run forever, if needed.
+- The Anbox Cloud Appliance now supports deploying behind a HTTP proxy through the `--proxy` argument available for the `anbox-cloud-appliance init` command.
 
 ## Bugs
 
-* AC-945 An unhandled exception is raised when starting Anbox
-* AC-943 No WebRTC metrics data are collected in the Grafana dashboard of the appliance
-* AC-932 Anbox aborts due to assert in `libsoup` being triggered
+- AC-945 An unhandled exception is raised when starting Anbox
+- AC-943 No WebRTC metrics data are collected in the Grafana dashboard of the appliance
+- AC-932 Anbox aborts due to assert in `libsoup` being triggered
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.15.0.md
+++ b/reference/release-notes/1.15.0.md
@@ -11,48 +11,48 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ### Common
 
-* All snaps are now based on the [`core20`](https://snapcraft.io/core20) snap, which removes the need to have older base snaps (for example, `core18`) installed on newer Ubuntu versions.
+- All snaps are now based on the [`core20`](https://snapcraft.io/core20) snap, which removes the need to have older base snaps (for example, `core18`) installed on newer Ubuntu versions.
 
 ### AMS
 
-* AMS now provides support for a {ref}`sec-dev-mode` for containers. This development mode mainly turns off status updates for the Anbox runtime inside a container, which usually cause AMS to stop the container.
-* TLS 1.3 is now enforced by default. This means that if you're running older images (< 1.15), they will fail to talk to AMS. You can temporarily enable TLS 1.2 support in AMS again by setting the `force_tls12` [configuration option of the AMS charm](https://charmhub.io/ams/configure?channel=1.15/stable#force_tls12).
-* With the new `cpu.limit_mode` configuration, the default strategy that AMS uses to assign CPU time to a container via the Linux kernel scheduler can be changed to use CPU core pinning instead. See {ref}`sec-instance-cpu-access` for more details and the caveats that each mode has.
-* If AMS is behind a load balancer, it can now be configured with the address of the load balancer via the [`load_balancer.url` configuration item](https://anbox-cloud.io/docs/ref/ams-configuration). This configuration will instruct containers to go through the load balancer instead of reaching out to the particular AMS instance that launched them.
+- AMS now provides support for a {ref}`sec-dev-mode` for containers. This development mode mainly turns off status updates for the Anbox runtime inside a container, which usually cause AMS to stop the container.
+- TLS 1.3 is now enforced by default. This means that if you're running older images (< 1.15), they will fail to talk to AMS. You can temporarily enable TLS 1.2 support in AMS again by setting the `force_tls12` [configuration option of the AMS charm](https://charmhub.io/ams/configure?channel=1.15/stable#force_tls12).
+- With the new `cpu.limit_mode` configuration, the default strategy that AMS uses to assign CPU time to a container via the Linux kernel scheduler can be changed to use CPU core pinning instead. See {ref}`sec-instance-cpu-access` for more details and the caveats that each mode has.
+- If AMS is behind a load balancer, it can now be configured with the address of the load balancer via the [`load_balancer.url` configuration item](https://anbox-cloud.io/docs/ref/ams-configuration). This configuration will instruct containers to go through the load balancer instead of reaching out to the particular AMS instance that launched them.
 
 ### Anbox
 
-* The [WebRTC streamer configuration](https://anbox-cloud.io/docs/ref/webrtc-streamer) can now be customized. Currently, only the minimum and the maximum bitrate can be configured, in addition to some options specific to [NVIDIA NvEnc](https://developer.nvidia.com/nvidia-video-codec-sdk).
-* {ref}`Tracing support <sec-anbox-https-api-tracing>` in Anbox now includes support for tracing the WebRTC stack as well.
-* A new HTTP `/1.0/platform` API allows runtime configuration of the currently loaded platform. For WebRTC, you can now enable RTP trace collection and retrieve information about the current status of the streamer.
-* Anbox now uses the recently released [LXC 5.0](https://discuss.linuxcontainers.org/t/lxc-5-0-lts-has-been-released/14381).
-* The WebRTC streamer now allows streaming only audio, only video or neither of them, which can be useful in cases where only the exchange of OOB messages is needed. See the [JS SDK](https://github.com/canonical/anbox-streaming-sdk/blob/master/js/anbox-stream-sdk.js) <!-- wokeignore:rule=master --> for details on how to use this feature.
-* Anbox now uses [`jemalloc`](https://github.com/jemalloc/jemalloc) as memory allocator to improve its overall memory footprint.
-* A new OOB version 2 implementation allows bi-directional communication with the Anbox container through the use of data channels. See [the documentation](https://anbox-cloud.io/docs/howto/stream/oob-data) for more details. With the introduction of OOB version 2, the former implementation is deprecated and will be removed in a future Anbox Cloud release.
+- The [WebRTC streamer configuration](https://anbox-cloud.io/docs/ref/webrtc-streamer) can now be customized. Currently, only the minimum and the maximum bitrate can be configured, in addition to some options specific to [NVIDIA NvEnc](https://developer.nvidia.com/nvidia-video-codec-sdk).
+- {ref}`Tracing support <sec-anbox-https-api-tracing>` in Anbox now includes support for tracing the WebRTC stack as well.
+- A new HTTP `/1.0/platform` API allows runtime configuration of the currently loaded platform. For WebRTC, you can now enable RTP trace collection and retrieve information about the current status of the streamer.
+- Anbox now uses the recently released [LXC 5.0](https://discuss.linuxcontainers.org/t/lxc-5-0-lts-has-been-released/14381).
+- The WebRTC streamer now allows streaming only audio, only video or neither of them, which can be useful in cases where only the exchange of OOB messages is needed. See the [JS SDK](https://github.com/canonical/anbox-streaming-sdk/blob/master/js/anbox-stream-sdk.js) <!-- wokeignore:rule=master --> for details on how to use this feature.
+- Anbox now uses [`jemalloc`](https://github.com/jemalloc/jemalloc) as memory allocator to improve its overall memory footprint.
+- A new OOB version 2 implementation allows bi-directional communication with the Anbox container through the use of data channels. See [the documentation](https://anbox-cloud.io/docs/howto/stream/oob-data) for more details. With the introduction of OOB version 2, the former implementation is deprecated and will be removed in a future Anbox Cloud release.
 
 ### Android
 
-* Added Android security updates for August 2022 (see [Android Security Bulletin - August 2022](https://source.android.com/docs/security/bulletin/2022-08-01) for more information).
-* Updated the Android WebView to [103.0.5060.129](https://chromereleases.googleblog.com/2022/07/chrome-for-android-update_01510389319.html).
-* Updated the Mesa graphics driver stack to [22.0.5](https://docs.mesa3d.org/relnotes/22.0.5.html).
-* The `ashmem` kernel module is now optional for all supported Android versions. Anbox Cloud will drop support for `ashmem` with the 1.18 release.
+- Added Android security updates for August 2022 (see [Android Security Bulletin - August 2022](https://source.android.com/docs/security/bulletin/2022-08-01) for more information).
+- Updated the Android WebView to [103.0.5060.129](https://chromereleases.googleblog.com/2022/07/chrome-for-android-update_01510389319.html).
+- Updated the Mesa graphics driver stack to [22.0.5](https://docs.mesa3d.org/relnotes/22.0.5.html).
+- The `ashmem` kernel module is now optional for all supported Android versions. Anbox Cloud will drop support for `ashmem` with the 1.18 release.
 
 ### Anbox Stream Gateway / Agent
 
-* Updated Dqlite to its latest [1.11.1 release](https://github.com/canonical/dqlite/releases/tag/v1.11.1).
+- Updated Dqlite to its latest [1.11.1 release](https://github.com/canonical/dqlite/releases/tag/v1.11.1).
 
 ### Appliance
 
-* The appliance now supports deployment on Ubuntu 22.04 LTS.
-* The minimum required storage size is now 20 GB.
+- The appliance now supports deployment on Ubuntu 22.04 LTS.
+- The minimum required storage size is now 20 GB.
 
 ### Charms
 
-* On Ubuntu 22.04 LTS, the NVIDIA driver is now installed from the Ubuntu archive on arm64 systems instead of from the NVIDIA CUDA archive.
+- On Ubuntu 22.04 LTS, the NVIDIA driver is now installed from the Ubuntu archive on arm64 systems instead of from the NVIDIA CUDA archive.
 
 ### Anbox Cloud tests
 
-* The WebRTC benchmark tool (`anbox-cloud-tests.benchmark`) can now:
+- The WebRTC benchmark tool (`anbox-cloud-tests.benchmark`) can now:
   * Attach to existing sessions (`--session=<id>`).
   * Mark sessions to be kept alive after the benchmark is done (`--keep-session`).
   * Set the WebRTC log level to gain low-level insight (`--log-level=<level>`).
@@ -63,12 +63,12 @@ n/a
 
 ## Bug fixes
 
-* AC-1036 A native crash happens when streaming from the camera on Safari (iOS device)
-* AC-1034 Fix race condition between `init.ranchu.rc` and SurfaceFlinger causing a crash
-* AC-1028 User-defined resources are overridden when both `instance-type` and `resources` specs are specified in `session.yaml`
-* AC-1015 Can't access the service that is exposed internally over IP forward
-* AC-1003 The network endpoint and port persist in the database even after the container is deleted from AMS
-* AC-966 Anbox tries to initialize the video decoder when a stream is being established
+- AC-1036 A native crash happens when streaming from the camera on Safari (iOS device)
+- AC-1034 Fix race condition between `init.ranchu.rc` and SurfaceFlinger causing a crash
+- AC-1028 User-defined resources are overridden when both `instance-type` and `resources` specs are specified in `session.yaml`
+- AC-1015 Can't access the service that is exposed internally over IP forward
+- AC-1003 The network endpoint and port persist in the database even after the container is deleted from AMS
+- AC-966 Anbox tries to initialize the video decoder when a stream is being established
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.15.1.md
+++ b/reference/release-notes/1.15.1.md
@@ -9,15 +9,15 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Included Android security updates for September 2022 (see [Android Security Bulletin - September 2022](https://source.android.com/security/bulletin/2022-09-01) for more information).
-* Updated Android WebView to [105.0.5195.79](https://chromereleases.googleblog.com/2022/09/chrome-for-android-update_5.html).
+- Included Android security updates for September 2022 (see [Android Security Bulletin - September 2022](https://source.android.com/security/bulletin/2022-09-01) for more information).
+- Updated Android WebView to [105.0.5195.79](https://chromereleases.googleblog.com/2022/09/chrome-for-android-update_5.html).
 
 ## Bugs
 
-* AC-1087 Can't delete an application when the application bootstrap ends up in an error state
-* AC-1079 Not possible to stream container anymore after Android rebooted
-* AC-1078 No input is possible after rebooting Android
-* AC-1069 Transport channel closed error occurred when disconnecting a stream on Android client
+- AC-1087 Can't delete an application when the application bootstrap ends up in an error state
+- AC-1079 Not possible to stream container anymore after Android rebooted
+- AC-1078 No input is possible after rebooting Android
+- AC-1069 Transport channel closed error occurred when disconnecting a stream on Android client
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.15.2.md
+++ b/reference/release-notes/1.15.2.md
@@ -9,13 +9,13 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Included Android security updates for October 2022 (see [Android Security Bulletin - October 2022](https://source.android.com/security/bulletin/2022-10-01) for more information).
+- Included Android security updates for October 2022 (see [Android Security Bulletin - October 2022](https://source.android.com/security/bulletin/2022-10-01) for more information).
 
 ## Bugs
 
-* AC-1136 All containers were gone after the appliance snap got refreshed
-* AC-1130 Cannot reconnect to stream session after client with unsupported video codecs tried
-* AC-1087 Can't delete an application when the application bootstrap ends up in an error state
+- AC-1136 All containers were gone after the appliance snap got refreshed
+- AC-1130 Cannot reconnect to stream session after client with unsupported video codecs tried
+- AC-1087 Can't delete an application when the application bootstrap ends up in an error state
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.15.3.md
+++ b/reference/release-notes/1.15.3.md
@@ -11,11 +11,11 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Work around a bug in Juju 2.9.35 that prevents the Anbox Cloud Appliance from deploying its software stack entirely. The workaround makes the deployment process independent of the Juju snap that is installed on the host system by including a Juju binary of a previous release inside the appliance snap.
+- Work around a bug in Juju 2.9.35 that prevents the Anbox Cloud Appliance from deploying its software stack entirely. The workaround makes the deployment process independent of the Juju snap that is installed on the host system by including a Juju binary of a previous release inside the appliance snap.
 
 ## Bugs
 
-* [LP:1993137](https://bugs.launchpad.net/juju/+bug/1993137) Juju 2.9.35 breaks LXD deployment
+- [LP:1993137](https://bugs.launchpad.net/juju/+bug/1993137) Juju 2.9.35 breaks LXD deployment
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.16.0.md
+++ b/reference/release-notes/1.16.0.md
@@ -39,11 +39,11 @@ The Anbox [images](https://anbox-cloud.io/docs/ref/provided-images) include a ne
 
 To allow better fine-tuning of the WebRTC based streaming implementation in Anbox Cloud, 1.16 includes various small improvements:
 
-* Video bitrate limits can now be specified on a per resolution/frame rate level.
-* Additional options allow enabling NVIDIA-specific options for H.264 encoding ([adaptive quantization](https://docs.nvidia.com/video-technologies/video-codec-sdk/11.0/nvenc-video-encoder-api-prog-guide/#adaptive-quantization-aq), [multi-pass frame encoding](https://docs.nvidia.com/video-technologies/video-codec-sdk/11.0/nvenc-video-encoder-api-prog-guide/#multi-pass-frame-phencoding)).
-* Audio and video are now sent on separate streams to improve playout delay on the client.
-* The benchmark utility can now provide statistics for minimum playout and jitter buffer delay.
-* TURN credentials for the container are now dynamically allocated and are no longer created with a constant lifetime.
+- Video bitrate limits can now be specified on a per resolution/frame rate level.
+- Additional options allow enabling NVIDIA-specific options for H.264 encoding ([adaptive quantization](https://docs.nvidia.com/video-technologies/video-codec-sdk/11.0/nvenc-video-encoder-api-prog-guide/#adaptive-quantization-aq), [multi-pass frame encoding](https://docs.nvidia.com/video-technologies/video-codec-sdk/11.0/nvenc-video-encoder-api-prog-guide/#multi-pass-frame-phencoding)).
+- Audio and video are now sent on separate streams to improve playout delay on the client.
+- The benchmark utility can now provide statistics for minimum playout and jitter buffer delay.
+- TURN credentials for the container are now dynamically allocated and are no longer created with a constant lifetime.
 
 ### Data channel v2
 
@@ -69,18 +69,18 @@ A new AMS charm configuration `use_network_acl` has been added. This configurati
 
 ### Other
 
-* Included Android security updates for November 2022 (see [Android Security Bulletin - November 2022](https://source.android.com/docs/security/bulletin/2022-11-01) for more information).
-* Updated Android WebView to [107.0.5304.105](https://chromereleases.googleblog.com/2022/11/chrome-for-android-update.html).
-* Updated the used NVIDIA driver series to [515](https://docs.nvidia.com/datacenter/tesla/index.html), which is supported until May 2023.
-* Updated the appliance to deploy LXD containers based on Ubuntu 22.04 LTS on new deployments (existing deployments keep their existing containers based on Ubuntu 20.04 LTS).
-* Updated the [`ams-lxd`](https://charmhub.io/ams-lxd) Juju charm and the Anbox Cloud Appliance to automatically detect AMD GPU support and configure the kernel `amdgpu` driver for best performance and support.
-* Added support for the [AWS `g4ad` instance types](https://aws.amazon.com/ec2/instance-types/g4/) (equipped with AMD v520 GPUs) to the [Anbox Cloud Appliance images](https://aws.amazon.com/marketplace/pp/prodview-3lx6xyaapstz4) that are available through the AWS marketplace.
-* Updated the appliance so that it can be initialized as any Ubuntu user, not just the `ubuntu` one.
+- Included Android security updates for November 2022 (see [Android Security Bulletin - November 2022](https://source.android.com/docs/security/bulletin/2022-11-01) for more information).
+- Updated Android WebView to [107.0.5304.105](https://chromereleases.googleblog.com/2022/11/chrome-for-android-update.html).
+- Updated the used NVIDIA driver series to [515](https://docs.nvidia.com/datacenter/tesla/index.html), which is supported until May 2023.
+- Updated the appliance to deploy LXD containers based on Ubuntu 22.04 LTS on new deployments (existing deployments keep their existing containers based on Ubuntu 20.04 LTS).
+- Updated the [`ams-lxd`](https://charmhub.io/ams-lxd) Juju charm and the Anbox Cloud Appliance to automatically detect AMD GPU support and configure the kernel `amdgpu` driver for best performance and support.
+- Added support for the [AWS `g4ad` instance types](https://aws.amazon.com/ec2/instance-types/g4/) (equipped with AMD v520 GPUs) to the [Anbox Cloud Appliance images](https://aws.amazon.com/marketplace/pp/prodview-3lx6xyaapstz4) that are available through the AWS marketplace.
+- Updated the appliance so that it can be initialized as any Ubuntu user, not just the `ubuntu` one.
 
 ## Deprecations
 
-* The Anbox [LXD images](https://anbox-cloud.io/docs/ref/provided-images) based on the Ubuntu 18.04 LTS (bionic) release are now deprecated. They will receive their last update with the Anbox Cloud 1.18 release in May 2023. We strongly recommend to upgrade to the Ubuntu 22.04 LTS (jammy) based images, which will be supported until May 2025. These images provide the exact same functionality but are based on a newer release of Ubuntu, which might require small adjustments in addons or customization.
-* The support for version 1 of the OOB data exchange protocol, which allows only half-duplex data transmission, has been removed in the Anbox Cloud 1.16 release. With {ref}`version 2 of the OOB data exchange protocol <howto-exchange-oob-data>`, Anbox Cloud supports full-duplex bidirectional data transmission. We recommend to migrate your integration of version 1 of the out-of-band data exchange to version 2 for full-duplex data transmission and better performance.
+- The Anbox [LXD images](https://anbox-cloud.io/docs/ref/provided-images) based on the Ubuntu 18.04 LTS (bionic) release are now deprecated. They will receive their last update with the Anbox Cloud 1.18 release in May 2023. We strongly recommend to upgrade to the Ubuntu 22.04 LTS (jammy) based images, which will be supported until May 2025. These images provide the exact same functionality but are based on a newer release of Ubuntu, which might require small adjustments in addons or customization.
+- The support for version 1 of the OOB data exchange protocol, which allows only half-duplex data transmission, has been removed in the Anbox Cloud 1.16 release. With {ref}`version 2 of the OOB data exchange protocol <howto-exchange-oob-data>`, Anbox Cloud supports full-duplex bidirectional data transmission. We recommend to migrate your integration of version 1 of the out-of-band data exchange to version 2 for full-duplex data transmission and better performance.
 
 ## Known issues
 
@@ -88,15 +88,15 @@ n/a
 
 ## Bug fixes
 
-* AC-1066 Security rules are not applied properly when deploying Anbox Cloud with clustering set up
-* AC-1101 Fingerprint support is marked as enabled
-* AC-1102 Android has `ro.serialno` not set
-* AC-1181 RenderThread is stopped when `/dev/anbox_sync` cannot be opened
-* AC-1197 WebRTC data proxy fails with `4/NOPERMISSION` on stop
-* AC-1204 The agent sets incorrect region value for provided metrics
-* AC-1205 Playout delay set via RTP header causes error/warning on receiver
-* AC-1207 Supervisor does not reconnect after agent was down for longer and terminates Anbox
-* AC-1208 `MESA_GLSL_CACHE_DIR` is deprecated; use `MESA_SHADER_CACHE_DIR` instead
+- AC-1066 Security rules are not applied properly when deploying Anbox Cloud with clustering set up
+- AC-1101 Fingerprint support is marked as enabled
+- AC-1102 Android has `ro.serialno` not set
+- AC-1181 RenderThread is stopped when `/dev/anbox_sync` cannot be opened
+- AC-1197 WebRTC data proxy fails with `4/NOPERMISSION` on stop
+- AC-1204 The agent sets incorrect region value for provided metrics
+- AC-1205 Playout delay set via RTP header causes error/warning on receiver
+- AC-1207 Supervisor does not reconnect after agent was down for longer and terminates Anbox
+- AC-1208 `MESA_GLSL_CACHE_DIR` is deprecated; use `MESA_SHADER_CACHE_DIR` instead
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.16.1.md
+++ b/reference/release-notes/1.16.1.md
@@ -9,17 +9,17 @@ Please see the {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Included Android security updates for December 2022 (see [Android Security Bulletin - December 2022](https://source.android.com/security/bulletin/2022-12-01) for more information).
-* Updated Android WebView to [108.0.5359.79](https://chromereleases.googleblog.com/2022/12/chrome-for-android-update.html).
+- Included Android security updates for December 2022 (see [Android Security Bulletin - December 2022](https://source.android.com/security/bulletin/2022-12-01) for more information).
+- Updated Android WebView to [108.0.5359.79](https://chromereleases.googleblog.com/2022/12/chrome-for-android-update.html).
 
 ## Bugs
 
-* AC-1222 `ext4` online metadata check service is active but should not be
-* AC-1229 Appliance bootstrap doesn't fail when an Juju unit ends up in an error status
-* AC-1230 The `gpu-slots` remains 0 occasionally even after AMS detects NVIDIA GPU type
-* AC-1235 ANGLE for `null` platform attempts to initialize Vulkan renderer
-* AC-1264 Fatal exception occurred to `com.android.systemui` when launching an application (Android 13 based) with boot package
-* AC-1267 Data channels fail to connect
+- AC-1222 `ext4` online metadata check service is active but should not be
+- AC-1229 Appliance bootstrap doesn't fail when an Juju unit ends up in an error status
+- AC-1230 The `gpu-slots` remains 0 occasionally even after AMS detects NVIDIA GPU type
+- AC-1235 ANGLE for `null` platform attempts to initialize Vulkan renderer
+- AC-1264 Fatal exception occurred to `com.android.systemui` when launching an application (Android 13 based) with boot package
+- AC-1267 Data channels fail to connect
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.16.2.md
+++ b/reference/release-notes/1.16.2.md
@@ -9,14 +9,14 @@ Please see the {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Included Android security updates for January 2023 (see [Android Security Bulletin - January 2023](https://source.android.com/security/bulletin/2023-01-01) for more information).
-* Updated Android WebView to [108.0.5359.128](https://chromereleases.googleblog.com/2022/12/chrome-for-android-update_13.html).
+- Included Android security updates for January 2023 (see [Android Security Bulletin - January 2023](https://source.android.com/security/bulletin/2023-01-01) for more information).
+- Updated Android WebView to [108.0.5359.128](https://chromereleases.googleblog.com/2022/12/chrome-for-android-update_13.html).
 
 ## Bugs
 
-* AC-1276 `finalrd.service`: Failed with result 'exit-code'.
-* AC-1277 The pre-start/install hook to modify Android's root file system always failed
-* [LP #2002020](https://bugs.launchpad.net/charm-etcd/+bug/2002020): `anbox-cloud-core`: `etcd/jammy`: hook failed: "install" due to `error in Tempita setup command: use_2to3 is invalid.`
+- AC-1276 `finalrd.service`: Failed with result 'exit-code'.
+- AC-1277 The pre-start/install hook to modify Android's root file system always failed
+- [LP #2002020](https://bugs.launchpad.net/charm-etcd/+bug/2002020): `anbox-cloud-core`: `etcd/jammy`: hook failed: "install" due to `error in Tempita setup command: use_2to3 is invalid.`
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.16.3.md
+++ b/reference/release-notes/1.16.3.md
@@ -21,7 +21,7 @@ n/a
 
 ## Bugs
 
-* [LP #2002776](https://bugs.launchpad.net/charm-grafana/+bug/2002776): Grafana APT repository key was rotated and charm needs to adapt
+- [LP #2002776](https://bugs.launchpad.net/charm-grafana/+bug/2002776): Grafana APT repository key was rotated and charm needs to adapt
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.16.4.md
+++ b/reference/release-notes/1.16.4.md
@@ -15,7 +15,7 @@ n/a
 
 ## Bugs
 
-* AC-1320 Anbox containers fail to start with LXD 5.0.2
+- AC-1320 Anbox containers fail to start with LXD 5.0.2
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.17.0.md
+++ b/reference/release-notes/1.17.0.md
@@ -42,39 +42,39 @@ This will be further enhanced in future releases to allow easy modification of n
 
 ### Other
 
-* Experimental support for software accelerated AV1 encoding is now available behind a [feature flag](https://anbox-cloud.io/docs/ref/ams-configuration) (`experimental.force_av1_software_encoding`).
-* Containers now connect to Anbox Stream Agent instead of Anbox Stream Gateway for WebRTC signaling.
-* HTTPS fingerprint checks were added to the Anbox runtime for deployment scenarios where the Anbox Stream Agent is not deployed with a certificate signed by a trusted CA.
-* Initial support for NUMA has been added to AMS. If a system has multiple NUMA nodes, AMS will select a node based on the locality of an additionally allocated GPU. If a container is not allocated with a GPU or if `cpu.limit_mode` is set to `pinning`, no specific NUMA is being selected.
-* To allow scheduling containers for applications onto specific nodes in a LXD cluster, an application in AMS can now add a `node-selector` part into its manifest. This will tell the scheduler in AMS to schedule a container for the application onto a node only if it matches the criteria of the node selector. The node selector currently supports tag based selection only.
-* Android still requires cgroup v1 but Ubuntu only supports cgroup v2 since Ubuntu 22.04 LTS. To still enable Android to function correctly, initial work for a translation layer to support cgroup v1 on cgroup v2 only systems via a new `anbox-fs` utility written in Rust has been added. By default, the translation layer is not yet enabled but will be in a future release.
-* Libsoup based websocket support for WebRTC signaling has been replaced with a custom implementation providing better stability.
-* The Android HW composer module based on Wayland is now in use for all supported GPU drivers (NVIDIA, AMD and Intel).
-* Android security updates for February 2023 (see [Android Security Bulletin - February 2023](https://source.android.com/docs/security/bulletin/2023-02-01) for more information).
-* The Android WebView has been updated to [110.0.5481.61](https://chromereleases.googleblog.com/2023/02/early-stable-update-for-android.html).
+- Experimental support for software accelerated AV1 encoding is now available behind a [feature flag](https://anbox-cloud.io/docs/ref/ams-configuration) (`experimental.force_av1_software_encoding`).
+- Containers now connect to Anbox Stream Agent instead of Anbox Stream Gateway for WebRTC signaling.
+- HTTPS fingerprint checks were added to the Anbox runtime for deployment scenarios where the Anbox Stream Agent is not deployed with a certificate signed by a trusted CA.
+- Initial support for NUMA has been added to AMS. If a system has multiple NUMA nodes, AMS will select a node based on the locality of an additionally allocated GPU. If a container is not allocated with a GPU or if `cpu.limit_mode` is set to `pinning`, no specific NUMA is being selected.
+- To allow scheduling containers for applications onto specific nodes in a LXD cluster, an application in AMS can now add a `node-selector` part into its manifest. This will tell the scheduler in AMS to schedule a container for the application onto a node only if it matches the criteria of the node selector. The node selector currently supports tag based selection only.
+- Android still requires cgroup v1 but Ubuntu only supports cgroup v2 since Ubuntu 22.04 LTS. To still enable Android to function correctly, initial work for a translation layer to support cgroup v1 on cgroup v2 only systems via a new `anbox-fs` utility written in Rust has been added. By default, the translation layer is not yet enabled but will be in a future release.
+- Libsoup based websocket support for WebRTC signaling has been replaced with a custom implementation providing better stability.
+- The Android HW composer module based on Wayland is now in use for all supported GPU drivers (NVIDIA, AMD and Intel).
+- Android security updates for February 2023 (see [Android Security Bulletin - February 2023](https://source.android.com/docs/security/bulletin/2023-02-01) for more information).
+- The Android WebView has been updated to [110.0.5481.61](https://chromereleases.googleblog.com/2023/02/early-stable-update-for-android.html).
 
 ### Removed functionality
 
-* The `anbox-stream-gateway.gatewayctl` command shipped with the `anbox-stream-gateway` snap has been removed after it was deprecated in Anbox Cloud 1.6.
+- The `anbox-stream-gateway.gatewayctl` command shipped with the `anbox-stream-gateway` snap has been removed after it was deprecated in Anbox Cloud 1.6.
 
 ### Deprecations
 
-* As Ubuntu 18.04 LTS (bionic) will be end of standard support by April 2023, the upcoming Anbox Cloud 1.18 release will be the last one shipping with Ubuntu 18.04 LTS based Anbox images. If you have not yet migrated to the Ubuntu 22.04 LTS based Anbox images, you should do so now. The Anbox Cloud specific functionality is identical, only the underlying Ubuntu base system has been changed.
-* Android 10 has been end of life since September 2022 but since it is still being patched by Google, Anbox Cloud continues to provide support for it. However starting with the 1.17 release, we mark it as officially being deprecated and recommend to update to a newer Android version. Anbox Cloud will stop shipping Android 10 in future versions.
+- As Ubuntu 18.04 LTS (bionic) will be end of standard support by April 2023, the upcoming Anbox Cloud 1.18 release will be the last one shipping with Ubuntu 18.04 LTS based Anbox images. If you have not yet migrated to the Ubuntu 22.04 LTS based Anbox images, you should do so now. The Anbox Cloud specific functionality is identical, only the underlying Ubuntu base system has been changed.
+- Android 10 has been end of life since September 2022 but since it is still being patched by Google, Anbox Cloud continues to provide support for it. However starting with the 1.17 release, we mark it as officially being deprecated and recommend to update to a newer Android version. Anbox Cloud will stop shipping Android 10 in future versions.
 
 ## Known issues
 
-* Dynamically changing the screen resolution of Anbox containers running with Android 10 is currently not supported.
+- Dynamically changing the screen resolution of Anbox containers running with Android 10 is currently not supported.
 
 ## Bug fixes
 
-* [LP:2001901](https://bugs.launchpad.net/anbox-cloud/+bug/2001901) Anbox crashes with: elf_dynamic_array_reader.h tag not found
-* [LP:1998471](https://bugs.launchpad.net/anbox-cloud/+bug/1998471) Custom `streamer.json` didn't apply to WebRTC streamer
-* AC-1287 `hwcomposer.anbox` crashes inside libwayland
-* AC-1288 Anbox crashes with `Main process exited, code=killed, status=11/SEGV`
-* AC-1304 Trigger an action from an Anbox platform would fail with `RPC timeout` always even after the action was executed successfully in Android container
-* AC-1348 JS SDK tries to apply ICE candidates without a remote description applied
-* AC-1350 Anbox browser activity does not allow Javascript
+- [LP:2001901](https://bugs.launchpad.net/anbox-cloud/+bug/2001901) Anbox crashes with: elf_dynamic_array_reader.h tag not found
+- [LP:1998471](https://bugs.launchpad.net/anbox-cloud/+bug/1998471) Custom `streamer.json` didn't apply to WebRTC streamer
+- AC-1287 `hwcomposer.anbox` crashes inside libwayland
+- AC-1288 Anbox crashes with `Main process exited, code=killed, status=11/SEGV`
+- AC-1304 Trigger an action from an Anbox platform would fail with `RPC timeout` always even after the action was executed successfully in Android container
+- AC-1348 JS SDK tries to apply ICE candidates without a remote description applied
+- AC-1350 Anbox browser activity does not allow Javascript
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.17.1.md
+++ b/reference/release-notes/1.17.1.md
@@ -9,24 +9,24 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* To minimize reboot of a machine or stopping of all containers, an internal check whether the GPU driver needs to be updated is in place. This also presents a status to the user indication the need to reboot the machine after a GPU driver update. The users can also ask if a pending upgrade will require a machine reboot or containers to be stopped.
-* If the LXD charm is deployed on a machine that has an NVIDIA GPU installed, running the `sudo apt update && sudo apt upgrade -y` command for the machine may upgrade the NVIDIA drivers, which accidentally suspends running containers with GPU support. Hence, the NVIDIA drivers are held from being upgraded until you upgrade the LXD charm using the Juju command. You can check if the NVIDIA drivers are being held from being upgraded and when required, you can update them manually.
-* Android security updates for March 2023 (see [Android Security Bulletin - March 2023](https://source.android.com/docs/security/bulletin/2023-03-01) for more information). Starting this month, Android 10 will no longer receive security updates as Google stops providing security patches for Android 10.
-* The Android WebView has been updated to [111.0.5563.49](https://chromereleases.googleblog.com/2023/03/early-stable-update-for-android.html).
+- To minimize reboot of a machine or stopping of all containers, an internal check whether the GPU driver needs to be updated is in place. This also presents a status to the user indication the need to reboot the machine after a GPU driver update. The users can also ask if a pending upgrade will require a machine reboot or containers to be stopped.
+- If the LXD charm is deployed on a machine that has an NVIDIA GPU installed, running the `sudo apt update && sudo apt upgrade -y` command for the machine may upgrade the NVIDIA drivers, which accidentally suspends running containers with GPU support. Hence, the NVIDIA drivers are held from being upgraded until you upgrade the LXD charm using the Juju command. You can check if the NVIDIA drivers are being held from being upgraded and when required, you can update them manually.
+- Android security updates for March 2023 (see [Android Security Bulletin - March 2023](https://source.android.com/docs/security/bulletin/2023-03-01) for more information). Starting this month, Android 10 will no longer receive security updates as Google stops providing security patches for Android 10.
+- The Android WebView has been updated to [111.0.5563.49](https://chromereleases.googleblog.com/2023/03/early-stable-update-for-android.html).
 
 ## Bug fixes
 
-* [AC-1380](https://warthogs.atlassian.net/browse/AC-1380) Android system UI crashes due to missing permissions.
-* [AC-1435](https://warthogs.atlassian.net/browse/AC-1435) Connection timer stays alive after connection attempt failed.
-* [AC-1447](https://warthogs.atlassian.net/browse/AC-1447) Anbox runtime becomes blocked when stopped before being fully started.
-* [AC-1444](https://warthogs.atlassian.net/browse/AC-1444) The `quote` key code doesn't get handled in Anbox Streaming JS SDK when interacting with the container.
+- [AC-1380](https://warthogs.atlassian.net/browse/AC-1380) Android system UI crashes due to missing permissions.
+- [AC-1435](https://warthogs.atlassian.net/browse/AC-1435) Connection timer stays alive after connection attempt failed.
+- [AC-1447](https://warthogs.atlassian.net/browse/AC-1447) Anbox runtime becomes blocked when stopped before being fully started.
+- [AC-1444](https://warthogs.atlassian.net/browse/AC-1444) The `quote` key code doesn't get handled in Anbox Streaming JS SDK when interacting with the container.
 
 ## Known issues
 
-* Since Android 10 will no longer receive security patches from Google starting this month, the security patch level for Android 10 should be 2023-02-05 rather than 2023-03-05. This will be fixed in the Anbox Cloud 1.17.2 release.
-* The following two commits from the [latest security tag](https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-security-11.0.0_r65) are not yet applied. They will be applied in the 1.17.2 release.
-    - [`https://android.googlesource.com/platform/frameworks/base/+/0340c219c094cbd0a07600eac471cfeeaceba60e`](https://android.googlesource.com/platform/frameworks/base/+/0340c219c094cbd0a07600eac471cfeeaceba60e)
-    - [`https://android.googlesource.com/platform/frameworks/base/+/523926b137a69b3a12da18b66dfd24afbf00f445`](https://android.googlesource.com/platform/frameworks/base/+/523926b137a69b3a12da18b66dfd24afbf00f445)
+- Since Android 10 will no longer receive security patches from Google starting this month, the security patch level for Android 10 should be 2023-02-05 rather than 2023-03-05. This will be fixed in the Anbox Cloud 1.17.2 release.
+- The following two commits from the [latest security tag](https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-security-11.0.0_r65) are not yet applied. They will be applied in the 1.17.2 release.
+  * [`https://android.googlesource.com/platform/frameworks/base/+/0340c219c094cbd0a07600eac471cfeeaceba60e`](https://android.googlesource.com/platform/frameworks/base/+/0340c219c094cbd0a07600eac471cfeeaceba60e)
+  * [`https://android.googlesource.com/platform/frameworks/base/+/523926b137a69b3a12da18b66dfd24afbf00f445`](https://android.googlesource.com/platform/frameworks/base/+/523926b137a69b3a12da18b66dfd24afbf00f445)
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.17.2.md
+++ b/reference/release-notes/1.17.2.md
@@ -9,27 +9,27 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* The security patch level is set separately for the vendor and system images. This ensures that the security patch level set by the Android system always takes precedence over the one set by vendor image.
-* Removed `ashmem_linux` kernel module to align with mainstream.
-* Until now, the `linux-modules-nvidia-xx package` was held even if the `use_prebuilt_nvidia_kernel_modules` config item default was set to false. This has been changed so that the Linux NVIDIA kernel module package will not be held by default.
-* Android security updates for April 2023 (see [Android Security Bulletin - April 2023](https://source.android.com/docs/security/bulletin/2023-04-01)).
-* The Android WebView has been updated to [112.0.5615.48](https://chromereleases.googleblog.com/2023/03/early-stable-update-for-android_01850485126.html).
+- The security patch level is set separately for the vendor and system images. This ensures that the security patch level set by the Android system always takes precedence over the one set by vendor image.
+- Removed `ashmem_linux` kernel module to align with mainstream.
+- Until now, the `linux-modules-nvidia-xx package` was held even if the `use_prebuilt_nvidia_kernel_modules` config item default was set to false. This has been changed so that the Linux NVIDIA kernel module package will not be held by default.
+- Android security updates for April 2023 (see [Android Security Bulletin - April 2023](https://source.android.com/docs/security/bulletin/2023-04-01)).
+- The Android WebView has been updated to [112.0.5615.48](https://chromereleases.googleblog.com/2023/03/early-stable-update-for-android_01850485126.html).
 
 ## Bug fixes
 
-* [AC-1511](https://warthogs.atlassian.net/browse/AC-1511) Gallery2 app crashed when editing an picture on Android 12 and 13.
-* [AC-1494](https://warthogs.atlassian.net/browse/AC-1494) The **Sessions** pane in the Anbox Streaming Stack dashboard showed only the sessions that were in *created* status.
-* [AC-1486](https://warthogs.atlassian.net/browse/AC-1486) Settings app crashes in SkiaPipeline::tryCapture
-* [AC-1496](https://warthogs.atlassian.net/browse/AC-1496) GPU render node name is not updated when it has changed.
-* [AC-1493](https://warthogs.atlassian.net/browse/AC-1493) The Grafana Anbox Cloud dashboard shows inflated metrics when there are multiple AMS nodes.
-* The known issue in Anbox Cloud 1.17.1 that the security patch level for Android 10 was 2023-03-05 instead of 2023-02-05 has been fixed.
-* For Android 11, the following two commits from the [latest security tag](https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-security-11.0.0_r65) are applied:
-    - [`https://android.googlesource.com/platform/frameworks/base/+/0340c219c094cbd0a07600eac471cfeeaceba60e`](https://android.googlesource.com/platform/frameworks/base/+/0340c219c094cbd0a07600eac471cfeeaceba60e)
-    - [`https://android.googlesource.com/platform/frameworks/base/+/523926b137a69b3a12da18b66dfd24afbf00f445`](https://android.googlesource.com/platform/frameworks/base/+/0340c219c094cbd0a07600eac471cfeeaceba60e)
+- [AC-1511](https://warthogs.atlassian.net/browse/AC-1511) Gallery2 app crashed when editing an picture on Android 12 and 13.
+- [AC-1494](https://warthogs.atlassian.net/browse/AC-1494) The **Sessions** pane in the Anbox Streaming Stack dashboard showed only the sessions that were in *created* status.
+- [AC-1486](https://warthogs.atlassian.net/browse/AC-1486) Settings app crashes in SkiaPipeline::tryCapture
+- [AC-1496](https://warthogs.atlassian.net/browse/AC-1496) GPU render node name is not updated when it has changed.
+- [AC-1493](https://warthogs.atlassian.net/browse/AC-1493) The Grafana Anbox Cloud dashboard shows inflated metrics when there are multiple AMS nodes.
+- The known issue in Anbox Cloud 1.17.1 that the security patch level for Android 10 was 2023-03-05 instead of 2023-02-05 has been fixed.
+- For Android 11, the following two commits from the [latest security tag](https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-security-11.0.0_r65) are applied:
+  * [`https://android.googlesource.com/platform/frameworks/base/+/0340c219c094cbd0a07600eac471cfeeaceba60e`](https://android.googlesource.com/platform/frameworks/base/+/0340c219c094cbd0a07600eac471cfeeaceba60e)
+  * [`https://android.googlesource.com/platform/frameworks/base/+/523926b137a69b3a12da18b66dfd24afbf00f445`](https://android.googlesource.com/platform/frameworks/base/+/0340c219c094cbd0a07600eac471cfeeaceba60e)
 
 ## Known issues
 
-* Some keystrokes are not picked up when interacting with the container. The keybinding doesn't work when you launch a session from the dashboard even if the application is built on top of the latest Anbox Cloud image. See [LP 2002536](https://bugs.launchpad.net/anbox-cloud/+bug/2002536) for more information.
+- Some keystrokes are not picked up when interacting with the container. The keybinding doesn't work when you launch a session from the dashboard even if the application is built on top of the latest Anbox Cloud image. See [LP 2002536](https://bugs.launchpad.net/anbox-cloud/+bug/2002536) for more information.
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.18.0.md
+++ b/reference/release-notes/1.18.0.md
@@ -11,61 +11,61 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ### Streaming improvements
 
-* The Streaming SDK now reports well defined error codes.<!--AC-1307-->
-* When the agent restarts, the container state is synchronized to the session state. This avoids the containers being stopped and sessions still being active after a reboot.<!--AC-290-->
-* Server side support for Forward Error Correction (FEC) is enabled by default and the corresponding controller is better optimized for networks with higher packet loss. FEC is an error recovery mechanism that allows WebRTC to recover lost RTP packets by using error correction codes. <!--AC-1397 and AC-1440-->
-* Client side freeze time in case of high packet loss is reduced to ~200 milliseconds from up to 3 seconds to recover quicker from these situations and allow smoother playback. <!--AC-1472 and AC-1473-->
+- The Streaming SDK now reports well defined error codes.<!--AC-1307-->
+- When the agent restarts, the container state is synchronized to the session state. This avoids the containers being stopped and sessions still being active after a reboot.<!--AC-290-->
+- Server side support for Forward Error Correction (FEC) is enabled by default and the corresponding controller is better optimized for networks with higher packet loss. FEC is an error recovery mechanism that allows WebRTC to recover lost RTP packets by using error correction codes. <!--AC-1397 and AC-1440-->
+- Client side freeze time in case of high packet loss is reduced to ~200 milliseconds from up to 3 seconds to recover quicker from these situations and allow smoother playback. <!--AC-1472 and AC-1473-->
 
 ### Dashboard improvements
 
-* The new **Edit** button allows editing the node configuration.
-* The sessions web page has pagination.
-* Streaming on mobile matches the device resolution.
-* Quick actions such as **Start**, **Stop**, and **Join** are available for the containers list view.
-* Editing of `manifest.yaml` upon creating an application is possible using the dashboard.
-* The general layout of the web pages and forms has been enhanced to improve user experience and accessibility.
+- The new **Edit** button allows editing the node configuration.
+- The sessions web page has pagination.
+- Streaming on mobile matches the device resolution.
+- Quick actions such as **Start**, **Stop**, and **Join** are available for the containers list view.
+- Editing of `manifest.yaml` upon creating an application is possible using the dashboard.
+- The general layout of the web pages and forms has been enhanced to improve user experience and accessibility.
 
 ### Anbox Management Service (AMS)
 
 <!-- vale off -->
-* The AMS node list output has a `master` column that is not user-relevant and is removed.<!--AC-1395-->
+- The AMS node list output has a `master` column that is not user-relevant and is removed.<!--AC-1395-->
   <!-- vale on -->
-* The `unscheduable` configuration item for a node is corrected to `unschedulable`. The existing configurations using `unscheduable` are still supported to maintain backward compatibility but the configuration item `unscheduable` is deprecated as of the 1.18 release. <!--AC-1346-->
-* In addition to creating applications or addons from a folder or a tarball file, you can create applications or addons using a file of `zip` format. This helps in optimizing the performance of AMS.See [How to create an application](https://anbox-cloud.io/docs/howto/application/create) and [Addons](https://anbox-cloud.io/docs/ref/addons).<!--AC-1500-->
-* Container devices and resources are dynamically allocated/deallocated when starting/stopping a container for effective resource management by AMS.<!--AC-1506-->
+- The `unscheduable` configuration item for a node is corrected to `unschedulable`. The existing configurations using `unscheduable` are still supported to maintain backward compatibility but the configuration item `unscheduable` is deprecated as of the 1.18 release. <!--AC-1346-->
+- In addition to creating applications or addons from a folder or a tarball file, you can create applications or addons using a file of `zip` format. This helps in optimizing the performance of AMS.See [How to create an application](https://anbox-cloud.io/docs/howto/application/create) and [Addons](https://anbox-cloud.io/docs/ref/addons).<!--AC-1500-->
+- Container devices and resources are dynamically allocated/deallocated when starting/stopping a container for effective resource management by AMS.<!--AC-1506-->
 
 ### Other
 
-* Investigations on performance improvements to our OpenGL translation layer revealed that on the decoding side, some workloads were spending between 23% and 30% of their total cycles allocating memory. It has now been reduced to account for only around 2.5% of their total cycle count. This could lead to lower power consumption, thereby lower costs and higher density. Such optimization efforts are a work in progress and we will further tune them in the future releases. <!--AC-1411-->
-* The Android development settings (which include an ADB connection) are enabled by default. Some applications require these settings to be disabled, which you can do with the `disable_development_settings` feature flag. Once set, this feature flag will be considered by all newly launched containers. <!--AC-1364 and AC-1379-->
-* The host ICE candidate IP address is no longer shared with the remote peer. <!--AC-1487-->
-* The Mesa driver is upgraded to the [latest 23.0.3](https://lists.freedesktop.org/archives/mesa-dev/2023-April/225982.html). <!--AC-1534-->
-* The feature flag `android.allow_custom_android_id` is introduced to enable the Android container to use a custom Android ID. Add this feature flag upon application creation to identify users by their corresponding `android_id`. See [AMS configuration](https://anbox-cloud.io/docs/ref/ams-configuration).<!--AC-1520-->
-* You can now start a stopped container that is in an `error` state.<!--AC-1438-->
-* Since the NVIDIA package is being held from upgrading when performing `apt upgrade`, this leads to the drivers missing the security patch. A Juju action is implemented to simplify this manual upgrade and perform the NVIDIA drivers upgrade on demand. See [How to Upgrade Anbox Cloud](https://anbox-cloud.io/docs/howto/update/upgrade-anbox). <!--AC-1436-->
-* Android security updates for May 2023 (see [Android Security Bulletin - May 2023](https://source.android.com/docs/security/bulletin/2023-05-01) for more information).
-* * The Android WebView has been updated to [113.0.5672.62](https://chromereleases.googleblog.com/2023/04/early-stable-update-for-android.html).
+- Investigations on performance improvements to our OpenGL translation layer revealed that on the decoding side, some workloads were spending between 23% and 30% of their total cycles allocating memory. It has now been reduced to account for only around 2.5% of their total cycle count. This could lead to lower power consumption, thereby lower costs and higher density. Such optimization efforts are a work in progress and we will further tune them in the future releases. <!--AC-1411-->
+- The Android development settings (which include an ADB connection) are enabled by default. Some applications require these settings to be disabled, which you can do with the `disable_development_settings` feature flag. Once set, this feature flag will be considered by all newly launched containers. <!--AC-1364 and AC-1379-->
+- The host ICE candidate IP address is no longer shared with the remote peer. <!--AC-1487-->
+- The Mesa driver is upgraded to the [latest 23.0.3](https://lists.freedesktop.org/archives/mesa-dev/2023-April/225982.html). <!--AC-1534-->
+- The feature flag `android.allow_custom_android_id` is introduced to enable the Android container to use a custom Android ID. Add this feature flag upon application creation to identify users by their corresponding `android_id`. See [AMS configuration](https://anbox-cloud.io/docs/ref/ams-configuration).<!--AC-1520-->
+- You can now start a stopped container that is in an `error` state.<!--AC-1438-->
+- Since the NVIDIA package is being held from upgrading when performing `apt upgrade`, this leads to the drivers missing the security patch. A Juju action is implemented to simplify this manual upgrade and perform the NVIDIA drivers upgrade on demand. See [How to Upgrade Anbox Cloud](https://anbox-cloud.io/docs/howto/update/upgrade-anbox). <!--AC-1436-->
+- Android security updates for May 2023 (see [Android Security Bulletin - May 2023](https://source.android.com/docs/security/bulletin/2023-05-01) for more information).
+- * The Android WebView has been updated to [113.0.5672.62](https://chromereleases.googleblog.com/2023/04/early-stable-update-for-android.html).
 
 ## Bug fixes
 
 The following issues were fixed as part of the Anbox Cloud 1.18 release:
 
-* [LP #2009811](https://bugs.launchpad.net/anbox-cloud/+bug/2009811) An agent that is highly available and deployed behind a load balancer is incorrectly addressed by the gateway because the gateway was addressing the agent for supervisor message by the agent id rather than the session id.<!--AC-1432-->
-* [LP #2009811](https://bugs.launchpad.net/anbox-cloud/+bug/2009811) Streaming the Anbox application fails because of an unreliable websocket connection. <!--AC-1433-->
-* [LP #2015712](https://bugs.launchpad.net/anbox-cloud/+bug/2015712) Anbox Application Registry (AAR) does not log authorization errors <!--AC-1523-->
-* [LP #2016044](https://bugs.launchpad.net/anbox-cloud/+bug/2016044) Initializing the Anbox Cloud appliance involves renaming the `/tmp` directory when the source and the location are not on the same device and this leads to a failure in the initialization of the Anbox Cloud Appliance.<!--AC-1522-->
-* [LP #2012989](https://bugs.launchpad.net/anbox-cloud/+bug/2012989) AMS does not reflect the updated instance details after resizing the LXD node. <!--AC-1524-->
-* Fix incorrect vsync timestamps in Anbox hardware composer. <!--AC-1354-->
-* The user action buttons were not visible without scrolling when using the web dashboard on mobile. <!--AC-1566-->
-* On the **Containers** page of the web dashboard, the application name was not displayed for containers launched from a raw image. <!--AC-1559-->
-* Vendor image browser activity identifies itself as Android WebView. This behavior is not allowed by several web services.<!--AC-1488-->
+- [LP #2009811](https://bugs.launchpad.net/anbox-cloud/+bug/2009811) An agent that is highly available and deployed behind a load balancer is incorrectly addressed by the gateway because the gateway was addressing the agent for supervisor message by the agent id rather than the session id.<!--AC-1432-->
+- [LP #2009811](https://bugs.launchpad.net/anbox-cloud/+bug/2009811) Streaming the Anbox application fails because of an unreliable websocket connection. <!--AC-1433-->
+- [LP #2015712](https://bugs.launchpad.net/anbox-cloud/+bug/2015712) Anbox Application Registry (AAR) does not log authorization errors <!--AC-1523-->
+- [LP #2016044](https://bugs.launchpad.net/anbox-cloud/+bug/2016044) Initializing the Anbox Cloud appliance involves renaming the `/tmp` directory when the source and the location are not on the same device and this leads to a failure in the initialization of the Anbox Cloud Appliance.<!--AC-1522-->
+- [LP #2012989](https://bugs.launchpad.net/anbox-cloud/+bug/2012989) AMS does not reflect the updated instance details after resizing the LXD node. <!--AC-1524-->
+- Fix incorrect vsync timestamps in Anbox hardware composer. <!--AC-1354-->
+- The user action buttons were not visible without scrolling when using the web dashboard on mobile. <!--AC-1566-->
+- On the **Containers** page of the web dashboard, the application name was not displayed for containers launched from a raw image. <!--AC-1559-->
+- Vendor image browser activity identifies itself as Android WebView. This behavior is not allowed by several web services.<!--AC-1488-->
 
 ## Known issues
 The following issues are known to occur with the 1.18.0 version of Anbox Cloud and are being investigated and planned to be fixed in a future release:
 
-* When streaming an application that changes the configuration during the runtime, if the [`watchdog`](https://anbox-cloud.io/docs/ref/application-manifest) attribute is enabled, it may be triggered because the application is relaunched to adapt to the changes to the configuration. You can work around this problem by disabling the `watchdog` attribute.
-* In the session view of the Anbox Cloud web dashboard, the session ID may appear truncated. <!--AC-1611-->
-* When using the Anbox Cloud web dashboard, occasionally, the navigation bar of the Android system may not appear. You can work around this by changing the aspect ratio of the browser window.<!--AC-1612-->
+- When streaming an application that changes the configuration during the runtime, if the [`watchdog`](https://anbox-cloud.io/docs/ref/application-manifest) attribute is enabled, it may be triggered because the application is relaunched to adapt to the changes to the configuration. You can work around this problem by disabling the `watchdog` attribute.
+- In the session view of the Anbox Cloud web dashboard, the session ID may appear truncated. <!--AC-1611-->
+- When using the Anbox Cloud web dashboard, occasionally, the navigation bar of the Android system may not appear. You can work around this by changing the aspect ratio of the browser window.<!--AC-1612-->
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.18.1.md
+++ b/reference/release-notes/1.18.1.md
@@ -9,22 +9,22 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Android security updates for June 2023 (See [Android Security Bulletin - June 2023](https://source.android.com/docs/security/bulletin/2023-06-01) for more information).
-* The Android WebView has been updated to [114.0.5735.53](https://chromereleases.googleblog.com/2023/05/early-stable-update-for-android.html).
-* Improve our emulation GL stack to deal with the case that some games provide incomplete texture and caused broken graphics output.
+- Android security updates for June 2023 (See [Android Security Bulletin - June 2023](https://source.android.com/docs/security/bulletin/2023-06-01) for more information).
+- The Android WebView has been updated to [114.0.5735.53](https://chromereleases.googleblog.com/2023/05/early-stable-update-for-android.html).
+- Improve our emulation GL stack to deal with the case that some games provide incomplete texture and caused broken graphics output.
 
 ## Bug fixes
 
-* [AC-1558](https://warthogs.atlassian.net/browse/AC-1558) Fix the crash caused by the `boot-application-relaunced` watchdog when streaming the `Beach Buggy Racing` application in the portrait mode.
-* [AC-1560](https://warthogs.atlassian.net/browse/AC-1560) Require a user confirmation when executing `amc start <container_id>` for containers with an `error` state. This fix is added so that users are aware that starting a container from an `error` state drops the container logs.
-* [AC-1570](https://warthogs.atlassian.net/browse/AC-1570) Add an intuitive error message in certain cases that directs users to check the snap access. Prior to 1.18.1, Creating an application from a directory gives a vague error message (e.g `no such file or directory: /my-app`) which might not reflect the real reason for failure. For example, when the directory exists but the AMC snap cannot access the directory.
-* [AC-1600](https://warthogs.atlassian.net/browse/AC-1600) Fix the permission denial error when broadcasting `ACTION_CLOSE_SYSTEM_DIALOGS` intent from AOSP calendar app.
-* [AC-1606](https://warthogs.atlassian.net/browse/AC-1606) Fix the image ID out-of-sync issue when adding an image into AMS. This fix enables people to launch a raw container with an image ID returned from the `amc image add` command.
-* [AC-1608](https://warthogs.atlassian.net/browse/AC-1608) Fix the `InputReader: Received unexpected event` error when enabling the touch emulation by default. This fix avoids unexpected events sent from the client to the Android container resulting in multiple error logs showing up during Android runtime.
-* [AC-1611](https://warthogs.atlassian.net/browse/AC-1611) Fix the issue in web dashboard when the **Session ID** was truncated in the session view.
-* [AC-1612](https://warthogs.atlassian.net/browse/AC-1612) Fix the issue in Anbox Cloud web dashboard when occasionally the navigation bar of the Android system may not appear.
-* [AC-1624](https://warthogs.atlassian.net/browse/AC-1624) Fix the broken graphical output during the game play of `Bingo Blitz`.
-* [AC-1625](https://warthogs.atlassian.net/browse/AC-1625) Fix the broken graphical output during the game play of `Slotomania`.
+- [AC-1558](https://warthogs.atlassian.net/browse/AC-1558) Fix the crash caused by the `boot-application-relaunced` watchdog when streaming the `Beach Buggy Racing` application in the portrait mode.
+- [AC-1560](https://warthogs.atlassian.net/browse/AC-1560) Require a user confirmation when executing `amc start <container_id>` for containers with an `error` state. This fix is added so that users are aware that starting a container from an `error` state drops the container logs.
+- [AC-1570](https://warthogs.atlassian.net/browse/AC-1570) Add an intuitive error message in certain cases that directs users to check the snap access. Prior to 1.18.1, Creating an application from a directory gives a vague error message (e.g `no such file or directory: /my-app`) which might not reflect the real reason for failure. For example, when the directory exists but the AMC snap cannot access the directory.
+- [AC-1600](https://warthogs.atlassian.net/browse/AC-1600) Fix the permission denial error when broadcasting `ACTION_CLOSE_SYSTEM_DIALOGS` intent from AOSP calendar app.
+- [AC-1606](https://warthogs.atlassian.net/browse/AC-1606) Fix the image ID out-of-sync issue when adding an image into AMS. This fix enables people to launch a raw container with an image ID returned from the `amc image add` command.
+- [AC-1608](https://warthogs.atlassian.net/browse/AC-1608) Fix the `InputReader: Received unexpected event` error when enabling the touch emulation by default. This fix avoids unexpected events sent from the client to the Android container resulting in multiple error logs showing up during Android runtime.
+- [AC-1611](https://warthogs.atlassian.net/browse/AC-1611) Fix the issue in web dashboard when the **Session ID** was truncated in the session view.
+- [AC-1612](https://warthogs.atlassian.net/browse/AC-1612) Fix the issue in Anbox Cloud web dashboard when occasionally the navigation bar of the Android system may not appear.
+- [AC-1624](https://warthogs.atlassian.net/browse/AC-1624) Fix the broken graphical output during the game play of `Bingo Blitz`.
+- [AC-1625](https://warthogs.atlassian.net/browse/AC-1625) Fix the broken graphical output during the game play of `Slotomania`.
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.18.2.md
+++ b/reference/release-notes/1.18.2.md
@@ -9,8 +9,8 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Android security updates for July 2023. See [Android Security Bulletin - July 2023](https://source.android.com/docs/security/bulletin/2023-07-01) for more information.
-* The Android WebView has been updated to 114.0.5735.131.
+- Android security updates for July 2023. See [Android Security Bulletin - July 2023](https://source.android.com/docs/security/bulletin/2023-07-01) for more information.
+- The Android WebView has been updated to 114.0.5735.131.
 
 ## Important notes
 For 1.18.2 version and later, if you have a load balancer with proper TLS certificates placed in front of the Anbox stream agent and if you have set the [`location`](https://charmhub.io/anbox-stream-agent/configuration#location) of the Anbox stream agent, TLS pinning must be disabled by running:
@@ -23,17 +23,17 @@ Otherwise, Anbox containers will fail to communicate with the stream agent.
 
 ## Bug fixes
 
-* When upgrading Anbox Cloud, the `Reboot required to activate new kernel or GPU drivers` message when running `juju status` does not clear even after rebooting and clearing the notification. <!--AC-1622-->
-* `Honkai: Star Rail` game had alpha blending issues and displayed a pink rectangle during game play. <!--AC-1628-->
-* `Invalid argument` error occurs when configuring kernel parameters during the LXD charm upgrade. <!--AC-1645-->
-* Cannot set a node as unschedulable using the `unschedulable` parameter when updating a node via PATH method to endpoint(1.0/nodes). <!--AC-1689-->
-* Applications requiring camera and microphone do not work in Anbox Cloud version 1.18.0 or later because of a change to the wire protocol between the WebRTC client and server. <!--AC-1710-->
-* In the [Anbox Stream Gateway Charm](https://charmhub.io/anbox-stream-gateway), TLS pinning is not enabled even after the `tls_use_pinning` configuration is set to `true`. <!--AC-1683-->
-* [LP 2024144](https://bugs.launchpad.net/anbox-cloud/+bug/2024144) The Grafana dashboard displays incorrect metrics for streaming stack. <!--AC-1685-->
-* [LP 2020801](https://bugs.launchpad.net/anbox-cloud/+bug/2020801) Accessibility service crashes on Android 13 for Anbox Cloud. <!--AC-1657-->
-* [LP 2024426](https://bugs.launchpad.net/anbox-cloud/+bug/2024426) Anbox Application Registry (AAR) loses metadata on upgrade. <!--AC-1691-->
-* [LP 2024559](https://bugs.launchpad.net/anbox-cloud/+bug/2024559) The LXD storage pool size is not evaluated during the initialization of Anbox Cloud Appliance. <!--AC-1698-->
-* [LP 2025058](https://bugs.launchpad.net/anbox-cloud/+bug/2025058) The Anbox Cloud stream fails with an error `Anbox stream failed Error: signaling timed out`. <!--AC-1733-->
+- When upgrading Anbox Cloud, the `Reboot required to activate new kernel or GPU drivers` message when running `juju status` does not clear even after rebooting and clearing the notification. <!--AC-1622-->
+- `Honkai: Star Rail` game had alpha blending issues and displayed a pink rectangle during game play. <!--AC-1628-->
+- `Invalid argument` error occurs when configuring kernel parameters during the LXD charm upgrade. <!--AC-1645-->
+- Cannot set a node as unschedulable using the `unschedulable` parameter when updating a node via PATH method to endpoint(1.0/nodes). <!--AC-1689-->
+- Applications requiring camera and microphone do not work in Anbox Cloud version 1.18.0 or later because of a change to the wire protocol between the WebRTC client and server. <!--AC-1710-->
+- In the [Anbox Stream Gateway Charm](https://charmhub.io/anbox-stream-gateway), TLS pinning is not enabled even after the `tls_use_pinning` configuration is set to `true`. <!--AC-1683-->
+- [LP 2024144](https://bugs.launchpad.net/anbox-cloud/+bug/2024144) The Grafana dashboard displays incorrect metrics for streaming stack. <!--AC-1685-->
+- [LP 2020801](https://bugs.launchpad.net/anbox-cloud/+bug/2020801) Accessibility service crashes on Android 13 for Anbox Cloud. <!--AC-1657-->
+- [LP 2024426](https://bugs.launchpad.net/anbox-cloud/+bug/2024426) Anbox Application Registry (AAR) loses metadata on upgrade. <!--AC-1691-->
+- [LP 2024559](https://bugs.launchpad.net/anbox-cloud/+bug/2024559) The LXD storage pool size is not evaluated during the initialization of Anbox Cloud Appliance. <!--AC-1698-->
+- [LP 2025058](https://bugs.launchpad.net/anbox-cloud/+bug/2025058) The Anbox Cloud stream fails with an error `Anbox stream failed Error: signaling timed out`. <!--AC-1733-->
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.19.0.md
+++ b/reference/release-notes/1.19.0.md
@@ -11,56 +11,56 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ### Core stack improvements
 
-* The Anbox Management Service (AMS) API documentation created using OpenAPI specification (Swagger 2.0) is available on the AMS host at `/1.0/swagger.json` and at [`https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/ams-api/`](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/ams-api/).<!--AC-1474-->
-* Pagination and filtering support is enabled for containers and applications in the AMS API. You can use it by directly interacting with the AMS using API calls.<!--AC-1475-->
-* A cgroup v1 emulation layer is added for cgroup v2-only hosts. This is required by Android for resource tracking and management.<!--AC-1463-->
-* Enhanced configuration of failure domain of LXD nodes to ensure LXD makes its database highly available across multiple availability zones.<!--AC-1573-->
-* The Android watchdog can now be enabled or disabled via `amc application set`. For example, `amc application set my-app watchdog.disabled=true`<!--AC-1577-->
-* An alias (`app`) is added for the `application` command in AMS. For example, you can use `amc app ls` in place of `amc application ls` to list all applications in AMS.<!--AC-1567-->
-* The default CPU limit mode is set to `pinning` for a better streaming experience. <!--AC-1787-->
+- The Anbox Management Service (AMS) API documentation created using OpenAPI specification (Swagger 2.0) is available on the AMS host at `/1.0/swagger.json` and at [`https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/ams-api/`](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/ams-api/).<!--AC-1474-->
+- Pagination and filtering support is enabled for containers and applications in the AMS API. You can use it by directly interacting with the AMS using API calls.<!--AC-1475-->
+- A cgroup v1 emulation layer is added for cgroup v2-only hosts. This is required by Android for resource tracking and management.<!--AC-1463-->
+- Enhanced configuration of failure domain of LXD nodes to ensure LXD makes its database highly available across multiple availability zones.<!--AC-1573-->
+- The Android watchdog can now be enabled or disabled via `amc application set`. For example, `amc application set my-app watchdog.disabled=true`<!--AC-1577-->
+- An alias (`app`) is added for the `application` command in AMS. For example, you can use `amc app ls` in place of `amc application ls` to list all applications in AMS.<!--AC-1567-->
+- The default CPU limit mode is set to `pinning` for a better streaming experience. <!--AC-1787-->
 
 ### Streaming stack improvements
 
-* AV1 hardware accelerated video encoding on NVIDIA GPUs is enabled.<!--AC-1461-->
+- AV1 hardware accelerated video encoding on NVIDIA GPUs is enabled.<!--AC-1461-->
 
 ### Dashboard improvements
 
 #### Registry
 
-* When the Anbox Application Registry (AAR) is configured, you can view and manage applications and their versions in the registry. If you have configured the AAR in manual mode, you can also manually push apps to and delete apps from registry. Use the **Registry** option on the left menu to explore more about this feature.
+- When the Anbox Application Registry (AAR) is configured, you can view and manage applications and their versions in the registry. If you have configured the AAR in manual mode, you can also manually push apps to and delete apps from registry. Use the **Registry** option on the left menu to explore more about this feature.
 
 #### Sessions
 
-* The streaming statistics for sessions are enhanced. When you click on the **Statistics** button, the right pane displays the stream statistics and relevant graphs.
-* The sessions list **Search and filter** feature is enhanced for easier filtering based on status and the region.
-* You can now use the **Sharing** button on the session page to invite users without an account to join the stream using a link.
+- The streaming statistics for sessions are enhanced. When you click on the **Statistics** button, the right pane displays the stream statistics and relevant graphs.
+- The sessions list **Search and filter** feature is enhanced for easier filtering based on status and the region.
+- You can now use the **Sharing** button on the session page to invite users without an account to join the stream using a link.
 
 #### Applications
 
-* An application detail page is added where you can see the details of the application and its versions. Click on the application name in the list of applications to view the application detail page.
-* You can manage application versions through the dashboard now. On the **Versions** tab of the application detail page, there's an **Actions** button that allows you to manage versions of the application.
+- An application detail page is added where you can see the details of the application and its versions. Click on the application name in the list of applications to view the application detail page.
+- You can manage application versions through the dashboard now. On the **Versions** tab of the application detail page, there's an **Actions** button that allows you to manage versions of the application.
 
 #### Containers
 
-* You can perform bulk actions on containers on the containers list page. Select one or more containers for the **Start**/**Stop** buttons to appear on top.
-* The container list **Search and filter** feature is enhanced for easier filtering based on status, type of containers, running applications, and the node on which it is running.
+- You can perform bulk actions on containers on the containers list page. Select one or more containers for the **Start**/**Stop** buttons to appear on top.
+- The container list **Search and filter** feature is enhanced for easier filtering based on status, type of containers, running applications, and the node on which it is running.
 
 ### Other
 
-* Android security updates for August 2023 (see [Android Security Bulletin - August 2023](https://source.android.com/docs/security/bulletin/2023-08-01) for more information).
-* The Android WebView has been updated to [115.0.5790.138](https://chromereleases.googleblog.com/2023/07/chrome-for-android-update_25.html).
-* The Mesa driver/VirGL renderer have been updated to the latest upstream version 23.1.<!--AC-1614-->
-* License information for used software components is available in the `NOTICE` file in the root file system.<!--AC-1663-->
-* A verification for secure boot and machine owner key is added to avoid appliance installation failures.<!--AC-1692-->
-* The `wait-for-if.sh` script in the LXD charm now uses `ip` instead of `ifconfig`.<!--AC-1696-->
-* Improved `anbox-cloud-tests` so that it does not delete containers/sessions other than those that it owns.<!--AC-1639-->
+- Android security updates for August 2023 (see [Android Security Bulletin - August 2023](https://source.android.com/docs/security/bulletin/2023-08-01) for more information).
+- The Android WebView has been updated to [115.0.5790.138](https://chromereleases.googleblog.com/2023/07/chrome-for-android-update_25.html).
+- The Mesa driver/VirGL renderer have been updated to the latest upstream version 23.1.<!--AC-1614-->
+- License information for used software components is available in the `NOTICE` file in the root file system.<!--AC-1663-->
+- A verification for secure boot and machine owner key is added to avoid appliance installation failures.<!--AC-1692-->
+- The `wait-for-if.sh` script in the LXD charm now uses `ip` instead of `ifconfig`.<!--AC-1696-->
+- Improved `anbox-cloud-tests` so that it does not delete containers/sessions other than those that it owns.<!--AC-1639-->
 
 ## Removed functionality
 
-* Ubuntu 18.04 LTS (bionic) images that were deprecated in 1.16.0 are no longer supported and are removed.
-* The `qemu-props` binary from the Android image was dropped as it is unnecessary and not energy efficient if the service is unused yet running during Android runtime.<!--AC-1599-->
-* The outdated `ashmem` module was originally removed in the 1.17.2 release but AMS still attached the `ashmem` device by default when starting a container. This could cause start up failures and hence with 1.19.0, `ashmem` module is completely removed from AMS and Anbox Cloud.<!--AC-1531-->
-* The following services that consumed unnecessary CPU time when launching a container are masked: <!--AC-1793-->
+- Ubuntu 18.04 LTS (bionic) images that were deprecated in 1.16.0 are no longer supported and are removed.
+- The `qemu-props` binary from the Android image was dropped as it is unnecessary and not energy efficient if the service is unused yet running during Android runtime.<!--AC-1599-->
+- The outdated `ashmem` module was originally removed in the 1.17.2 release but AMS still attached the `ashmem` device by default when starting a container. This could cause start up failures and hence with 1.19.0, `ashmem` module is completely removed from AMS and Anbox Cloud.<!--AC-1531-->
+- The following services that consumed unnecessary CPU time when launching a container are masked: <!--AC-1793-->
 
 ```
 e2scrub@.service
@@ -72,26 +72,26 @@ e2scrub_reap.service
 
 ## Deprecations
 
-* Android 11 images are deprecated since 1.19.0 and are planned to be removed when they no longer get security patches from Google. This is expected to happen around the Anbox Cloud 1.21 release. See provided images for the current list of supported and deprecated images.
-* Support for Ubuntu 20.04 LTS (focal) hosts is deprecated and will be removed when Ubuntu 24.04 LTS is available.
+- Android 11 images are deprecated since 1.19.0 and are planned to be removed when they no longer get security patches from Google. This is expected to happen around the Anbox Cloud 1.21 release. See provided images for the current list of supported and deprecated images.
+- Support for Ubuntu 20.04 LTS (focal) hosts is deprecated and will be removed when Ubuntu 24.04 LTS is available.
 
 ## Known issues
 
-* Forcing software rendering for applications in the `manifest.yaml` via `video-encoder: software` does not work and as a result, the Anbox runtime fails to start. This issue is planned to be fixed in the upcoming 1.19.1 release.
+- Forcing software rendering for applications in the `manifest.yaml` via `video-encoder: software` does not work and as a result, the Anbox runtime fails to start. This issue is planned to be fixed in the upcoming 1.19.1 release.
 
 ## Bug fixes
 
-* [LP 2028337](https://bugs.launchpad.net/anbox-cloud/+bug/2028337) Launching a container fails because Anbox IME process is not started. <!--AC-1768-->
-* [LP 2028028](https://bugs.launchpad.net/anbox-cloud/+bug/2028028) The stream stack dashboard reports incorrect statistics.<!--AC-1747-->
-* [LP 2027534](https://bugs.launchpad.net/anbox-cloud/+bug/2027534) The `evony` game has a long startup time because of slowness in file loading.<!--AC-1751-->
-* Emulation in the kernel for the Arm `SWP` instruction that is required to be enabled by Android was not enabled by default. <!--AC-1649-->
-* Anbox Cloud stream failed because exception handling was not implemented for the `setRemoteDescription` method. <!--AC-1709-->
-* Message loss issue when using websocket for ICE candidate exchange. <!--AC-1660-->
-* Websocket client crashes when responding to ping message due to concurrent usage of the socket.<!--AC-1781-->
-* Added missing licenses for Mesa driver.<!--AC-1661-->
-* CPU pinning is not applied until the LXD daemon is reloaded after initialization. <!--AC-1791-->
-* Creation of fence gets stuck and causes the system to stop responding.<!--AC-1794-->
-* All runtime permissions are granted to an application irrespective of the permissions specified in the application manifest. <!--AC-1648-->
+- [LP 2028337](https://bugs.launchpad.net/anbox-cloud/+bug/2028337) Launching a container fails because Anbox IME process is not started. <!--AC-1768-->
+- [LP 2028028](https://bugs.launchpad.net/anbox-cloud/+bug/2028028) The stream stack dashboard reports incorrect statistics.<!--AC-1747-->
+- [LP 2027534](https://bugs.launchpad.net/anbox-cloud/+bug/2027534) The `evony` game has a long startup time because of slowness in file loading.<!--AC-1751-->
+- Emulation in the kernel for the Arm `SWP` instruction that is required to be enabled by Android was not enabled by default. <!--AC-1649-->
+- Anbox Cloud stream failed because exception handling was not implemented for the `setRemoteDescription` method. <!--AC-1709-->
+- Message loss issue when using websocket for ICE candidate exchange. <!--AC-1660-->
+- Websocket client crashes when responding to ping message due to concurrent usage of the socket.<!--AC-1781-->
+- Added missing licenses for Mesa driver.<!--AC-1661-->
+- CPU pinning is not applied until the LXD daemon is reloaded after initialization. <!--AC-1791-->
+- Creation of fence gets stuck and causes the system to stop responding.<!--AC-1794-->
+- All runtime permissions are granted to an application irrespective of the permissions specified in the application manifest. <!--AC-1648-->
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.19.1.md
+++ b/reference/release-notes/1.19.1.md
@@ -9,33 +9,33 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* The `anbox-cloud-appliance status` command now lists the version of the application that you are running.
-* The following snaps will be held from being automatically refreshed. They are refreshed only when the charms are upgraded.
-    - `ams`
-    - `ams-node-controller`
-    - `anbox-cloud-dashboard`
-    - `anbox-stream-agent`
-    - `anbox-stream-gateway`
-    - `lxd`
-* You can now see when an application or its version was created using the `CreatedAt` field listed when you run `amc application show`.
-* Android security updates for September 2023 (see [Android Security Bulletin - September 2023](https://source.android.com/docs/security/bulletin/2023-09-01) for more information).
-* The Android WebView has been updated to [116.0.5845.163](https://chromereleases.googleblog.com/2023/08/chrome-for-android-update_02015057758.html).
-* Launching a stopped base container is no longer allowed.<!--AC-1870-->
+- The `anbox-cloud-appliance status` command now lists the version of the application that you are running.
+- The following snaps will be held from being automatically refreshed. They are refreshed only when the charms are upgraded.
+  * `ams`
+  * `ams-node-controller`
+  * `anbox-cloud-dashboard`
+  * `anbox-stream-agent`
+  * `anbox-stream-gateway`
+  * `lxd`
+- You can now see when an application or its version was created using the `CreatedAt` field listed when you run `amc application show`.
+- Android security updates for September 2023 (see [Android Security Bulletin - September 2023](https://source.android.com/docs/security/bulletin/2023-09-01) for more information).
+- The Android WebView has been updated to [116.0.5845.163](https://chromereleases.googleblog.com/2023/08/chrome-for-android-update_02015057758.html).
+- Launching a stopped base container is no longer allowed.<!--AC-1870-->
 
 ## Bugs fixed
 
-* [LP 2031665](https://bugs.launchpad.net/juju/+bug/2031665)  Appliance fails to refresh Grafana charm. <!--AC-1857-->
-* [LP 2032172](https://bugs.launchpad.net/anbox-cloud/+bug/2032172) Containers are stuck at `Started` status when using Android 13 images.<!--AC-1867-->
-* [LP 2033372](https://bugs.launchpad.net/anbox-cloud/+bug/2033372) Grafana installation fails because the [GPG keys used previously were replaced with a new key](https://grafana.com/blog/2023/08/24/grafana-security-update-gpg-signing-key-rotation/). Starting this release, the key is updated automatically. <!--AC-1911-->
-* [LP 2031463](https://bugs.launchpad.net/anbox-cloud/+bug/2031463) Binder error causes service failure.<!--AC-1849-->
-* Session fails to start when using a GPU instance type with software video encoding. <!--AC-1845-->
-* [Anbox Application Registry(AAR)](https://anbox-cloud.io/docs/exp/aar) charm fails when certificate is part of the relation multiple times. <!--AC-1847-->
-* The `anbox-cloud-appliance.buginfo` command displays empty outputs for `juju status` and `juju config` sections.<!--AC-1866-->
-* A disruption in the LXD node connection causes a crash in Anbox Management Service (AMS). <!--AC-1873-->
-* The model for the `NETINT Quadra T1 U2` model was incorrectly encoded as `QuadraT1-U2` instead of `QuadraT1U`.<!--AC-1876-->
-* Slowness in rendering due to old allocated buffers retaining the screen resolution even after the resolution changes. <!--AC-1840-->
-* Appliance fails to initialize on a machine with legacy BIOS. <!--AC-1913-->
-* I/O timeout issue on the supervisor channel caused by an incorrect write deadline for the WebSocket connection.<!--AC-1884-->
+- [LP 2031665](https://bugs.launchpad.net/juju/+bug/2031665)  Appliance fails to refresh Grafana charm. <!--AC-1857-->
+- [LP 2032172](https://bugs.launchpad.net/anbox-cloud/+bug/2032172) Containers are stuck at `Started` status when using Android 13 images.<!--AC-1867-->
+- [LP 2033372](https://bugs.launchpad.net/anbox-cloud/+bug/2033372) Grafana installation fails because the [GPG keys used previously were replaced with a new key](https://grafana.com/blog/2023/08/24/grafana-security-update-gpg-signing-key-rotation/). Starting this release, the key is updated automatically. <!--AC-1911-->
+- [LP 2031463](https://bugs.launchpad.net/anbox-cloud/+bug/2031463) Binder error causes service failure.<!--AC-1849-->
+- Session fails to start when using a GPU instance type with software video encoding. <!--AC-1845-->
+- [Anbox Application Registry(AAR)](https://anbox-cloud.io/docs/exp/aar) charm fails when certificate is part of the relation multiple times. <!--AC-1847-->
+- The `anbox-cloud-appliance.buginfo` command displays empty outputs for `juju status` and `juju config` sections.<!--AC-1866-->
+- A disruption in the LXD node connection causes a crash in Anbox Management Service (AMS). <!--AC-1873-->
+- The model for the `NETINT Quadra T1 U2` model was incorrectly encoded as `QuadraT1-U2` instead of `QuadraT1U`.<!--AC-1876-->
+- Slowness in rendering due to old allocated buffers retaining the screen resolution even after the resolution changes. <!--AC-1840-->
+- Appliance fails to initialize on a machine with legacy BIOS. <!--AC-1913-->
+- I/O timeout issue on the supervisor channel caused by an incorrect write deadline for the WebSocket connection.<!--AC-1884-->
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.19.2.md
+++ b/reference/release-notes/1.19.2.md
@@ -9,20 +9,20 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* When the Anbox Cloud Appliance upgrade fails, you can force run the upgrade again by using the `--force` option when running `anbox-cloud-appliance upgrade`.
-* Android security updates for October 2023 (see [Android Security Bulletin - October 2023](https://source.android.com/docs/security/bulletin/2023-10-01) for more information).
-* The Android WebView has been updated to 117.0.5938.61.
+- When the Anbox Cloud Appliance upgrade fails, you can force run the upgrade again by using the `--force` option when running `anbox-cloud-appliance upgrade`.
+- Android security updates for October 2023 (see [Android Security Bulletin - October 2023](https://source.android.com/docs/security/bulletin/2023-10-01) for more information).
+- The Android WebView has been updated to 117.0.5938.61.
 
 ## Bugs fixed
 
-* Screen rotation fails to work and causes an `Unknown orientation type` error. <!--AC-1864-->
-* The existing telegraf configuration that collects metrics for the running containers does not work for cgroup-v2. <!--AC-1919-->
-* Anbox Cloud Appliance fails to initialize with the following error on systems that have EFI but do not support secure boot: <!--AC-1951-->
+- Screen rotation fails to work and causes an `Unknown orientation type` error. <!--AC-1864-->
+- The existing telegraf configuration that collects metrics for the running containers does not work for cgroup-v2. <!--AC-1919-->
+- Anbox Cloud Appliance fails to initialize with the following error on systems that have EFI but do not support secure boot: <!--AC-1951-->
     `Error: failed to check secure boot status: exit status 255`
-* A container is deleted when its start operation fails. <!--AC-1952-->
-* After a container is stopped, GPUs and VPUs assigned to it are not cleared. This leads to having multiple GPUs/VPUs assigned to the container without proper allocation or utilization. <!--AC-1953-->
-* When an NVMe-based VPU is assigned to a container, the corresponding control device is not assigned. This could prevent the drivers from using the control device. <!--AC-1955-->
-* When the upgrade process for the appliance is in progress, the output of the `gpu-support.sh` is missing from the `upgrade.log`.<!--AC-1956-->
+- A container is deleted when its start operation fails. <!--AC-1952-->
+- After a container is stopped, GPUs and VPUs assigned to it are not cleared. This leads to having multiple GPUs/VPUs assigned to the container without proper allocation or utilization. <!--AC-1953-->
+- When an NVMe-based VPU is assigned to a container, the corresponding control device is not assigned. This could prevent the drivers from using the control device. <!--AC-1955-->
+- When the upgrade process for the appliance is in progress, the output of the `gpu-support.sh` is missing from the `upgrade.log`.<!--AC-1956-->
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.2.0.md
+++ b/reference/release-notes/1.2.0.md
@@ -5,20 +5,20 @@ orphan: true
 
 ## New features & improvements
 
-* Full support for an {ref}`exp-aar`.
-* Updated Android 7.x with all [security patches](https://source.android.com/security/bulletin) as of Mar 5 2019
-* Support for Intel and AMD GPUs
-* If configured, images will now be automatically pulled from a Canonical provided image server which will automatically bring updates once published.
-* Various performance and stability improvements
-* Dynamic management of [KSM](https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html)
-* Dedicated tool to backup and restore user data of Android applications
-* Extended timeouts for addon hook execution
-* Tab completion (bash only) for the `amc` command
-* Improve startup time for the Android container
-* The `amc` command now has `shell` and `exec` subcommands to allow easy access of containers
-* Applications can now be tagged
-* Filtering of containers and applications via the `amc` command
-* `amc wait` allows to wait for a status change of a container or application object
-* Reworked APK validator for application packages
-* The Android container now uses dnsmasq, as provided by LXD on the host, as DNS server
-* Various improvements on the Anbox Cloud charms
+- Full support for an {ref}`exp-aar`.
+- Updated Android 7.x with all [security patches](https://source.android.com/security/bulletin) as of Mar 5 2019
+- Support for Intel and AMD GPUs
+- If configured, images will now be automatically pulled from a Canonical provided image server which will automatically bring updates once published.
+- Various performance and stability improvements
+- Dynamic management of [KSM](https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html)
+- Dedicated tool to backup and restore user data of Android applications
+- Extended timeouts for addon hook execution
+- Tab completion (bash only) for the `amc` command
+- Improve startup time for the Android container
+- The `amc` command now has `shell` and `exec` subcommands to allow easy access of containers
+- Applications can now be tagged
+- Filtering of containers and applications via the `amc` command
+- `amc wait` allows to wait for a status change of a container or application object
+- Reworked APK validator for application packages
+- The Android container now uses dnsmasq, as provided by LXD on the host, as DNS server
+- Various improvements on the Anbox Cloud charms

--- a/reference/release-notes/1.2.1.md
+++ b/reference/release-notes/1.2.1.md
@@ -5,12 +5,12 @@ orphan: true
 
 ## Bug fixes
 
-* Telegraf was restarted every five minutes which caused metrics from Anbox being lost.
-* Android framework crashed in [`WifiManager.getWifiState()`](https://developer.android.com/reference/android/net/wifi/WifiManager.html#getWifiState())
-* Application updates failed due to limited cluster capacity. Base containers are now queued up and processed in order as soon as capacity is available.
-* AMS was not correctly finishing a container timeout on launch when restarted. On restart AMS now resumes the timeout.
-* Base containers are now correctly marked as stopped during the bootstrap process when the related LXD container is also stopped.
-* Fixed unhandled timeouts in the LXD API client implementation causing API calls to stall forever.
-* Added Android security fixes from April 2019. See the [Android Security Bulletins](https://source.android.com/security/bulletin) for more information.
-* Installing applications with an architecture not supported by the LXD cluster caused the installation process to stall. AMS now checks on APK upload if the APK can be executed by the available machines in the LXD cluster. The installation process was updated to not stall on unsupported APKs.
-* The Android WebView crashed in specific scenarios with SIGBUS on ARM64. This was caused by unaligned memory access in the OpenGL translation layer inside Anbox.
+- Telegraf was restarted every five minutes which caused metrics from Anbox being lost.
+- Android framework crashed in [`WifiManager.getWifiState()`](https://developer.android.com/reference/android/net/wifi/WifiManager.html#getWifiState())
+- Application updates failed due to limited cluster capacity. Base containers are now queued up and processed in order as soon as capacity is available.
+- AMS was not correctly finishing a container timeout on launch when restarted. On restart AMS now resumes the timeout.
+- Base containers are now correctly marked as stopped during the bootstrap process when the related LXD container is also stopped.
+- Fixed unhandled timeouts in the LXD API client implementation causing API calls to stall forever.
+- Added Android security fixes from April 2019. See the [Android Security Bulletins](https://source.android.com/security/bulletin) for more information.
+- Installing applications with an architecture not supported by the LXD cluster caused the installation process to stall. AMS now checks on APK upload if the APK can be executed by the available machines in the LXD cluster. The installation process was updated to not stall on unsupported APKs.
+- The Android WebView crashed in specific scenarios with SIGBUS on ARM64. This was caused by unaligned memory access in the OpenGL translation layer inside Anbox.

--- a/reference/release-notes/1.20.0.md
+++ b/reference/release-notes/1.20.0.md
@@ -11,58 +11,58 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ### Core stack improvements
 
-* Anbox Cloud has introduced support for creating virtual machine instances. This is especially helpful for use cases that require a stronger isolation. You can use both containers and virtual machines for your applications. However, GPU support is not yet available for virtual machine instances.
+- Anbox Cloud has introduced support for creating virtual machine instances. This is especially helpful for use cases that require a stronger isolation. You can use both containers and virtual machines for your applications. However, GPU support is not yet available for virtual machine instances.
 
   For easy understanding, we have introduced a change in terminology as well. The *Anbox Cloud containers* or *LXD containers* are now called *Instances*. The term *Instance* in the [Anbox Cloud documentation](https://anbox-cloud.io/docs) denotes a container or a virtual machine that hosts an application or an image. <!--AC-1459 and AC-2010 and AC-1916-->
-* The Anbox Management Service (AMS) snaps use [core22](https://snapcraft.io/core22).<!--AC-1853-->
-* AMS downloads the image from the image server only at first use instead of downloading all available images. <!--AC-1158-->
-* The watchdog can be enabled without specifying a boot package in the application manifest. <!--AC-2057-->
-* The Anbox Cloud images no longer start `android.hardware.media.c2` services automatically.<!--AC-2033-->
-* The included Mesa driver is tracking the latest 23.2.1 version and the `virglrenderer` is also tracking the latest upstream.<!--AC-1933-->
-* Some improvements to the swagger response for the AMS HTTP API are included. <!--AC-1923-->
-* The communication between LXD and AMS is improved and more robust. <!--AC-2058-->
+- The Anbox Management Service (AMS) snaps use [core22](https://snapcraft.io/core22).<!--AC-1853-->
+- AMS downloads the image from the image server only at first use instead of downloading all available images. <!--AC-1158-->
+- The watchdog can be enabled without specifying a boot package in the application manifest. <!--AC-2057-->
+- The Anbox Cloud images no longer start `android.hardware.media.c2` services automatically.<!--AC-2033-->
+- The included Mesa driver is tracking the latest 23.2.1 version and the `virglrenderer` is also tracking the latest upstream.<!--AC-1933-->
+- Some improvements to the swagger response for the AMS HTTP API are included. <!--AC-1923-->
+- The communication between LXD and AMS is improved and more robust. <!--AC-2058-->
 
 ### Streaming improvements
 
-* The required NVIDIA driver version has been updated from the 525 series to 535 series.<!--AC-1924-->
-* Alpha quality support for Vulkan on NVIDIA GPUs is now available through a feature flag. To use this feature, you require newer NVIDIA drivers (versions 545 or later). Since the feature is at Alpha level, bugs and crashes can occur. If you are interested in early testing, contact us through the [users forum on discourse](https://discourse.ubuntu.com/c/anbox-cloud/users/148). Stable product support for this feature is planned for the 1.21 release.
+- The required NVIDIA driver version has been updated from the 525 series to 535 series.<!--AC-1924-->
+- Alpha quality support for Vulkan on NVIDIA GPUs is now available through a feature flag. To use this feature, you require newer NVIDIA drivers (versions 545 or later). Since the feature is at Alpha level, bugs and crashes can occur. If you are interested in early testing, contact us through the [users forum on discourse](https://discourse.ubuntu.com/c/anbox-cloud/users/148). Stable product support for this feature is planned for the 1.21 release.
 
 ### Dashboard improvements
 
 With the 1.20.0 release, we have made the following improvements to the web dashboard experience:
 
-* Improvements to session streaming statistics
-* Ability to select and delete multiple instances
-* Ability to change the Anbox Cloud configuration using the web dashboard
-* Simplified app version selection for new sessions
-* Improvements to general design and layout
-* Warning messages to improve user experience
+- Improvements to session streaming statistics
+- Ability to select and delete multiple instances
+- Ability to change the Anbox Cloud configuration using the web dashboard
+- Simplified app version selection for new sessions
+- Improvements to general design and layout
+- Warning messages to improve user experience
 
 ### Other
 
-* Android security updates for November 2023 (see [Android Security Bulletin - November 2023](https://source.android.com/docs/security/bulletin/2023-11-01) for more information).
-* The Android WebView has been updated to [119.0.6045.66](https://chromereleases.googleblog.com/2023/10/early-stable-update-for-android_01005299231.html).
-* We have modernized the existing NATS charm to align with best practices in developing charms. The new NATS charm is available at [`https://charmhub.io/nats`](https://charmhub.io/nats). The 1.21.0 release of Anbox Cloud will automatically upgrade to the new charm.
+- Android security updates for November 2023 (see [Android Security Bulletin - November 2023](https://source.android.com/docs/security/bulletin/2023-11-01) for more information).
+- The Android WebView has been updated to [119.0.6045.66](https://chromereleases.googleblog.com/2023/10/early-stable-update-for-android_01005299231.html).
+- We have modernized the existing NATS charm to align with best practices in developing charms. The new NATS charm is available at [`https://charmhub.io/nats`](https://charmhub.io/nats). The 1.21.0 release of Anbox Cloud will automatically upgrade to the new charm.
 
 ## Deprecations
 
-* The {ref}`sec-application-manifest-instance-type` attribute is deprecated now. You can use the `resources` attribute to specify any custom resource requirements.
+- The {ref}`sec-application-manifest-instance-type` attribute is deprecated now. You can use the `resources` attribute to specify any custom resource requirements.
 
   Also, in the Anbox Cloud documentation, the use of the term *Instance type* to indicate a set of resources is deprecated and will be completely removed in the future releases. Instead, the term *Resource preset* is used to indicate a set of resources available for an instance.
 
 ## Removed functionality
 
-* The Mesa build in `/opt/mesa` is removed. <!--AC-1928-->
-* The Grafana and Prometheus tools for monitoring are removed. The Anbox Cloud roadmap has plans of providing a monitoring solution using the [Canonical Observability Stack](https://charmhub.io/topics/canonical-observability-stack). <!--AC-1925-->
+- The Mesa build in `/opt/mesa` is removed. <!--AC-1928-->
+- The Grafana and Prometheus tools for monitoring are removed. The Anbox Cloud roadmap has plans of providing a monitoring solution using the [Canonical Observability Stack](https://charmhub.io/topics/canonical-observability-stack). <!--AC-1925-->
 
 ## Bug fixes
 The following bugs are fixed in the Anbox Cloud 1.20 version:
 
-* Permission errors when Android tries to access cgroup. <!--AC-1748-->
-* Missing support for VPU slots for `amc` commands. <!--AC-2004-->
-* [LP 2031059](https://bugs.launchpad.net/anbox-cloud/+bug/2031059) When streaming from a tablet, the display area is partially blocked even after the client side keyboard is closed.<!--AC-2035-->
-* Android screen timeout is not disabled by default, This causes a blank screen during streaming.<!--AC-2051-->
-* When an application that was created in a version earlier than 1.19.0 does not have the `video-encoder` attribute in its manifest, new versions of that application are not uploaded to the Anbox Application Registry (AAR).<!--AC-2054-->
+- Permission errors when Android tries to access cgroup. <!--AC-1748-->
+- Missing support for VPU slots for `amc` commands. <!--AC-2004-->
+- [LP 2031059](https://bugs.launchpad.net/anbox-cloud/+bug/2031059) When streaming from a tablet, the display area is partially blocked even after the client side keyboard is closed.<!--AC-2035-->
+- Android screen timeout is not disabled by default, This causes a blank screen during streaming.<!--AC-2051-->
+- When an application that was created in a version earlier than 1.19.0 does not have the `video-encoder` attribute in its manifest, new versions of that application are not uploaded to the Anbox Application Registry (AAR).<!--AC-2054-->
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.20.1.md
+++ b/reference/release-notes/1.20.1.md
@@ -9,22 +9,22 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* A new `amc image sync` command is available to explicitly trigger download of an image from the image server. <!--AC-2085-->
-* The Anbox Management Service (AMS) derives instance architecture from the architecture of the selected image instead of the Application Binary Interface (ABI).<!--AC-2138-->
-* Android security updates for December 2023 (see [Android Security Bulletin - December 2023](https://source.android.com/docs/security/bulletin/2023-12-01) for more information).<!--AC-2127-->
-* The Android WebView has been updated to [120.0.6099.43](https://chromereleases.googleblog.com/2023/11/early-stable-update-for-android.html).
-* `amc` returns better error details when the AMS client is not registered to the LXD cluster. <!--AC-2097-->
-* When an instance is being created, better status messages that give information on the steps of instance creation are displayed. These status messages are cleared once the instance moves to running status. <!--AC-2120-->
-* In the AMS HTTP API, the `ErrorMessage` field is moved from the `types.Image` to the `types.ImageVersion` object. <!--AC-2047-->
+- A new `amc image sync` command is available to explicitly trigger download of an image from the image server. <!--AC-2085-->
+- The Anbox Management Service (AMS) derives instance architecture from the architecture of the selected image instead of the Application Binary Interface (ABI).<!--AC-2138-->
+- Android security updates for December 2023 (see [Android Security Bulletin - December 2023](https://source.android.com/docs/security/bulletin/2023-12-01) for more information).<!--AC-2127-->
+- The Android WebView has been updated to [120.0.6099.43](https://chromereleases.googleblog.com/2023/11/early-stable-update-for-android.html).
+- `amc` returns better error details when the AMS client is not registered to the LXD cluster. <!--AC-2097-->
+- When an instance is being created, better status messages that give information on the steps of instance creation are displayed. These status messages are cleared once the instance moves to running status. <!--AC-2120-->
+- In the AMS HTTP API, the `ErrorMessage` field is moved from the `types.Image` to the `types.ImageVersion` object. <!--AC-2047-->
 
 ## Bugs fixed
 
-* Post an Anbox Cloud appliance upgrade, streaming fails because the stream agent and gateway could not communicate with each other. <!--AC-2139-->
-* Instances are not able to start the nested Android LXD container.<!--AC-2136-->
-* Base instances are available for deletion on the *Instances* list page of the web dashboard. <!--AC-2146-->
-* The web dashboard allows to edit immutable applications, for example, an application synchronized from the application registry. <!--AC-2144-->
-* LXD charm fails in `api-relation-changed` hook. <!--AC-2070-->
-* A session that has an error status is stuck with a connecting indicator instead of displaying the error details. <!--AC-2141-->
+- Post an Anbox Cloud appliance upgrade, streaming fails because the stream agent and gateway could not communicate with each other. <!--AC-2139-->
+- Instances are not able to start the nested Android LXD container.<!--AC-2136-->
+- Base instances are available for deletion on the *Instances* list page of the web dashboard. <!--AC-2146-->
+- The web dashboard allows to edit immutable applications, for example, an application synchronized from the application registry. <!--AC-2144-->
+- LXD charm fails in `api-relation-changed` hook. <!--AC-2070-->
+- A session that has an error status is stuck with a connecting indicator instead of displaying the error details. <!--AC-2141-->
 
 ## Known issues
 

--- a/reference/release-notes/1.20.2.md
+++ b/reference/release-notes/1.20.2.md
@@ -9,21 +9,21 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* VPU slots for an app are synchronized through the Anbox Application Registry (AAR).<!--AC-2143-->
-* Extended logging is available for WebRTC connections. This extended logging includes logging of local and remote ICE candidates which can be used by enabling the feature flag `webrtc.enable_ice_logging`.<!--AC-2184-->
-* Android security updates for January 2024 (see [Android Security Bulletin - January 2024](https://source.android.com/docs/security/bulletin/2024-01-01) for more information).<!--AC-2203-->
-* The Android WebView has been updated to [120.0.6099.193](https://chromereleases.googleblog.com/2024/01/chrome-for-android-update.html).
+- VPU slots for an app are synchronized through the Anbox Application Registry (AAR).<!--AC-2143-->
+- Extended logging is available for WebRTC connections. This extended logging includes logging of local and remote ICE candidates which can be used by enabling the feature flag `webrtc.enable_ice_logging`.<!--AC-2184-->
+- Android security updates for January 2024 (see [Android Security Bulletin - January 2024](https://source.android.com/docs/security/bulletin/2024-01-01) for more information).<!--AC-2203-->
+- The Android WebView has been updated to [120.0.6099.193](https://chromereleases.googleblog.com/2024/01/chrome-for-android-update.html).
 
 ## Bugs fixed
 
-* Automotive audio control service (`android.hardware.automotive.audiocontrol`) gets launched by accident with the currently provided images.<!--AC-2199-->
-* LXD error `NonReusableSucceeded` is not handled properly, causing the application creation to proceed without issues even when the post-stop hook of an addon fails to execute. <!--AC-2212-->
-* System security updates for instances are applied even when the corresponding AMS configuration was set to explicitly disable them. <!--AC-2122-->
-* With all Android versions, screen recording from the quick settings fails to start.<!--AC-2180-->
-* Starting an Android 11 instance without a GPU fails to start. <!--AC-2181-->
-* On the web dashboard, the *Create session* button is clickable even when the *Application* field is empty.<!--AC-2179-->
-* [LP #2046348](https://bugs.launchpad.net/anbox-cloud/+bug/2046348) When dynamically changing the screen resolution upon joining a streaming session to a lower resolution than the configured resolution, the resolution of the resulting video stream does not match. Instead, it stays at the resolution initially configured for the streaming session.<!--AC-2188-->
-* [Bug report](https://discourse.ubuntu.com/t/enable-webgl-in-anbox-cloud/41170/4) When running WebGL based applications, the WebView shows an error and indicates that the WebView APK shipped as part of the Android image does not support WebGL.<!--AC-2214-->
+- Automotive audio control service (`android.hardware.automotive.audiocontrol`) gets launched by accident with the currently provided images.<!--AC-2199-->
+- LXD error `NonReusableSucceeded` is not handled properly, causing the application creation to proceed without issues even when the post-stop hook of an addon fails to execute. <!--AC-2212-->
+- System security updates for instances are applied even when the corresponding AMS configuration was set to explicitly disable them. <!--AC-2122-->
+- With all Android versions, screen recording from the quick settings fails to start.<!--AC-2180-->
+- Starting an Android 11 instance without a GPU fails to start. <!--AC-2181-->
+- On the web dashboard, the *Create session* button is clickable even when the *Application* field is empty.<!--AC-2179-->
+- [LP #2046348](https://bugs.launchpad.net/anbox-cloud/+bug/2046348) When dynamically changing the screen resolution upon joining a streaming session to a lower resolution than the configured resolution, the resolution of the resulting video stream does not match. Instead, it stays at the resolution initially configured for the streaming session.<!--AC-2188-->
+- [Bug report](https://discourse.ubuntu.com/t/enable-webgl-in-anbox-cloud/41170/4) When running WebGL based applications, the WebView shows an error and indicates that the WebView APK shipped as part of the Android image does not support WebGL.<!--AC-2214-->
 
 ## Upgrade instructions
 See {ref}`howto-upgrade-anbox-cloud` or {ref}`howto-upgrade-appliance` for instructions on how to update your Anbox Cloud deployment to the 1.20.2 release.

--- a/reference/release-notes/1.21.0.md
+++ b/reference/release-notes/1.21.0.md
@@ -13,54 +13,54 @@ The 1.21.0 release of Anbox Cloud brings the following features and improvements
 
 ### Core stack improvements
 
-* Android Automotive (AAOS) images with experimental VHAL support are available. See [Provided images](https://anbox-cloud.io/docs/reference/provided-images) for more details.
-* Initial support for installing Anbox Cloud Appliance on Ubuntu 24.04 LTS.<!--AC-2229-->
-* Production support for Vulkan on NVIDIA GPUs is available but remains opt-in. Support must be explicitly enabled and set up. For instructions on enabling the VirGL rendering path for Vulkan support, see [How to enable VirGL](https://anbox-cloud.io/docs/howto/anbox/enable-virgl).<!--AC-2152-->
+- Android Automotive (AAOS) images with experimental VHAL support are available. See [Provided images](https://anbox-cloud.io/docs/reference/provided-images) for more details.
+- Initial support for installing Anbox Cloud Appliance on Ubuntu 24.04 LTS.<!--AC-2229-->
+- Production support for Vulkan on NVIDIA GPUs is available but remains opt-in. Support must be explicitly enabled and set up. For instructions on enabling the VirGL rendering path for Vulkan support, see [How to enable VirGL](https://anbox-cloud.io/docs/howto/anbox/enable-virgl).<!--AC-2152-->
 
   This release also provides [Renderdoc](https://github.com/baldurk/renderdoc) support for debugging purposes. See [Graphics debugging with renderdoc](https://anbox-cloud.io/docs/howto/android/graphics-debugging-with-renderdoc) for more information. <!--AC-2093-->
-* The NVIDIA UDA driver variant with version 545 or later can be installed with the Anbox Cloud Appliance by using the `nvidia-driver-series` and `use-nvidia-uda-driver` flags with the `anbox-cloud-appliance init` command.  <!--AC-2259-->
-* GL Async swap support is disabled by default.<!--AC-2228-->
-* In the [AMS HTTP API](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/ams-api/), `/1.0` endpoint exposes the cluster ID and name to enable identifying a subcluster.<!--AC-2148-->
-* The [Anbox Cloud NFS operator](https://github.com/canonical/anbox-cloud-nfs-operator) charm now supports mounting EFS file system on AWS when you require Transport Layer Security (TLS). With an EFS file system, you can [configure](https://github.com/canonical/anbox-cloud-nfs-operator/blob/main/config.yaml) the charm with the following parameters:<!--AC-2119/2001-->
-  - `mount_type` set to `efs`
-  - `nfs_extra_options` set to `tls`
-* The Anbox Application Registry(AAR) can make use of Identity and Access Management(IAM) roles applied to an AWS instance using instance profiles. This relieves you from having to configure an access key/secret for instances. For information on how to use an IAM role in AAR, see [how to deploy AAR](https://anbox-cloud.io/docs/howto/aar/deploy). <!--AC-2025/1700-->
-* The NATS charm is switched from its [older version](https://charmhub.io/nats-charmers-nats) to a [newer version](https://charmhub.io/nats) on Charmhub. This would require that you switch to the new charm source. For more information, see {ref}`howto-upgrade-anbox-cloud`.
+- The NVIDIA UDA driver variant with version 545 or later can be installed with the Anbox Cloud Appliance by using the `nvidia-driver-series` and `use-nvidia-uda-driver` flags with the `anbox-cloud-appliance init` command.  <!--AC-2259-->
+- GL Async swap support is disabled by default.<!--AC-2228-->
+- In the [AMS HTTP API](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/ams-api/), `/1.0` endpoint exposes the cluster ID and name to enable identifying a subcluster.<!--AC-2148-->
+- The [Anbox Cloud NFS operator](https://github.com/canonical/anbox-cloud-nfs-operator) charm now supports mounting EFS file system on AWS when you require Transport Layer Security (TLS). With an EFS file system, you can [configure](https://github.com/canonical/anbox-cloud-nfs-operator/blob/main/config.yaml) the charm with the following parameters:<!--AC-2119/2001-->
+  * `mount_type` set to `efs`
+  * `nfs_extra_options` set to `tls`
+- The Anbox Application Registry(AAR) can make use of Identity and Access Management(IAM) roles applied to an AWS instance using instance profiles. This relieves you from having to configure an access key/secret for instances. For information on how to use an IAM role in AAR, see [how to deploy AAR](https://anbox-cloud.io/docs/howto/aar/deploy). <!--AC-2025/1700-->
+- The NATS charm is switched from its [older version](https://charmhub.io/nats-charmers-nats) to a [newer version](https://charmhub.io/nats) on Charmhub. This would require that you switch to the new charm source. For more information, see {ref}`howto-upgrade-anbox-cloud`.
 
 ### Dashboard improvements
 
 The following improvements are available in the Anbox Cloud dashboard for this release:
 
-* Launching an instance independent of a session is now possible using the Anbox Cloud dashboard.  This is especially useful for situations where you want to create an instance but do not want to stream anything. To do this, select the *Create Instance* button on the *Instances* view, provide the information required for instance creation and select *Create and Start*.
-* Support multiple subclusters from the dashboard for large scale deployments.
-* Client side upscaling is now available as an experimental feature.You can now add `upscaling` as a query parameter to your session URL. For example, `http://<ip_address_of_instance>/sessions/<session_ID>?upscaling=true`.
-* Experimental support for managing the [Vehicle Hardware Abstraction Layer (VHAL)](https://source.android.com/docs/automotive/vhal) properties for [AAOS](https://source.android.com/docs/automotive/start/what_automotive) images.
-* Enhancements for improved responsiveness, error handling and messages
-* Updated Python and Javascript dependencies.
+- Launching an instance independent of a session is now possible using the Anbox Cloud dashboard.  This is especially useful for situations where you want to create an instance but do not want to stream anything. To do this, select the *Create Instance* button on the *Instances* view, provide the information required for instance creation and select *Create and Start*.
+- Support multiple subclusters from the dashboard for large scale deployments.
+- Client side upscaling is now available as an experimental feature.You can now add `upscaling` as a query parameter to your session URL. For example, `http://<ip_address_of_instance>/sessions/<session_ID>?upscaling=true`.
+- Experimental support for managing the [Vehicle Hardware Abstraction Layer (VHAL)](https://source.android.com/docs/automotive/vhal) properties for [AAOS](https://source.android.com/docs/automotive/start/what_automotive) images.
+- Enhancements for improved responsiveness, error handling and messages
+- Updated Python and Javascript dependencies.
 
 ### Other
 
-* Android security updates for February 2024 (see [Android Security Bulletin - February 2024](https://source.android.com/docs/security/bulletin/2024-02-01) for more information).<!--AC-2249-->
-* The Android WebView has been updated to [121.0.6167.143](https://chromereleases.googleblog.com/2024/01/chrome-for-android-update_0251787784.html).
+- Android security updates for February 2024 (see [Android Security Bulletin - February 2024](https://source.android.com/docs/security/bulletin/2024-02-01) for more information).<!--AC-2249-->
+- The Android WebView has been updated to [121.0.6167.143](https://chromereleases.googleblog.com/2024/01/chrome-for-android-update_0251787784.html).
 
 ## Removed functionality
 
-* Clustering support (which existed as an experimental feature) for Anbox Cloud Appliance is removed.<!--AC-2176-->
-* The deprecated Android 11 images are now unsupported and hence removed.<!--AC-2108-->
+- Clustering support (which existed as an experimental feature) for Anbox Cloud Appliance is removed.<!--AC-2176-->
+- The deprecated Android 11 images are now unsupported and hence removed.<!--AC-2108-->
 
 ## Known issues
 
-* [LP 2053106](https://bugs.launchpad.net/anbox-cloud/+bug/2053106) In the Anbox Cloud dashboard, selecting the *Download all* button to download all logs from an instance in *Error* state displays a *Page not found (404)* error.<!--AC-2284-->
+- [LP 2053106](https://bugs.launchpad.net/anbox-cloud/+bug/2053106) In the Anbox Cloud dashboard, selecting the *Download all* button to download all logs from an instance in *Error* state displays a *Page not found (404)* error.<!--AC-2284-->
 
 ## Bug fixes
 
-* `Invalid session` error When streaming an audio-only WebRTC session.<!--AC-2256-->
-* Initializing Anbox Cloud Appliance as root user causes a `missing AMC client cert` error. <!--AC-2255-->
-* [LP 2049734](https://bugs.launchpad.net/anbox-cloud/+bug/2049734) `INSTANCE_TYPE` is set to `regular` instead of `base` during the runtime of the post-stop hook of an addon.<!--AC-2238-->
-* When using the web dashboard for application creation, changing the container/VM radio button from one option to another causes a spurious error about the image not being of type `string`. This error occurs only when there is no default container image present.<!--AC-2178-->
-* When using the [AMS HTTP API](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/ams-api/), the API response for `GET /1.0/instances` does not properly return information for the fields `config` and `resources`. <!--AC-2156-->
-* Video decoder is not considered inactive when initialization fails. <!--AC-2071-->
-* Concurrent stop operations on the same instance occurs due to mixed responsibilities in two internal AMS components.<!--AC-2167-->
+- `Invalid session` error When streaming an audio-only WebRTC session.<!--AC-2256-->
+- Initializing Anbox Cloud Appliance as root user causes a `missing AMC client cert` error. <!--AC-2255-->
+- [LP 2049734](https://bugs.launchpad.net/anbox-cloud/+bug/2049734) `INSTANCE_TYPE` is set to `regular` instead of `base` during the runtime of the post-stop hook of an addon.<!--AC-2238-->
+- When using the web dashboard for application creation, changing the container/VM radio button from one option to another causes a spurious error about the image not being of type `string`. This error occurs only when there is no default container image present.<!--AC-2178-->
+- When using the [AMS HTTP API](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/ams-api/), the API response for `GET /1.0/instances` does not properly return information for the fields `config` and `resources`. <!--AC-2156-->
+- Video decoder is not considered inactive when initialization fails. <!--AC-2071-->
+- Concurrent stop operations on the same instance occurs due to mixed responsibilities in two internal AMS components.<!--AC-2167-->
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.21.1.md
+++ b/reference/release-notes/1.21.1.md
@@ -11,18 +11,18 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ### Core stack improvements
 
-* Improved detection of whether LXD is already initialized when setting up the Anbox Cloud Appliance.
+- Improved detection of whether LXD is already initialized when setting up the Anbox Cloud Appliance.
 
 ### Other
 
-* Android security updates for March 2024 (see [Android Security Bulletin - March 2024](https://source.android.com/docs/security/bulletin/2024-03-01) for more information).
-* The Android WebView has been updated to [122.0.6261.90](https://chromereleases.googleblog.com/2024/02/chrome-for-android-update_28.html).
+- Android security updates for March 2024 (see [Android Security Bulletin - March 2024](https://source.android.com/docs/security/bulletin/2024-03-01) for more information).
+- The Android WebView has been updated to [122.0.6261.90](https://chromereleases.googleblog.com/2024/02/chrome-for-android-update_28.html).
 
 ## Bug fixes
 
-* [LP 2054692](https://bugs.launchpad.net/anbox-cloud/+bug/2054692) Anbox Cloud dashboard does not have mandatory security headers.
-* [LP 2054430](https://bugs.launchpad.net/anbox-cloud/+bug/2054430) Unable to reset `images.auth` configuration to an empty string.
-* [LP 2053106](https://bugs.launchpad.net/anbox-cloud/+bug/2053106) Selecting the *Download all* button on an instance in the *Error* state displays a 404 error.
+- [LP 2054692](https://bugs.launchpad.net/anbox-cloud/+bug/2054692) Anbox Cloud dashboard does not have mandatory security headers.
+- [LP 2054430](https://bugs.launchpad.net/anbox-cloud/+bug/2054430) Unable to reset `images.auth` configuration to an empty string.
+- [LP 2053106](https://bugs.launchpad.net/anbox-cloud/+bug/2053106) Selecting the *Download all* button on an instance in the *Error* state displays a 404 error.
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.21.2.md
+++ b/reference/release-notes/1.21.2.md
@@ -11,23 +11,23 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ### Core stack improvements
 
-* WiFi support for AAOS images.<!--AC-2211-->
+- WiFi support for AAOS images.<!--AC-2211-->
 
 ### Other
 
-* Android security updates for April 2024 (see [Android Security Bulletin - April 2024](https://source.android.com/docs/security/bulletin/2024-04-01) for more information).<!--AC-2391-->
-* The Android WebView has been updated to [123.0.6312.99](https://chromereleases.googleblog.com/2024/04/chrome-for-android-update.html).
+- Android security updates for April 2024 (see [Android Security Bulletin - April 2024](https://source.android.com/docs/security/bulletin/2024-04-01) for more information).<!--AC-2391-->
+- The Android WebView has been updated to [123.0.6312.99](https://chromereleases.googleblog.com/2024/04/chrome-for-android-update.html).
 
 ### Bug fixes
 
-* [LP 2051220](https://bugs.launchpad.net/anbox-cloud/+bug/2051220) Unable to initialize the Anbox Cloud Appliance when it is behind a HTTP proxy.<!--AC-2306-->
-* [LP 2055497](https://bugs.launchpad.net/anbox-cloud/+bug/2055497) Native crash occurs in the Audio HAL module when booting up the Android system.<!--AC-2330-->
-* [LP 2054443](https://bugs.launchpad.net/anbox-cloud/+bug/2054443) Fix for the session crash when opening an installed app.<!--AC-2297-->
-* Fix for Bluetooth terminating abruptly in the AAOS launcher.<!--AC-2265-->
+- [LP 2051220](https://bugs.launchpad.net/anbox-cloud/+bug/2051220) Unable to initialize the Anbox Cloud Appliance when it is behind a HTTP proxy.<!--AC-2306-->
+- [LP 2055497](https://bugs.launchpad.net/anbox-cloud/+bug/2055497) Native crash occurs in the Audio HAL module when booting up the Android system.<!--AC-2330-->
+- [LP 2054443](https://bugs.launchpad.net/anbox-cloud/+bug/2054443) Fix for the session crash when opening an installed app.<!--AC-2297-->
+- Fix for Bluetooth terminating abruptly in the AAOS launcher.<!--AC-2265-->
 
 ## Known issues
 
-* When streaming from an instance that is based on an AAOS image, the following error is displayed on the right panel:<!--AC-2456-->
+- When streaming from an instance that is based on an AAOS image, the following error is displayed on the right panel:<!--AC-2456-->
 
   ```
   VHAL error, could not get fan positions

--- a/reference/release-notes/1.22.0.md
+++ b/reference/release-notes/1.22.0.md
@@ -13,40 +13,40 @@ The 1.22.0 release of Anbox Cloud brings the following features and improvements
 
 ### Core stack improvements
 
-* Support for 64-bit only systems for all supported Android versions.<!--AC-1890, AC-2428-->
-* Support for installing relevant 32-bit NVIDIA userspace binaries on AMD64 systems.<!--AC-2450-->
-* To allow easier identification and use of instances, you can now explicitly name an instance when creating it. See [How to create an instance](https://anbox-cloud.io/docs/howto/instance/create).<!--AC-2395-->
-* VHAL enhancements:
-    - Configuration returned by the APIs have a new field containing a name and a list of area names for the standard VHAL properties.<!--AC-2290 and AC-2289-->
-    - Property values returned by the APIs have a new field containing a list of area names for the standard VHAL properties.<!--AC-2290-->
-    - You can replace the Anbox Cloud VHAL implementation with your custom implementation for AAOS images. See [How to use a custom VHAL implementation](https://anbox-cloud.io/docs/howto/android/custom_vhal). <!--AC-2371-->
+- Support for 64-bit only systems for all supported Android versions.<!--AC-1890, AC-2428-->
+- Support for installing relevant 32-bit NVIDIA userspace binaries on AMD64 systems.<!--AC-2450-->
+- To allow easier identification and use of instances, you can now explicitly name an instance when creating it. See [How to create an instance](https://anbox-cloud.io/docs/howto/instance/create).<!--AC-2395-->
+- VHAL enhancements:
+  * Configuration returned by the APIs have a new field containing a name and a list of area names for the standard VHAL properties.<!--AC-2290 and AC-2289-->
+  * Property values returned by the APIs have a new field containing a list of area names for the standard VHAL properties.<!--AC-2290-->
+  * You can replace the Anbox Cloud VHAL implementation with your custom implementation for AAOS images. See [How to use a custom VHAL implementation](https://anbox-cloud.io/docs/howto/android/custom_vhal). <!--AC-2371-->
 
 ### Streaming stack improvements
 
-* Streaming can now be enabled when launching an instance using the `--enable-streaming` option. Existing installations will require the charm deployment for Anbox Cloud to be manually upgraded to use the new relation between the AMS and the stream agent.
+- Streaming can now be enabled when launching an instance using the `--enable-streaming` option. Existing installations will require the charm deployment for Anbox Cloud to be manually upgraded to use the new relation between the AMS and the stream agent.
 
   See [How to stream applications](https://anbox-cloud.io/docs/howto/application/stream) and [How to create an instance](https://anbox-cloud.io/docs/howto/instance/create) for details on launching stream-enabled instances. See [How to upgrade Anbox Cloud](https://anbox-cloud.io/docs/howto/update/upgrade-anbox) for instructions on manually upgrading the relation between the AMS and the stream agent charms.<!--Ac-2460 and AC-2360-->
 
-* VirGL is the default renderer for NVIDIA GPUs with driver version 545 and later. For driver versions earlier than 545 or old NVIDIA GPU architecture such as Turing, Ampere or Ada, EmuGL is used as the default renderer. See [Rendering architecture](https://anbox-cloud.io/docs/explanation/rendering-architecture).<!--AC-2459, AC-2270 and AC-2348-->
-* Experimental support for [pointer lock](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API) is available with this release. This helps in locking the pointer to a particular browser element, for example, your game window, and limits movement outside the game until the lock is disabled. The pointer lock property must be explicitly enabled on the stream object via the [streaming SDK](https://github.com/canonical/anbox-streaming-sdk).<!--AC-2379-->
-* All components of Anbox Cloud upgrade to NVIDIA 550 driver series by default on Ubuntu 22.04 LTS images. For Ubuntu 20.04 LTS images, 535 driver series will be used. <!--AC-2309-->
+- VirGL is the default renderer for NVIDIA GPUs with driver version 545 and later. For driver versions earlier than 545 or old NVIDIA GPU architecture such as Turing, Ampere or Ada, EmuGL is used as the default renderer. See [Rendering architecture](https://anbox-cloud.io/docs/explanation/rendering-architecture).<!--AC-2459, AC-2270 and AC-2348-->
+- Experimental support for [pointer lock](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API) is available with this release. This helps in locking the pointer to a particular browser element, for example, your game window, and limits movement outside the game until the lock is disabled. The pointer lock property must be explicitly enabled on the stream object via the [streaming SDK](https://github.com/canonical/anbox-streaming-sdk).<!--AC-2379-->
+- All components of Anbox Cloud upgrade to NVIDIA 550 driver series by default on Ubuntu 22.04 LTS images. For Ubuntu 20.04 LTS images, 535 driver series will be used. <!--AC-2309-->
 
 ### Dashboard improvements
 
 The following improvements are available in the Anbox Cloud dashboard for this release:
 
-* Page level guided tours are now available for help in navigating through the dashboard.
-* Support for using custom authentication server instead of Ubuntu SSO.
-* Custom instance name field in *Create instance* form.
-* User experience enhancements to the AAOS control panel:
-  - Extending VHAL support to allow setting the geographic location and to be able to provide and revoke consent for enabling APIs in the browser when using maps.
-* Enhancements to forms to support AOSP vs AAOS applications.
+- Page level guided tours are now available for help in navigating through the dashboard.
+- Support for using custom authentication server instead of Ubuntu SSO.
+- Custom instance name field in *Create instance* form.
+- User experience enhancements to the AAOS control panel:
+  * Extending VHAL support to allow setting the geographic location and to be able to provide and revoke consent for enabling APIs in the browser when using maps.
+- Enhancements to forms to support AOSP vs AAOS applications.
 
 ### Other
 
-* Support for building custom images of Anbox Cloud based on AAOS. See [Custom images](https://anbox-cloud.io/docs/explanation/custom-images).<!--AC-2458-->
-* Android security updates for May 2024 (see [Android Security Bulletin - May 2024](https://source.android.com/docs/security/bulletin/2024-05-01) for more information).<!--AC-2437-->
-* The Android WebView has been updated to [124.0.6367.82](https://chromereleases.googleblog.com/2024/04/chrome-for-android-update_24.html).
+- Support for building custom images of Anbox Cloud based on AAOS. See [Custom images](https://anbox-cloud.io/docs/explanation/custom-images).<!--AC-2458-->
+- Android security updates for May 2024 (see [Android Security Bulletin - May 2024](https://source.android.com/docs/security/bulletin/2024-05-01) for more information).<!--AC-2437-->
+- The Android WebView has been updated to [124.0.6367.82](https://chromereleases.googleblog.com/2024/04/chrome-for-android-update_24.html).
 
 ## Deprecations
 
@@ -54,15 +54,15 @@ See [Deprecation notices](https://anbox-cloud.io/docs/reference/deprecation-noti
 
 ## Removed functionality
 
-* Documentation on how to enable VirGL manually is removed because with this release, VirGL is the default renderer for NVIDIA GPUs.
+- Documentation on how to enable VirGL manually is removed because with this release, VirGL is the default renderer for NVIDIA GPUs.
 
 ## Known issues
 
 The following known issues exist in the 1.22.0 release and are planned to be fixed in future releases:
 
-* Video playback does not work on 64-bit only systems where the NVIDIA GPU is installed.
-* For existing charmed deployments, creating instances with streaming enabled using the `enable-streaming` option requires manually adding the new relation between the AMS and the stream agent charms. See [How to upgrade Anbox Cloud](https://anbox-cloud.io/docs/howto/update/upgrade-anbox).
-* To work around [issue 13420](https://github.com/canonical/lxd/issues/13420) in LXD, run the following command after deploying a new unit of the [LXD for Anbox Cloud](https://charmhub.io/ams-lxd) charm:
+- Video playback does not work on 64-bit only systems where the NVIDIA GPU is installed.
+- For existing charmed deployments, creating instances with streaming enabled using the `enable-streaming` option requires manually adding the new relation between the AMS and the stream agent charms. See [How to upgrade Anbox Cloud](https://anbox-cloud.io/docs/howto/update/upgrade-anbox).
+- To work around [issue 13420](https://github.com/canonical/lxd/issues/13420) in LXD, run the following command after deploying a new unit of the [LXD for Anbox Cloud](https://charmhub.io/ams-lxd) charm:
 
     ```
     juju ssh lxd/n -- lxc storage set ams0 volume.zfs.block_mode=false
@@ -76,25 +76,25 @@ The following known issues exist in the 1.22.0 release and are planned to be fix
 
 ## Bugs fixed
 
-* [LP 2061700](https://bugs.launchpad.net/anbox-cloud/+bug/2061700) When streaming from an instance that is based on an AAOS image, the following error is displayed on the right panel:<!--AC-2456-->
+- [LP 2061700](https://bugs.launchpad.net/anbox-cloud/+bug/2061700) When streaming from an instance that is based on an AAOS image, the following error is displayed on the right panel:<!--AC-2456-->
 
   ```
   VHAL error, could not get fan positions
   ```
 
-* [LP 2060110](https://bugs.launchpad.net/anbox-cloud/+bug/2060110) Keyboard is not displayed in the *Honkai: Star Rail*.<!--AC-2446-->
-* [LP 2045823](https://bugs.launchpad.net/anbox-cloud/+bug/2045823) Keyboard display flickers in *Monopoly Go*. <!--AC-2439 and 2168-->
-* [LP 2059887](https://bugs.launchpad.net/anbox-cloud/+bug/2059887) Sluggish performance when playing *Honkai: Star Rail*.<!--AC-2433-->
-* [LP 2058423](https://bugs.launchpad.net/anbox-cloud/+bug/2058423) Compatibility issues with *Monopoly Go* and *Marvel Strike* in Vulkan mode causing the games to end abruptly.<!--AC-2402-->
-* [LP 2056707](https://bugs.launchpad.net/anbox-cloud/+bug/2056707) Android system unable to boot due to the error: `Extension not supported: VK_KHR_swapchain`. <!--AC-2363-->
-* [LP 2056527](https://bugs.launchpad.net/anbox-cloud/+bug/2056527) Android stops working with the error `MESA-VIRTIO: failed to create nv_mem from dma_buf`.<!--AC-2357-->
-* [LP 2046249](https://bugs.launchpad.net/anbox-cloud/+bug/2046249) Deleted applications leave behind base instances in *Error* state.<!--AC-2257-->
-* [LP 2060023](https://bugs.launchpad.net/anbox-cloud/+bug/2060023) Missing `min` values for VHAL properties.
-* [LP 2060605](https://bugs.launchpad.net/anbox-cloud/+bug/2060605) The post-stop hook fails to be called when terminating a session via the gateway DELETE endpoint API.
-* [LP 2061741](https://bugs.launchpad.net/anbox-cloud/+bug/2061741) VHAL panel displays empty values for VHAL properties.
-* Compilation errors when building Anbox kernel modules on kernel 6.8 <!--AC-2359-->
-* When using the web dashboard, occasionally the VHAL panel does not appear due to timing issues between the stream client, the stream gateway, the stream agent and the server.<!--AC-2288 and AC-2286-->
-* When running Anbox Cloud with VirGL enabled on NVIDIA L4 GPUs, Android stops abruptly on startup with the following error:<!--AC-2335-->
+- [LP 2060110](https://bugs.launchpad.net/anbox-cloud/+bug/2060110) Keyboard is not displayed in the *Honkai: Star Rail*.<!--AC-2446-->
+- [LP 2045823](https://bugs.launchpad.net/anbox-cloud/+bug/2045823) Keyboard display flickers in *Monopoly Go*. <!--AC-2439 and 2168-->
+- [LP 2059887](https://bugs.launchpad.net/anbox-cloud/+bug/2059887) Sluggish performance when playing *Honkai: Star Rail*.<!--AC-2433-->
+- [LP 2058423](https://bugs.launchpad.net/anbox-cloud/+bug/2058423) Compatibility issues with *Monopoly Go* and *Marvel Strike* in Vulkan mode causing the games to end abruptly.<!--AC-2402-->
+- [LP 2056707](https://bugs.launchpad.net/anbox-cloud/+bug/2056707) Android system unable to boot due to the error: `Extension not supported: VK_KHR_swapchain`. <!--AC-2363-->
+- [LP 2056527](https://bugs.launchpad.net/anbox-cloud/+bug/2056527) Android stops working with the error `MESA-VIRTIO: failed to create nv_mem from dma_buf`.<!--AC-2357-->
+- [LP 2046249](https://bugs.launchpad.net/anbox-cloud/+bug/2046249) Deleted applications leave behind base instances in *Error* state.<!--AC-2257-->
+- [LP 2060023](https://bugs.launchpad.net/anbox-cloud/+bug/2060023) Missing `min` values for VHAL properties.
+- [LP 2060605](https://bugs.launchpad.net/anbox-cloud/+bug/2060605) The post-stop hook fails to be called when terminating a session via the gateway DELETE endpoint API.
+- [LP 2061741](https://bugs.launchpad.net/anbox-cloud/+bug/2061741) VHAL panel displays empty values for VHAL properties.
+- Compilation errors when building Anbox kernel modules on kernel 6.8 <!--AC-2359-->
+- When using the web dashboard, occasionally the VHAL panel does not appear due to timing issues between the stream client, the stream gateway, the stream agent and the server.<!--AC-2288 and AC-2286-->
+- When running Anbox Cloud with VirGL enabled on NVIDIA L4 GPUs, Android stops abruptly on startup with the following error:<!--AC-2335-->
 
   ```
   vtest_resource_create_blob called virgl_renderer_resource_create_blob which failed (-1)

--- a/reference/release-notes/1.22.1.md
+++ b/reference/release-notes/1.22.1.md
@@ -9,32 +9,32 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Android security updates for June 2024 (see [Android Security Bulletin - June 2024](https://source.android.com/docs/security/bulletin/2024-06-01) for more information).
-* The Android WebView has been updated to [126.0.6478.40](https://chromereleases.googleblog.com/2024/06/chrome-beta-for-android-update.html).
+- Android security updates for June 2024 (see [Android Security Bulletin - June 2024](https://source.android.com/docs/security/bulletin/2024-06-01) for more information).
+- The Android WebView has been updated to [126.0.6478.40](https://chromereleases.googleblog.com/2024/06/chrome-beta-for-android-update.html).
 
 ### Bug fixes
 
 The following bugs are fixed in this release:
 
-* [LP 2066338](https://bugs.launchpad.net/anbox-cloud/+bug/2066338) Failed to join a session with the following error:
+- [LP 2066338](https://bugs.launchpad.net/anbox-cloud/+bug/2066338) Failed to join a session with the following error:
 
     ```
     Service: Failed to generate new generation for session cp5oh64ut74s9inbvt3g: database is locked
     ```
 
-* [LP 2067735](https://bugs.launchpad.net/anbox-cloud/+bug/2067735) AMS couldn't create instances with an error message similar to the following (occurs sporadically):
+- [LP 2067735](https://bugs.launchpad.net/anbox-cloud/+bug/2067735) AMS couldn't create instances with an error message similar to the following (occurs sporadically):
 
     ```
     Failed creating instance from image: Could not locate a zvol for ams0/containers/ams-cpc64323ho619qhebfrg
     ```
 
-* [LP 2067455](https://bugs.launchpad.net/anbox-cloud/+bug/2067455) Juju controller is not selected during appliance upgrade and the upgrade fails.
-* [LP 2064923](https://bugs.launchpad.net/anbox-cloud/+bug/2064923) `nvidia-smi` command is not detected correctly and rendering falls back to EmuGL.
-* [LP 2065401](https://bugs.launchpad.net/anbox-cloud/+bug/2065401) `amc list` always returns a full instance list when filtering with `app=nonexistent`.
+- [LP 2067455](https://bugs.launchpad.net/anbox-cloud/+bug/2067455) Juju controller is not selected during appliance upgrade and the upgrade fails.
+- [LP 2064923](https://bugs.launchpad.net/anbox-cloud/+bug/2064923) `nvidia-smi` command is not detected correctly and rendering falls back to EmuGL.
+- [LP 2065401](https://bugs.launchpad.net/anbox-cloud/+bug/2065401) `amc list` always returns a full instance list when filtering with `app=nonexistent`.
 
 ## Known issues
 <!-- wokeignore:rule=master -->
-* [LP 2069021](https://bugs.launchpad.net/anbox-cloud/+bug/2069021) Recent changes to the [AMS SDK](https://github.com/canonical/ams-sdk) has caused the Golang-based projects that were developed and built with the AMS SDK to stop working. This will be fixed in the 1.23.0 release.
+- [LP 2069021](https://bugs.launchpad.net/anbox-cloud/+bug/2069021) Recent changes to the [AMS SDK](https://github.com/canonical/ams-sdk) has caused the Golang-based projects that were developed and built with the AMS SDK to stop working. This will be fixed in the 1.23.0 release.
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.22.2.md
+++ b/reference/release-notes/1.22.2.md
@@ -9,20 +9,20 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New features & improvements
 
-* Android security updates for July 2024 (see [Android Security Bulletin - July 2024](https://source.android.com/docs/security/bulletin/2024-07-01) for more information).
-* The Android WebView has been updated to [126.0.6478.122](https://chromereleases.googleblog.com/2024/06/chrome-for-android-update_24.html).
+- Android security updates for July 2024 (see [Android Security Bulletin - July 2024](https://source.android.com/docs/security/bulletin/2024-07-01) for more information).
+- The Android WebView has been updated to [126.0.6478.122](https://chromereleases.googleblog.com/2024/06/chrome-for-android-update_24.html).
 
 ## Bug fixes
 
 The following bugs are fixed in this release:
 
-* [LP 2068688](https://bugs.launchpad.net/anbox-cloud/+bug/2068688) Discrepancy between the number of running instances and the number of active sessions. This discrepancy could be observed from the web dashboard and Grafana.
+- [LP 2068688](https://bugs.launchpad.net/anbox-cloud/+bug/2068688) Discrepancy between the number of running instances and the number of active sessions. This discrepancy could be observed from the web dashboard and Grafana.
 
-* [LP 2065142](https://bugs.launchpad.net/anbox-cloud/+bug/2065142) A sporadic issue in which the Android container couldn't boot up successfully due to the following error:
+- [LP 2065142](https://bugs.launchpad.net/anbox-cloud/+bug/2065142) A sporadic issue in which the Android container couldn't boot up successfully due to the following error:
 
         MESA-VIRTIO: failed to create nv_mem from dma_buf
 
-* [LP 2067685](https://bugs.launchpad.net/anbox-cloud/+bug/2067685) With the default VirGL renderer, occasionally blocks of black overlay disrupts viewing the elements of the game.
+- [LP 2067685](https://bugs.launchpad.net/anbox-cloud/+bug/2067685) With the default VirGL renderer, occasionally blocks of black overlay disrupts viewing the elements of the game.
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.23.0.md
+++ b/reference/release-notes/1.23.0.md
@@ -26,9 +26,9 @@ Android Automotive OS based images are fully supported starting from this releas
 
 The Anbox Cloud dashboard has the following improvements:
 
-* The *Instances* and the *Sessions* pages and their functionalities are merged to provide an enhanced user experience while creating and streaming an application.
-* The initial VHAL values upon joining a stream are now captured as a default. You can revert to these values using the *Reset* button, while you are on the stream page.
-* You can easily authorize ADB connections for any stream-enabled instance from the dashboard.
+- The *Instances* and the *Sessions* pages and their functionalities are merged to provide an enhanced user experience while creating and streaming an application.
+- The initial VHAL values upon joining a stream are now captured as a default. You can revert to these values using the *Reset* button, while you are on the stream page.
+- You can easily authorize ADB connections for any stream-enabled instance from the dashboard.
 
 ### Anbox Cloud charms
 
@@ -64,34 +64,34 @@ In the 1.24.0 release, the node controller will be fully replaced with LXD proxy
 
 ## Known issues
 
-* WiFi support is not available with any of the images. This issue will be fixed in the 1.23.1 release. <!--AC-2647-->
-* No crash dump is generated for the `anbox session` or `container-manager` process when running an Anbox session on ARM64.
-* Occasionally, the VHAL panel will not show up on AAOS streams. Reloading the stream page fixes the issue in most cases. In case it doesn't, restarting the instance will fix the issue.
-* In a multi-cluster deployment that has more than one AMS, you cannot use a single web dashboard to control all the clusters in the deployment.
-* When connecting to an Android instance using `anbox-connect <connection_url>`, you might occasionally encounter the following error:
+- WiFi support is not available with any of the images. This issue will be fixed in the 1.23.1 release. <!--AC-2647-->
+- No crash dump is generated for the `anbox session` or `container-manager` process when running an Anbox session on ARM64.
+- Occasionally, the VHAL panel will not show up on AAOS streams. Reloading the stream page fixes the issue in most cases. In case it doesn't, restarting the instance will fix the issue.
+- In a multi-cluster deployment that has more than one AMS, you cannot use a single web dashboard to control all the clusters in the deployment.
+- When connecting to an Android instance using `anbox-connect <connection_url>`, you might occasionally encounter the following error:
 
     ```
     Failed to communicate with the signaler:  Failed to add ICE candidate: InvalidStateError: remote description is not set
     ```
 
     Retrying the command resolves the issue.
-* In the Anbox Cloud appliance, a service declared to be publicly available in the application manifest is not exposed publicly. If your deployment is behind a NAT, you can run the following command to overcome this issue:
+- In the Anbox Cloud appliance, a service declared to be publicly available in the application manifest is not exposed publicly. If your deployment is behind a NAT, you can run the following command to overcome this issue:
 
     ```
     amc node set lxd0 public-address <public-address-of-lxd0>
     ```
 
-* Disabling GPU accelerated encoding (setting `video-encoder` to `software` in an application's manifest) for instances causes Anbox to fail on startup due to incorrectly linking the NVIDIA encoding libraries. See the [bug report on Launchpad](https://bugs.launchpad.net/anbox-cloud/+bug/2076893) for more information.
+- Disabling GPU accelerated encoding (setting `video-encoder` to `software` in an application's manifest) for instances causes Anbox to fail on startup due to incorrectly linking the NVIDIA encoding libraries. See the [bug report on Launchpad](https://bugs.launchpad.net/anbox-cloud/+bug/2076893) for more information.
 
 ## Bug fixes
 
-* [LP 2058004](https://bugs.launchpad.net/anbox-cloud/+bug/2058004) Deploying Anbox Cloud dashboard fails when using AMI that has a Ubuntu Pro subscription.
-* [LP 2065281](https://bugs.launchpad.net/anbox-cloud/+bug/2065281) Android 13 unable to use Vulkan 1.3 despite Vulkan 1.3 being supported.
-* [LP 2067314](https://bugs.launchpad.net/anbox-cloud/+bug/2067314) Current `amc shell` is a plain bash shell and will not source any common profile scripts.
-* [LP 2067316](https://bugs.launchpad.net/anbox-cloud/+bug/2067316) The `pprof` endpoint exposed by AMS for profiling heap allocations does not expose `allocs` handler.
-* [LP 2067252](https://bugs.launchpad.net/anbox-cloud/+bug/2067252) Incorrect  `Error: api extension "zip_archive_support" not supported` error while creating an application.
-* [LP 2069021](https://bugs.launchpad.net/anbox-cloud/+bug/2069021) Updating the AMS SDK to 1.21.0 prevents building the AMS client.
-* [LP 2070252](https://bugs.launchpad.net/anbox-cloud/+bug/2070252) When running an Android application, the `SensorListener` runs into a hot loop and the following messages can be seen in the logs:
+- [LP 2058004](https://bugs.launchpad.net/anbox-cloud/+bug/2058004) Deploying Anbox Cloud dashboard fails when using AMI that has a Ubuntu Pro subscription.
+- [LP 2065281](https://bugs.launchpad.net/anbox-cloud/+bug/2065281) Android 13 unable to use Vulkan 1.3 despite Vulkan 1.3 being supported.
+- [LP 2067314](https://bugs.launchpad.net/anbox-cloud/+bug/2067314) Current `amc shell` is a plain bash shell and will not source any common profile scripts.
+- [LP 2067316](https://bugs.launchpad.net/anbox-cloud/+bug/2067316) The `pprof` endpoint exposed by AMS for profiling heap allocations does not expose `allocs` handler.
+- [LP 2067252](https://bugs.launchpad.net/anbox-cloud/+bug/2067252) Incorrect  `Error: api extension "zip_archive_support" not supported` error while creating an application.
+- [LP 2069021](https://bugs.launchpad.net/anbox-cloud/+bug/2069021) Updating the AMS SDK to 1.21.0 prevents building the AMS client.
+- [LP 2070252](https://bugs.launchpad.net/anbox-cloud/+bug/2070252) When running an Android application, the `SensorListener` runs into a hot loop and the following messages can be seen in the logs:
 
     ```
     06-13 12:12:16.403 3221 3221 D SensorMonitor: Temperature Sensor value changed
@@ -99,9 +99,9 @@ In the 1.24.0 release, the node controller will be fully replaced with LXD proxy
     06-13 12:12:16.413 3221 3221 D SensorMonitor: Temperature Sensor value  changed
     ```
 
-* [LP 2072367](https://bugs.launchpad.net/anbox-cloud/+bug/2072367) When initializing the Anbox Cloud Appliance, if you provide an empty public address, invalid STUN/TURN server details are generated.
-* [LP 2071903](https://bugs.launchpad.net/anbox-cloud/+bug/2071903) Stream gateway swagger API is missing `/1.0/sessions POST` documentation.
-* [LP 2072955](https://bugs.launchpad.net/anbox-cloud/+bug/2072955)
+- [LP 2072367](https://bugs.launchpad.net/anbox-cloud/+bug/2072367) When initializing the Anbox Cloud Appliance, if you provide an empty public address, invalid STUN/TURN server details are generated.
+- [LP 2071903](https://bugs.launchpad.net/anbox-cloud/+bug/2071903) Stream gateway swagger API is missing `/1.0/sessions POST` documentation.
+- [LP 2072955](https://bugs.launchpad.net/anbox-cloud/+bug/2072955)
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.23.1.md
+++ b/reference/release-notes/1.23.1.md
@@ -17,38 +17,38 @@ See the {ref}`ref-requirements` for details on general and deployment specific r
 
 ### Anbox Cloud Appliance
 
-* You can now set the following appliance network configuration using `anbox-cloud-appliance config set`:<!--AC-2732-->
-  - The network's public IP address (`network.public_address`)
-  - The network's DNS name (`network.location`)<!--AC-2727-->.
-* You can now configure the [CORS settings](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for those API endpoints that the appliance reverse proxy passes to the Anbox Stream Gateway. You can set the following using the `anbox-cloud-appliance config set` command:<!--AC-2732-->
-  - The [HTTP origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin) (`core.https_allowed_origin`)
-  - List of allowed HTTP headers (`core.https_allowed_headers`)
-  - List of allowed HTTP methods (`core.https_allowed_methods`)
-* You can skip setting up coturn when initializing the appliance and can configure a custom STUN server.<!--AC-2719-->
-* The [`prepare-node-script`](https://documentation.ubuntu.com/anbox-cloud/reference/cmd-ref/appliance/anbox-cloud-appliance_prepare-node-script/) command is extended to support systems with an already installed NVIDIA driver. <!--AC-2714-->
-* You can now set up a custom identity provider for the dashboard by configuring an OpenID Connect provider through the preseed configuration when initializing the appliance.
+- You can now set the following appliance network configuration using `anbox-cloud-appliance config set`:<!--AC-2732-->
+  * The network's public IP address (`network.public_address`)
+  * The network's DNS name (`network.location`)<!--AC-2727-->.
+- You can now configure the [CORS settings](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for those API endpoints that the appliance reverse proxy passes to the Anbox Stream Gateway. You can set the following using the `anbox-cloud-appliance config set` command:<!--AC-2732-->
+  * The [HTTP origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin) (`core.https_allowed_origin`)
+  * List of allowed HTTP headers (`core.https_allowed_headers`)
+  * List of allowed HTTP methods (`core.https_allowed_methods`)
+- You can skip setting up coturn when initializing the appliance and can configure a custom STUN server.<!--AC-2719-->
+- The [`prepare-node-script`](https://documentation.ubuntu.com/anbox-cloud/reference/cmd-ref/appliance/anbox-cloud-appliance_prepare-node-script/) command is extended to support systems with an already installed NVIDIA driver. <!--AC-2714-->
+- You can now set up a custom identity provider for the dashboard by configuring an OpenID Connect provider through the preseed configuration when initializing the appliance.
 
 ### Streaming
 
-* With the 1.23.0 release, the functionalities of the *Instances* page and the *Sessions* page on the web dashboard were merged. For debugging purposes, viewing a list of available sessions can be really useful. With the 1.23.1 release, you can list all available sessions using the `anbox-stream-gateway sessions list` command.<!--AC-2662-->
-* You can dynamically change the display density when joining an existing streaming session.<!--AC-2673-->
+- With the 1.23.0 release, the functionalities of the *Instances* page and the *Sessions* page on the web dashboard were merged. For debugging purposes, viewing a list of available sessions can be really useful. With the 1.23.1 release, you can list all available sessions using the `anbox-stream-gateway sessions list` command.<!--AC-2662-->
+- You can dynamically change the display density when joining an existing streaming session.<!--AC-2673-->
 
 ### VHAL
 
-* Starting with 1.23.0, the VNDK version required for building a custom VHAL is 34.<!--AC-2720-->
+- Starting with 1.23.0, the VNDK version required for building a custom VHAL is 34.<!--AC-2720-->
 
 ### Android vendor image
 
-* WiFi support for all Android versions.<!--AC-2707-->
+- WiFi support for all Android versions.<!--AC-2707-->
 
 ### Other
 
-* Android security updates for September 2024 (see [Android Security Bulletin - September 2024](https://source.android.com/docs/security/bulletin/2024-09-01) for more information). <!--AC-2712-->
-* The Android WebView has been updated to [128.0.6613.127](https://chromereleases.googleblog.com/2024/09/chrome-for-android-update.html).
+- Android security updates for September 2024 (see [Android Security Bulletin - September 2024](https://source.android.com/docs/security/bulletin/2024-09-01) for more information). <!--AC-2712-->
+- The Android WebView has been updated to [128.0.6613.127](https://chromereleases.googleblog.com/2024/09/chrome-for-android-update.html).
 
 ## Known issues
 
-* Since version 1.23.0, the Anbox WebRTC Data Proxy service starts on demand rather than at container startup. However, its startup time may take longer than expected, which can negatively impact the {ref}`out-of-band data exchange <howto-exchange-oob-data>` between the WebRTC server and client. This issue can be worked around by applying the following tweak in a [pre-start hook](https://anbox-cloud.io/docs/ref/hooks).
+- Since version 1.23.0, the Anbox WebRTC Data Proxy service starts on demand rather than at container startup. However, its startup time may take longer than expected, which can negatively impact the {ref}`out-of-band data exchange <howto-exchange-oob-data>` between the WebRTC server and client. This issue can be worked around by applying the following tweak in a [pre-start hook](https://anbox-cloud.io/docs/ref/hooks).
 
   ```
   #!/bin/sh -ex
@@ -67,7 +67,7 @@ See the {ref}`ref-requirements` for details on general and deployment specific r
   sudo systemctl enable anbox-webrtc-data-proxy
   ```
 
-* Launching a VM image with default size fails with the following error: <!--LP 2076907-->
+- Launching a VM image with default size fails with the following error: <!--LP 2076907-->
 
       $ amc launch -r --vm jammy:android13:arm64
       Error: Failed creating instance from image: Source image size (16106127360) exceeds specified volume size (15000010752)
@@ -99,21 +99,21 @@ The Anbox Cloud 1.23.1 release includes fixes from the respective upstreams for 
 
 ## Bug fixes
 
-* [LP 2080334](https://bugs.launchpad.net/anbox-cloud/+bug/2080334) Peer connection fails with the following error: `InvalidStateError: remote description is not set`.<!--AC-2690-->
-* [LP 2080329](https://bugs.launchpad.net/anbox-cloud/+bug/2080329) After deploying the new epoch=1 version of the appliance behind a NAT, services are not publicly accessible even when configured for public access.
-* [LP 2077999](https://bugs.launchpad.net/anbox-cloud/+bug/2077999) For most of the WebRTC signaling messages exchanged between client and Anbox, the first discover message takes ~2s to receive a response.
-* [LP 2077944](https://bugs.launchpad.net/anbox-cloud/+bug/2077944) A session that enters into an error status cannot be revived again even when the associated instance is started again.
-* [LP 2077188](https://bugs.launchpad.net/anbox-cloud/+bug/2077188) When using the Anbox Cloud Appliance, the dashboard UI displays a `Something unexpected has gone wrong` error after 5 seconds.
-* [LP 2077116](https://bugs.launchpad.net/anbox-cloud/+bug/2077116) The new version of the Anbox Cloud Appliance (epoch=1) is missing required firewall rules on Oracle Cloud deployments.
-* [LP 2076893](https://bugs.launchpad.net/anbox-cloud/+bug/2076893) Instances without GPU encoding fail to start.
-* [LP 2076593](https://bugs.launchpad.net/anbox-cloud/+bug/2076593) In regular Anbox Cloud deployments, when trying to register the web dashboard, the dashboard displays an error that it is missing information to connect to either the Anbox Management Service (AMS) or the Anbox Stream Gateway. This error is caused due the dashboard charm failing to generate the certificate and key.
-* [LP 2076894](https://bugs.launchpad.net/anbox-cloud/+bug/2076894) The new epoch=1 version of the appliance uses a node preparation script which does not detect the history of enabling Anbox Cloud on Ubuntu Pro, irrespective of the Ubuntu release.
-* [LP 2077898](https://bugs.launchpad.net/anbox-cloud/+bug/2077898) Screen resolution selector for AAOS doesn't show predefined resolutions when creating a new instance for the first time (no instances or applications exist).
-* Private bugs:
-  - [LP 2076494](https://bugs.launchpad.net/anbox-cloud/+bug/2076494)
-  - [LP 2071806](https://bugs.launchpad.net/anbox-cloud/+bug/2071806)
-  - [LP 2071925](https://bugs.launchpad.net/anbox-cloud/+bug/2071925)
-  - [LP 2075494](https://bugs.launchpad.net/anbox-cloud/+bug/2075494)
+- [LP 2080334](https://bugs.launchpad.net/anbox-cloud/+bug/2080334) Peer connection fails with the following error: `InvalidStateError: remote description is not set`.<!--AC-2690-->
+- [LP 2080329](https://bugs.launchpad.net/anbox-cloud/+bug/2080329) After deploying the new epoch=1 version of the appliance behind a NAT, services are not publicly accessible even when configured for public access.
+- [LP 2077999](https://bugs.launchpad.net/anbox-cloud/+bug/2077999) For most of the WebRTC signaling messages exchanged between client and Anbox, the first discover message takes ~2s to receive a response.
+- [LP 2077944](https://bugs.launchpad.net/anbox-cloud/+bug/2077944) A session that enters into an error status cannot be revived again even when the associated instance is started again.
+- [LP 2077188](https://bugs.launchpad.net/anbox-cloud/+bug/2077188) When using the Anbox Cloud Appliance, the dashboard UI displays a `Something unexpected has gone wrong` error after 5 seconds.
+- [LP 2077116](https://bugs.launchpad.net/anbox-cloud/+bug/2077116) The new version of the Anbox Cloud Appliance (epoch=1) is missing required firewall rules on Oracle Cloud deployments.
+- [LP 2076893](https://bugs.launchpad.net/anbox-cloud/+bug/2076893) Instances without GPU encoding fail to start.
+- [LP 2076593](https://bugs.launchpad.net/anbox-cloud/+bug/2076593) In regular Anbox Cloud deployments, when trying to register the web dashboard, the dashboard displays an error that it is missing information to connect to either the Anbox Management Service (AMS) or the Anbox Stream Gateway. This error is caused due the dashboard charm failing to generate the certificate and key.
+- [LP 2076894](https://bugs.launchpad.net/anbox-cloud/+bug/2076894) The new epoch=1 version of the appliance uses a node preparation script which does not detect the history of enabling Anbox Cloud on Ubuntu Pro, irrespective of the Ubuntu release.
+- [LP 2077898](https://bugs.launchpad.net/anbox-cloud/+bug/2077898) Screen resolution selector for AAOS doesn't show predefined resolutions when creating a new instance for the first time (no instances or applications exist).
+- Private bugs:
+  * [LP 2076494](https://bugs.launchpad.net/anbox-cloud/+bug/2076494)
+  * [LP 2071806](https://bugs.launchpad.net/anbox-cloud/+bug/2071806)
+  * [LP 2071925](https://bugs.launchpad.net/anbox-cloud/+bug/2071925)
+  * [LP 2075494](https://bugs.launchpad.net/anbox-cloud/+bug/2075494)
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.23.2.md
+++ b/reference/release-notes/1.23.2.md
@@ -15,12 +15,12 @@ See the {ref}`ref-requirements` for details on general and deployment specific r
 
 ## New features & improvements
 
-* Android security updates for October 2024 (see [Android Security Bulletin - October 2024](https://source.android.com/docs/security/bulletin/2024-10-01) for more information).
-* The Android WebView has been updated to [129.0.6668.81](https://chromereleases.googleblog.com/2024/10/chrome-for-android-update.html).
+- Android security updates for October 2024 (see [Android Security Bulletin - October 2024](https://source.android.com/docs/security/bulletin/2024-10-01) for more information).
+- The Android WebView has been updated to [129.0.6668.81](https://chromereleases.googleblog.com/2024/10/chrome-for-android-update.html).
 
 ## Known issues
 
-* Since version 1.23.0, the Anbox WebRTC Data Proxy service starts on demand rather than at container startup. However, its startup time may take longer than expected, which can negatively impact the {ref}`out-of-band data exchange <howto-exchange-oob-data>` between the WebRTC server and client. This issue can be worked around by applying the following tweak in a [pre-start hook](https://anbox-cloud.io/docs/ref/hooks).
+- Since version 1.23.0, the Anbox WebRTC Data Proxy service starts on demand rather than at container startup. However, its startup time may take longer than expected, which can negatively impact the {ref}`out-of-band data exchange <howto-exchange-oob-data>` between the WebRTC server and client. This issue can be worked around by applying the following tweak in a [pre-start hook](https://anbox-cloud.io/docs/ref/hooks).
 
   ```
   #!/bin/sh -ex
@@ -56,14 +56,14 @@ The Anbox Cloud 1.23.2 release includes fixes from the respective upstreams for 
 
 ## Bug fixes
 
-* [LP 2081073](https://bugs.launchpad.net/anbox-cloud/+bug/2081073) Resizing instance terminal in the Anbox Cloud dashboard fails.
-* [LP 2060532](https://bugs.launchpad.net/anbox-cloud/+bug/2060532) VHAL panel is not displayed for new sessions.
-* [LP 2082068](https://bugs.launchpad.net/anbox-cloud/+bug/2082068) When creating a session, the `1.0/events` endpoint does not report that the instance has moved to `running` status.
-* [LP 2080491](https://bugs.launchpad.net/anbox-cloud/+bug/2080491) No device is attached to the ADB server even when Anbox is running.
-* [LP 2077003](https://bugs.launchpad.net/anbox-cloud/+bug/2077003) Anbox does not parse VHAL messages
-* [LP 2076907](https://bugs.launchpad.net/anbox-cloud/+bug/2076907) Launching a VM image fails with default size
-* [LP 2081989](https://bugs.launchpad.net/anbox-cloud/+bug/2081989) `amc monitor` command is not documented in help text.
-* [LP 2069927](https://bugs.launchpad.net/anbox-cloud/+bug/2069927) (Private bug)
+- [LP 2081073](https://bugs.launchpad.net/anbox-cloud/+bug/2081073) Resizing instance terminal in the Anbox Cloud dashboard fails.
+- [LP 2060532](https://bugs.launchpad.net/anbox-cloud/+bug/2060532) VHAL panel is not displayed for new sessions.
+- [LP 2082068](https://bugs.launchpad.net/anbox-cloud/+bug/2082068) When creating a session, the `1.0/events` endpoint does not report that the instance has moved to `running` status.
+- [LP 2080491](https://bugs.launchpad.net/anbox-cloud/+bug/2080491) No device is attached to the ADB server even when Anbox is running.
+- [LP 2077003](https://bugs.launchpad.net/anbox-cloud/+bug/2077003) Anbox does not parse VHAL messages
+- [LP 2076907](https://bugs.launchpad.net/anbox-cloud/+bug/2076907) Launching a VM image fails with default size
+- [LP 2081989](https://bugs.launchpad.net/anbox-cloud/+bug/2081989) `amc monitor` command is not documented in help text.
+- [LP 2069927](https://bugs.launchpad.net/anbox-cloud/+bug/2069927) (Private bug)
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.24.0.md
+++ b/reference/release-notes/1.24.0.md
@@ -17,56 +17,56 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 ### Updates to components
 
-* Anbox Cloud includes and uses the following latest versions for components it uses:
-  - LXC version 6.0.2<!--AC-2812-->
-  - Mesa driver version 24.2.4<!--AC-2800-->
-  - VirGL renderer version 1.9.0.<!--AC-2800-->
+- Anbox Cloud includes and uses the following latest versions for components it uses:
+  * LXC version 6.0.2<!--AC-2812-->
+  * Mesa driver version 24.2.4<!--AC-2800-->
+  * VirGL renderer version 1.9.0.<!--AC-2800-->
 
 ### Security
 
-* We have enhanced security with a minimum version of TLS 1.3 as a requirement for all services working with Anbox Cloud. TLS 1.3 is also enabled by default for the Anbox Stream Agent and Gateway.<!--AC-2728 and AC-2654-->
+- We have enhanced security with a minimum version of TLS 1.3 as a requirement for all services working with Anbox Cloud. TLS 1.3 is also enabled by default for the Anbox Stream Agent and Gateway.<!--AC-2728 and AC-2654-->
 
 ### Anbox Management Service (AMS)
 
-* We have increased the maximum number of queued operations in AMS to allow better performance.<!--AC-2831-->
-* AMS supports querying the image variant (`android` or `aaos`) for Anbox Cloud images.<!--AC-2757-->
-* The web client, for example, the Anbox Cloud dashboard can communicate with multiple AMS instances.<!--AC-2674-->
+- We have increased the maximum number of queued operations in AMS to allow better performance.<!--AC-2831-->
+- AMS supports querying the image variant (`android` or `aaos`) for Anbox Cloud images.<!--AC-2757-->
+- The web client, for example, the Anbox Cloud dashboard can communicate with multiple AMS instances.<!--AC-2674-->
 
 ### Android
 
-* This release includes Android 14 based AOSP and AAOS images.
-* We now support using the lock screen in Anbox Cloud([LP 1983426](https://bugs.launchpad.net/anbox-cloud/+bug/1983426)).
-* For the Android 14 image, the out of band v2 feature in Anbox Cloud requires the Android app to be running to receive broadcasts. If the app is in the [cached state](https://developer.android.com/guide/components/activities/process-lifecycle), the system places [context-registered broadcasts in a queue](https://developer.android.com/develop/background-work/background-tasks/broadcasts#android-14) and hence the app may not receive broadcasts immediately as it would when it is running.<!--AC-2852-->
+- This release includes Android 14 based AOSP and AAOS images.
+- We now support using the lock screen in Anbox Cloud([LP 1983426](https://bugs.launchpad.net/anbox-cloud/+bug/1983426)).
+- For the Android 14 image, the out of band v2 feature in Anbox Cloud requires the Android app to be running to receive broadcasts. If the app is in the [cached state](https://developer.android.com/guide/components/activities/process-lifecycle), the system places [context-registered broadcasts in a queue](https://developer.android.com/develop/background-work/background-tasks/broadcasts#android-14) and hence the app may not receive broadcasts immediately as it would when it is running.<!--AC-2852-->
 
 ### Charms
 
-* For the NFS Operator charm for Anbox Cloud, `Cachefilesd` is now optional and is used only when `fsc` is provided as a mount option.<!--AC-2839-->
+- For the NFS Operator charm for Anbox Cloud, `Cachefilesd` is now optional and is used only when `fsc` is provided as a mount option.<!--AC-2839-->
 
 ### Dashboard
 
-* You can now debug a session with the new developer tools on the stream page. Terminal and logs are available in parallel when streaming an instance.
-* For mobile streams, a location selector is now available.
-* For increased security, HTTPS is mandatory for all connections.
-* Image type is auto-detected once application is selected.
-* Improved accessibility with a *Skip to content* button.
+- You can now debug a session with the new developer tools on the stream page. Terminal and logs are available in parallel when streaming an instance.
+- For mobile streams, a location selector is now available.
+- For increased security, HTTPS is mandatory for all connections.
+- Image type is auto-detected once application is selected.
+- Improved accessibility with a *Skip to content* button.
 
 ### Streaming
 
-* Anbox Cloud now provides an option to allow the use of custom fragment shader-based upscaling algorithms for video streaming. This helps you to apply multiple shaders sequentially to perform multi-pass upscaling and replaces the default [AMD FidelityFX Super Resolution 1.0](https://gpuopen.com/fidelityfx-superresolution/) shader. See {ref}`sec-custom-fragment-shader` for more information.<!--AC-2541-->
-* The Anbox Streaming SDK now includes two additional examples that demonstrate shader-based upscaling algorithms integrated with the JS SDK:<!--AC-2543-->
-  - [Snapdragon™ Game Super Resolution(SGSR)](https://github.com/SnapdragonStudios/snapdragon-gsr)
-  - [Anime4K high-quality real-time anime](https://github.com/bloc97/Anime4K)
+- Anbox Cloud now provides an option to allow the use of custom fragment shader-based upscaling algorithms for video streaming. This helps you to apply multiple shaders sequentially to perform multi-pass upscaling and replaces the default [AMD FidelityFX Super Resolution 1.0](https://gpuopen.com/fidelityfx-superresolution/) shader. See {ref}`sec-custom-fragment-shader` for more information.<!--AC-2541-->
+- The Anbox Streaming SDK now includes two additional examples that demonstrate shader-based upscaling algorithms integrated with the JS SDK:<!--AC-2543-->
+  * [Snapdragon™ Game Super Resolution(SGSR)](https://github.com/SnapdragonStudios/snapdragon-gsr)
+  * [Anime4K high-quality real-time anime](https://github.com/bloc97/Anime4K)
 
 ### Other
 
-* Android security updates for November 2024 (see [Android Security Bulletin - November 2024](https://source.android.com/docs/security/bulletin/2024-11-01) for more information).
-* The Android WebView has been updated to 130.0.6723.73.
+- Android security updates for November 2024 (see [Android Security Bulletin - November 2024](https://source.android.com/docs/security/bulletin/2024-11-01) for more information).
+- The Android WebView has been updated to 130.0.6723.73.
 
 ## Removed functionality
 
 Following deprecation in earlier releases, these functionalities have been removed from Anbox Cloud with the 1.24.0 release:
 
-* Support for Ubuntu 20.04 LTS (Focal Fossa)
+- Support for Ubuntu 20.04 LTS (Focal Fossa)
 
 ## Deprecations
 
@@ -74,29 +74,29 @@ There are no new deprecations announced for 1.24.0. For the list of features or 
 
 ## Known issues
 
-* The following features can be enabled for AAOS images based on Android 14. However, this is not supported and may result in unexpected behavior. This will be removed in the next patch release:<!--AC-2848-->
-  - `enable_virtual_keyboard`
-  - `enable_system_ui`
-  - `enable_anbox_ime`
-  - Custom Android ID
-  - Custom system apps
-  - Boot package support
+- The following features can be enabled for AAOS images based on Android 14. However, this is not supported and may result in unexpected behavior. This will be removed in the next patch release:<!--AC-2848-->
+  * `enable_virtual_keyboard`
+  * `enable_system_ui`
+  * `enable_anbox_ime`
+  * Custom Android ID
+  * Custom system apps
+  * Boot package support
 
-* When using the Android 14 image, displaying an activity from a boot package using the `foregroundActivity` option in the [Anbox Streaming SDK](https://github.com/canonical/anbox-streaming-sdk/tree/main) may not work. This issue occurs due to a native crash occurring in the Android container.
+- When using the Android 14 image, displaying an activity from a boot package using the `foregroundActivity` option in the [Anbox Streaming SDK](https://github.com/canonical/anbox-streaming-sdk/tree/main) may not work. This issue occurs due to a native crash occurring in the Android container.
 
 ## Bug fixes
 
 The following bugs have been fixed as part of the Anbox Cloud 1.24.0 release.
 
-* [LP 2064900](https://bugs.launchpad.net/anbox-cloud/+bug/2064900) If an instance fails and ends up with *Error* status, the session for the instance is set to *Error* status as well. When the instance is restarted, the session status remains in *Error* and it is not possible to stream from the instance again.
-* [LP 2084897](https://bugs.launchpad.net/anbox-cloud/+bug/2084897) Null pointer exception when opening Anbox IME.
-* [LP 2072496](https://bugs.launchpad.net/anbox-cloud/+bug/2072496) Setting user data while creating an instance with streaming enabled creates an instance but does not allow you to join the session.
-* [LP 2085098](https://bugs.launchpad.net/anbox-cloud/+bug/2085098) The dashboard fails to connect to the stream gateway because the value of the `ASG_API_URL` configuration is used to limit the dashboard's communication. So when the CORS header is set to, for example, the private address of the gateway, the dashboard cannot connect to the gateway.
-* [LP 2084800](https://bugs.launchpad.net/anbox-cloud/+bug/2084800) The `no_wait` query parameter for the `POST /1.0/instances` endpoint is not documented.
-* [LP 2084120](https://bugs.launchpad.net/anbox-cloud/+bug/2084120) Anbox WebRTC Data Proxy service takes too long to get started.
-* [LP 2083795](https://bugs.launchpad.net/anbox-cloud/+bug/2083795) When reconnecting to the ADB server, the connection is refused.
-* [LP 2077638](https://bugs.launchpad.net/anbox-cloud/+bug/2077638) After initializing the Anbox Cloud Appliance, the output of `amc image list` remains empty. This shows that the Anbox Management Service (AMS) has not loaded the image list immediately after the initialization.
-* [LP 2084253](https://bugs.launchpad.net/anbox-cloud/+bug/2084253) 64-bit only detection on ARM systems does not work and causes a boot failure.
+- [LP 2064900](https://bugs.launchpad.net/anbox-cloud/+bug/2064900) If an instance fails and ends up with *Error* status, the session for the instance is set to *Error* status as well. When the instance is restarted, the session status remains in *Error* and it is not possible to stream from the instance again.
+- [LP 2084897](https://bugs.launchpad.net/anbox-cloud/+bug/2084897) Null pointer exception when opening Anbox IME.
+- [LP 2072496](https://bugs.launchpad.net/anbox-cloud/+bug/2072496) Setting user data while creating an instance with streaming enabled creates an instance but does not allow you to join the session.
+- [LP 2085098](https://bugs.launchpad.net/anbox-cloud/+bug/2085098) The dashboard fails to connect to the stream gateway because the value of the `ASG_API_URL` configuration is used to limit the dashboard's communication. So when the CORS header is set to, for example, the private address of the gateway, the dashboard cannot connect to the gateway.
+- [LP 2084800](https://bugs.launchpad.net/anbox-cloud/+bug/2084800) The `no_wait` query parameter for the `POST /1.0/instances` endpoint is not documented.
+- [LP 2084120](https://bugs.launchpad.net/anbox-cloud/+bug/2084120) Anbox WebRTC Data Proxy service takes too long to get started.
+- [LP 2083795](https://bugs.launchpad.net/anbox-cloud/+bug/2083795) When reconnecting to the ADB server, the connection is refused.
+- [LP 2077638](https://bugs.launchpad.net/anbox-cloud/+bug/2077638) After initializing the Anbox Cloud Appliance, the output of `amc image list` remains empty. This shows that the Anbox Management Service (AMS) has not loaded the image list immediately after the initialization.
+- [LP 2084253](https://bugs.launchpad.net/anbox-cloud/+bug/2084253) 64-bit only detection on ARM systems does not work and causes a boot failure.
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.24.1.md
+++ b/reference/release-notes/1.24.1.md
@@ -15,19 +15,19 @@ See [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/refere
 
 ## New features
 
-* The [`anbox-cloud-appliance buginfo`](https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/cmd-ref/appliance/anbox-cloud-appliance_buginfo/) command also includes the appliance configuration details for better troubleshooting.<!--AC-2893-->
-* Android security updates for December 2024 (see [Android Security Bulletin - December 2024](https://source.android.com/docs/security/bulletin/2024-12-01) for more information).
-* The Android WebView has been updated to 131.0.6778.81.<!--AC-2985-->
+- The [`anbox-cloud-appliance buginfo`](https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/cmd-ref/appliance/anbox-cloud-appliance_buginfo/) command also includes the appliance configuration details for better troubleshooting.<!--AC-2893-->
+- Android security updates for December 2024 (see [Android Security Bulletin - December 2024](https://source.android.com/docs/security/bulletin/2024-12-01) for more information).
+- The Android WebView has been updated to 131.0.6778.81.<!--AC-2985-->
 
 ## Removed functionality
 
-* The following unsupported features cannot be enabled in AAOS 14 images:<!--AC-2849-->
-  - `enable_virtual_keyboard`
-  - `enable_system_ui`
-  - `enable_anbox_ime`
-  - Custom Android ID
-  - Custom system apps
-  - Boot package support
+- The following unsupported features cannot be enabled in AAOS 14 images:<!--AC-2849-->
+  * `enable_virtual_keyboard`
+  * `enable_system_ui`
+  * `enable_anbox_ime`
+  * Custom Android ID
+  * Custom system apps
+  * Boot package support
 
 Although they were unsupported, they could be enabled in the previous 1.24.0 release and when enabled, could cause unexpected behavior.
 
@@ -37,7 +37,7 @@ There are no new deprecations announced for 1.24.1. For the list of features or 
 
 ## Known issues
 
-* Rendering does not work for AMD and Intel GPUs. For deployments that use AMD GPUs, the instance does not start and for deployments using Intel GPUs, the graphical output is incorrect.<!--AC-2963-->
+- Rendering does not work for AMD and Intel GPUs. For deployments that use AMD GPUs, the instance does not start and for deployments using Intel GPUs, the graphical output is incorrect.<!--AC-2963-->
 
 ## CVEs
 
@@ -61,16 +61,16 @@ The Anbox Cloud 1.24.1 release includes fixes from the respective upstreams for 
 
 The following bugs have been fixed as part of the Anbox Cloud 1.24.1 release.
 
-* [LP 2089631](https://bugs.launchpad.net/anbox-cloud/+bug/2089631) Unusually high GPU memory consumption when multiple clients connect with varying screen resolutions.<!--AC-2988-->
-* [LP 2086814](https://bugs.launchpad.net/anbox-cloud/+bug/2086814) When the Anbox Stream Gateway runs in HA mode, it creates multiple sessions for a single AMS node, but only a single session is recorded in the AMS.<!--AC-2866-->
-* [LP 2087525](https://bugs.launchpad.net/anbox-cloud/+bug/2087525) When using `amc list`, the `TAGS` column (with `session=SESSION_ID`) is included in the table format, but missing from the JSON/YAML format.<!--AC-2890-->
-* [LP 2087550](https://bugs.launchpad.net/anbox-cloud/+bug/2087550) The size of images is set incorrectly when they are not completely downloaded. When they are not yet downloaded, the image size is set to `0B` and when they are being downloaded, the size is set to `-1B`.<!--AC-2891-->
-* [LP 2087554](https://bugs.launchpad.net/anbox-cloud/+bug/2087554) The output from the `anbox-cloud-appliance buginfo` command in the appliance contains `unknown` as the value instead of version information.<!--AC-2892-->
-* [LP 2087958](https://bugs.launchpad.net/anbox-cloud/+bug/2087958) When using the Android 14 image, displaying an activity from a boot package using the `foregroundActivity` option in the [Anbox Streaming SDK](https://github.com/canonical/anbox-streaming-sdk/tree/main) did not work frequently. This issue occurred due to a native crash occurring in the Android container. <!--AC-2912-->
-* [LP 2089265](https://bugs.launchpad.net/anbox-cloud/+bug/2089265) After enabling _Developer option_ from the _Settings_ app in Android, the page stops working.<!--AC-2979-->
-* [LP 2089228](https://bugs.launchpad.net/anbox-cloud/+bug/2089228) In AAOS 13 and AAOS 14 images, HVAC application in AAOS does not work. Some of the manifestations of this bug were that buttons in the UI were not responding, it was not possible to change the target temperature, changing values in the VHAL panel did not show any changes in the Android UI.<!--AC-2976-->
-* [LP 2077890](https://bugs.launchpad.net/anbox-cloud/+bug/2077890) Broken documentation link in Anbox Streaming SDK.
-* [LP 2071925](https://bugs.launchpad.net/anbox-cloud/+bug/2071925) (Private bug)<!--AC-2844-->
+- [LP 2089631](https://bugs.launchpad.net/anbox-cloud/+bug/2089631) Unusually high GPU memory consumption when multiple clients connect with varying screen resolutions.<!--AC-2988-->
+- [LP 2086814](https://bugs.launchpad.net/anbox-cloud/+bug/2086814) When the Anbox Stream Gateway runs in HA mode, it creates multiple sessions for a single AMS node, but only a single session is recorded in the AMS.<!--AC-2866-->
+- [LP 2087525](https://bugs.launchpad.net/anbox-cloud/+bug/2087525) When using `amc list`, the `TAGS` column (with `session=SESSION_ID`) is included in the table format, but missing from the JSON/YAML format.<!--AC-2890-->
+- [LP 2087550](https://bugs.launchpad.net/anbox-cloud/+bug/2087550) The size of images is set incorrectly when they are not completely downloaded. When they are not yet downloaded, the image size is set to `0B` and when they are being downloaded, the size is set to `-1B`.<!--AC-2891-->
+- [LP 2087554](https://bugs.launchpad.net/anbox-cloud/+bug/2087554) The output from the `anbox-cloud-appliance buginfo` command in the appliance contains `unknown` as the value instead of version information.<!--AC-2892-->
+- [LP 2087958](https://bugs.launchpad.net/anbox-cloud/+bug/2087958) When using the Android 14 image, displaying an activity from a boot package using the `foregroundActivity` option in the [Anbox Streaming SDK](https://github.com/canonical/anbox-streaming-sdk/tree/main) did not work frequently. This issue occurred due to a native crash occurring in the Android container. <!--AC-2912-->
+- [LP 2089265](https://bugs.launchpad.net/anbox-cloud/+bug/2089265) After enabling _Developer option_ from the _Settings_ app in Android, the page stops working.<!--AC-2979-->
+- [LP 2089228](https://bugs.launchpad.net/anbox-cloud/+bug/2089228) In AAOS 13 and AAOS 14 images, HVAC application in AAOS does not work. Some of the manifestations of this bug were that buttons in the UI were not responding, it was not possible to change the target temperature, changing values in the VHAL panel did not show any changes in the Android UI.<!--AC-2976-->
+- [LP 2077890](https://bugs.launchpad.net/anbox-cloud/+bug/2077890) Broken documentation link in Anbox Streaming SDK.
+- [LP 2071925](https://bugs.launchpad.net/anbox-cloud/+bug/2071925) (Private bug)<!--AC-2844-->
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.24.2.md
+++ b/reference/release-notes/1.24.2.md
@@ -15,9 +15,9 @@ See [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/refere
 
 ## New features
 
-* The `anbox-cloud-appliance config show` command lists the available endpoints and their URLs.<!--AC-3002-->
-* Android security updates for January 2025 (see [Android Security Bulletin - January 2025](https://source.android.com/docs/security/bulletin/2025-01-01) for more information).
-* The Android WebView has been updated to 131.0.6778.200.
+- The `anbox-cloud-appliance config show` command lists the available endpoints and their URLs.<!--AC-3002-->
+- Android security updates for January 2025 (see [Android Security Bulletin - January 2025](https://source.android.com/docs/security/bulletin/2025-01-01) for more information).
+- The Android WebView has been updated to 131.0.6778.200.
 
 ## Deprecations
 
@@ -27,7 +27,7 @@ There are no new deprecations announced for 1.24.2. For the list of features or 
 
 The following are known issues with the 1.24.2 release and we are working towards fixing them for the next release:
 
-* The [out-of-band v2](https://documentation.ubuntu.com/anbox-cloud/en/latest/howto/stream/exchange-oob-data/) feature does not work when VM images are in use because of strict system hardening security directives. These directives cause the `anbox-webrtc-data-proxy` unit to fail to start. For more information, see [LP 2093887](https://bugs.launchpad.net/anbox-cloud/+bug/2093887).
+- The [out-of-band v2](https://documentation.ubuntu.com/anbox-cloud/en/latest/howto/stream/exchange-oob-data/) feature does not work when VM images are in use because of strict system hardening security directives. These directives cause the `anbox-webrtc-data-proxy` unit to fail to start. For more information, see [LP 2093887](https://bugs.launchpad.net/anbox-cloud/+bug/2093887).
 
 ## CVEs
 
@@ -67,16 +67,16 @@ The Anbox Cloud 1.24.2 release includes fixes from the respective upstreams and 
 
 The following bugs have been fixed as part of the Anbox Cloud 1.24.2 release.
 
-* [LP 2092393](https://bugs.launchpad.net/anbox-cloud/+bug/2092393) Android system settings are sometimes not persistent after bootstrapping of an application.<!--AC-3049-->
-* [LP 2092447](https://bugs.launchpad.net/anbox-cloud/+bug/2092447) When setting up an ADB connection against local Anbox Cloud appliance using `anbox-connect`, the connection could not be established. This issue occurred sporadically and when it did, the following error could be observed in the `anbox-adb-proxy` system unit:<!--AC-3050-->
+- [LP 2092393](https://bugs.launchpad.net/anbox-cloud/+bug/2092393) Android system settings are sometimes not persistent after bootstrapping of an application.<!--AC-3049-->
+- [LP 2092447](https://bugs.launchpad.net/anbox-cloud/+bug/2092447) When setting up an ADB connection against local Anbox Cloud appliance using `anbox-connect`, the connection could not be established. This issue occurred sporadically and when it did, the following error could be observed in the `anbox-adb-proxy` system unit:<!--AC-3050-->
 
 ```
     Failed to establish peer connection: dial unix /run/user/1000/anbox/adb/data_xxxxxxxxxx: connect: connection refused
 ```
 
-* [LP 2089822](https://bugs.launchpad.net/anbox-cloud/+bug/2089822) Unable to modify the vehicle property value even if the VHAL service implements the Anbox-specific HIDL interface. <!--AC-2994-->
-* [LP 2088310](https://bugs.launchpad.net/anbox-cloud/+bug/2088310) Rendering does not work for AMD and Intel GPUs. For deployments that use AMD GPUs, the instance does not start and for deployments using Intel GPUs, the graphical output is incorrect.<!--AC-2963-->
-* [LP 2089754](https://bugs.launchpad.net/anbox-cloud/+bug/2089754) API documentation is corrected to contain information about the `DELETE /1.0/applications` endpoint.
+- [LP 2089822](https://bugs.launchpad.net/anbox-cloud/+bug/2089822) Unable to modify the vehicle property value even if the VHAL service implements the Anbox-specific HIDL interface. <!--AC-2994-->
+- [LP 2088310](https://bugs.launchpad.net/anbox-cloud/+bug/2088310) Rendering does not work for AMD and Intel GPUs. For deployments that use AMD GPUs, the instance does not start and for deployments using Intel GPUs, the graphical output is incorrect.<!--AC-2963-->
+- [LP 2089754](https://bugs.launchpad.net/anbox-cloud/+bug/2089754) API documentation is corrected to contain information about the `DELETE /1.0/applications` endpoint.
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.25.0.md
+++ b/reference/release-notes/1.25.0.md
@@ -21,54 +21,54 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 ### Anbox Cloud Dashboard
 
-* The dashboard now includes an onboarding tour for new users. Click *Get Started* on the navigation to take the tour.
-* A new *Images* page is included in the Anbox Cloud dashboard so that you can directly add an image or work with the existing images.<!--AC-3001-->
-* Enhancements to the following forms and pages:
-    - *Create Application*
-    - *Edit Application*
-    - *Create Instance*
-    - *Profile*
-    - *Application details*
+- The dashboard now includes an onboarding tour for new users. Click *Get Started* on the navigation to take the tour.
+- A new *Images* page is included in the Anbox Cloud dashboard so that you can directly add an image or work with the existing images.<!--AC-3001-->
+- Enhancements to the following forms and pages:
+  * *Create Application*
+  * *Edit Application*
+  * *Create Instance*
+  * *Profile*
+  * *Application details*
 
 ### AMS
 
-* When querying image related information, you can now see the image variant without waiting for the full image to be downloaded.<!--AC-2987-->
-* The GPU type is included in the AMS node API object, to provide better visibility into hardware specifications.<!--AC-3004-->
+- When querying image related information, you can now see the image variant without waiting for the full image to be downloaded.<!--AC-2987-->
+- The GPU type is included in the AMS node API object, to provide better visibility into hardware specifications.<!--AC-3004-->
 
 ### Stream Gateway
 
-* An administrator can revoke a pre-signed ADB connection URL before it expires, to prevent malicious actions using the command:
+- An administrator can revoke a pre-signed ADB connection URL before it expires, to prevent malicious actions using the command:
 
       anbox-stream-gateway share delete <share_id>
 
 See {ref}`howto-access-android-instance` for more information.<!--AC-3052-->
 
-* You can now update the expiration date, description and the timeout values of a shared session using the command:<!--AC-3053-->
+- You can now update the expiration date, description and the timeout values of a shared session using the command:<!--AC-3053-->
 
         anbox-stream-gateway share update <share_id> --expiry=30m --description=new_description
-* The Stream Gateway now uses the latest [Dqlite LTS version](https://dqlite.io/).<!--AC-2990-->
-* Anbox Cloud uses WebRTC 6778.<!--AC-2904-->
+- The Stream Gateway now uses the latest [Dqlite LTS version](https://dqlite.io/).<!--AC-2990-->
+- Anbox Cloud uses WebRTC 6778.<!--AC-2904-->
 
 ### Monitoring
 
-* A new `/1.0/metrics` endpoint is added to support collecting metrics from the Anbox runtime.<!--AC-3062-->
+- A new `/1.0/metrics` endpoint is added to support collecting metrics from the Anbox runtime.<!--AC-3062-->
 
 ### Other
 
-* Android security updates for February 2025 (see [Android Security Bulletin - February 2025](https://source.android.com/docs/security/bulletin/2025-02-01) for more information).
-* The Android WebView has been updated to 132.0.6834.80.<!--AC-3105-->
+- Android security updates for February 2025 (see [Android Security Bulletin - February 2025](https://source.android.com/docs/security/bulletin/2025-02-01) for more information).
+- The Android WebView has been updated to 132.0.6834.80.<!--AC-3105-->
 
 ## Removed functionality
 
-* Starting with the 1.25.0 release, the appliance snap with `epoch=0` is removed and unsupported. This epoch will no longer receive updates.
+- Starting with the 1.25.0 release, the appliance snap with `epoch=0` is removed and unsupported. This epoch will no longer receive updates.
 To start using the new appliance snap with `epoch=1`, a fresh install of the appliance snap is required.
 
 ## Deprecations
 
 The following deprecations are announced as part of the 1.25.0 release. See {ref}`ref-deprecation-notes` for more information on when the support for these items will be dropped:
 
-* The support for LXD 5.0 snap is deprecated.<!--AC-2734-->
-* The support for kernels older than 6.8 is deprecated.<!--AC-3106-->
+- The support for LXD 5.0 snap is deprecated.<!--AC-2734-->
+- The support for kernels older than 6.8 is deprecated.<!--AC-3106-->
 
 ## CVEs
 
@@ -98,23 +98,23 @@ The Anbox Cloud 1.25.0 release includes fixes from the respective upstreams and 
 
 ## Bug fixes
 
-* [LP 2095559](https://bugs.launchpad.net/anbox-cloud/+bug/2095559) When stopping an instance with GPU slots and starting it later on, the instance fails to start. This issue was caused by multiple GPUs attached to the LXD container interfering with how the Anbox Cloud scripts detect the NVIDIA driver version.<!--AC-3097-->
-* [LP 2095551](https://bugs.launchpad.net/anbox-cloud/+bug/2095551) When creating an application, the `hooks.timeout` property is auto-populated to have an empty value and this causes the operation to fail.<!--AC-3096-->
-* [LP 2095179](https://bugs.launchpad.net/anbox-cloud/+bug/2095179) Unable to log in to the Anbox Cloud dashboard after updating the appliance's network address.<!--AC-3081-->
-* [LP 2089261](https://bugs.launchpad.net/anbox-cloud/+bug/2089261) After restarting the host machine running Anbox Cloud, the instances that have a *running* status need to be restarted. This is due to an issue where the status of the instance in LXD is not in sync with the status in AMS.<!--AC-3077-->
-* [LP 2093887](https://bugs.launchpad.net/anbox-cloud/+bug/2093887) Launching an instance from a `jammy:android12:amd64` VM image floods the journal logs with `Operation not permitted` errors.<!--AC-3067-->
-* [LP 2092193](https://bugs.launchpad.net/anbox-cloud/+bug/2092193) Some Anbox system services take a longer time than usual to get started and show high CPU usage.<!--AC-3048-->
-* [LP 2091921](https://bugs.launchpad.net/anbox-cloud/+bug/2091921) The dashboard generates an `anbox-connect` command on demand, but the connection URL that is displayed as part of the output is not enclosed within quotes, causing issues when copying and running the command in a `fish` shell.
-* [LP 2094279](https://bugs.launchpad.net/anbox-cloud/+bug/2094279) Instance deletion does not happen in the background. When an instance is deleted and you are accessing a stream of a different instance, the streaming web page navigates back to the *Instance* page to confirm the deletion of the other instance.
-* [LP 2086853](https://bugs.launchpad.net/anbox-cloud/+bug/2086853) On all Android versions, irrespective of whether the instance is a container or a VM, taking pictures or videos from the default camera application results in only black and white pictures/videos with software rendering. This issue does not happen with a GPU.
-* [LP 2095568](https://bugs.launchpad.net/anbox-cloud/+bug/2095568) The API swagger documentation states that `/1.0/applications/{id}/manifest GET` states that AMS returns `JSON` when AMS is actually returning an octet-stream.
-* [LP 2096666](https://bugs.launchpad.net/anbox-cloud/+bug/2096666) When using the registration URL for the dashboard more than once, the following error occurs: `Error adding user to database`.
-* [LP 2096982](https://bugs.launchpad.net/anbox-cloud/+bug/2096982) The name for the field that is used to set an expiration timestamp for a session share is inconsistent across the different API requests and responses.
+- [LP 2095559](https://bugs.launchpad.net/anbox-cloud/+bug/2095559) When stopping an instance with GPU slots and starting it later on, the instance fails to start. This issue was caused by multiple GPUs attached to the LXD container interfering with how the Anbox Cloud scripts detect the NVIDIA driver version.<!--AC-3097-->
+- [LP 2095551](https://bugs.launchpad.net/anbox-cloud/+bug/2095551) When creating an application, the `hooks.timeout` property is auto-populated to have an empty value and this causes the operation to fail.<!--AC-3096-->
+- [LP 2095179](https://bugs.launchpad.net/anbox-cloud/+bug/2095179) Unable to log in to the Anbox Cloud dashboard after updating the appliance's network address.<!--AC-3081-->
+- [LP 2089261](https://bugs.launchpad.net/anbox-cloud/+bug/2089261) After restarting the host machine running Anbox Cloud, the instances that have a *running* status need to be restarted. This is due to an issue where the status of the instance in LXD is not in sync with the status in AMS.<!--AC-3077-->
+- [LP 2093887](https://bugs.launchpad.net/anbox-cloud/+bug/2093887) Launching an instance from a `jammy:android12:amd64` VM image floods the journal logs with `Operation not permitted` errors.<!--AC-3067-->
+- [LP 2092193](https://bugs.launchpad.net/anbox-cloud/+bug/2092193) Some Anbox system services take a longer time than usual to get started and show high CPU usage.<!--AC-3048-->
+- [LP 2091921](https://bugs.launchpad.net/anbox-cloud/+bug/2091921) The dashboard generates an `anbox-connect` command on demand, but the connection URL that is displayed as part of the output is not enclosed within quotes, causing issues when copying and running the command in a `fish` shell.
+- [LP 2094279](https://bugs.launchpad.net/anbox-cloud/+bug/2094279) Instance deletion does not happen in the background. When an instance is deleted and you are accessing a stream of a different instance, the streaming web page navigates back to the *Instance* page to confirm the deletion of the other instance.
+- [LP 2086853](https://bugs.launchpad.net/anbox-cloud/+bug/2086853) On all Android versions, irrespective of whether the instance is a container or a VM, taking pictures or videos from the default camera application results in only black and white pictures/videos with software rendering. This issue does not happen with a GPU.
+- [LP 2095568](https://bugs.launchpad.net/anbox-cloud/+bug/2095568) The API swagger documentation states that `/1.0/applications/{id}/manifest GET` states that AMS returns `JSON` when AMS is actually returning an octet-stream.
+- [LP 2096666](https://bugs.launchpad.net/anbox-cloud/+bug/2096666) When using the registration URL for the dashboard more than once, the following error occurs: `Error adding user to database`.
+- [LP 2096982](https://bugs.launchpad.net/anbox-cloud/+bug/2096982) The name for the field that is used to set an expiration timestamp for a session share is inconsistent across the different API requests and responses.
 To avoid confusion, the field naming should be consistent across all requests and responses.
-* [LP 2071806](https://bugs.launchpad.net/anbox-cloud/+bug/2071806) Private bug <!--AC-2629-->
-* [LP 2091609](https://bugs.launchpad.net/anbox-cloud/+bug/2091609) Private bug<!--AC-3046-->
-* [LP 2096628](https://bugs.launchpad.net/anbox-cloud/+bug/2096628) Private bug<!--AC-3099-->
-* [GitHub Issue 251](https://github.com/canonical/anbox-cloud-docs/issues/251) We have updated the prometheus metrics documentation to reflect accurate information.<!--AC-3056-->
+- [LP 2071806](https://bugs.launchpad.net/anbox-cloud/+bug/2071806) Private bug <!--AC-2629-->
+- [LP 2091609](https://bugs.launchpad.net/anbox-cloud/+bug/2091609) Private bug<!--AC-3046-->
+- [LP 2096628](https://bugs.launchpad.net/anbox-cloud/+bug/2096628) Private bug<!--AC-3099-->
+- [GitHub Issue 251](https://github.com/canonical/anbox-cloud-docs/issues/251) We have updated the prometheus metrics documentation to reflect accurate information.<!--AC-3056-->
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.25.1.md
+++ b/reference/release-notes/1.25.1.md
@@ -17,27 +17,27 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 ### Charms
 
-* All our charms are reworked to use the [Operator Framework](https://github.com/canonical/operator). The new charms use different configuration attributes. For more information, see {ref}`ref-charm-configuration`.  
+- All our charms are reworked to use the [Operator Framework](https://github.com/canonical/operator). The new charms use different configuration attributes. For more information, see {ref}`ref-charm-configuration`.  
 
 Starting this release, the default channel for the LXD snap has changed to 5.21/stable. If you are running LXD clusters with the LXD snap tracking a channel which is different than 5.21/stable, it is important to set the charm configuration item `channel` *explicitly* to the currently used channel before scaling up or down.  
 
 The upgrade path for the LXD charm since 1.25.1 is different from the upgrade path in earlier versions. The instructions for both paths are available at {ref}`howto-upgrade-anbox-cloud`.
 
-* The dashboard charm now provides actions for creating and restoring backups of the dashboard data. We will be supporting backup and restore across all charms in the future releases.
-* The AAR charm can now remove client certificates from its trust store when the relation with another charm is removed.
-* Initial support for [Grafana Tempo](https://grafana.com/oss/tempo/) for all Anbox Cloud charms using the `ops` framework.
-* The LXD charm provides the public address of the machine when AMS adds a node, instead of having to explicitly set it through the relation for the AMS charm.
+- The dashboard charm now provides actions for creating and restoring backups of the dashboard data. We will be supporting backup and restore across all charms in the future releases.
+- The AAR charm can now remove client certificates from its trust store when the relation with another charm is removed.
+- Initial support for [Grafana Tempo](https://grafana.com/oss/tempo/) for all Anbox Cloud charms using the `ops` framework.
+- The LXD charm provides the public address of the machine when AMS adds a node, instead of having to explicitly set it through the relation for the AMS charm.
 
 ### Other
 
-* Android security updates for March 2025 (see [Android Security Bulletin - March 2025](https://source.android.com/docs/security/bulletin/2025-03-01)).
-* The Android WebView has been updated to 133.0.6943.121.
+- Android security updates for March 2025 (see [Android Security Bulletin - March 2025](https://source.android.com/docs/security/bulletin/2025-03-01)).
+- The Android WebView has been updated to 133.0.6943.121.
 
 ## Deprecations
 
 The following deprecations are announced as part of the 1.25.1 release. See {ref}`ref-deprecation-notes` for more information on when the support for these items will be dropped:
 
-* Juju 2.9
+- Juju 2.9
 
 ## Known issues
 
@@ -69,20 +69,20 @@ The Anbox Cloud 1.25.1 release includes fixes from the respective upstreams and 
 
 ## Bug fixes
 
-* [LP 2100576](https://bugs.launchpad.net/anbox-cloud/+bug/2100576) If an app was created in a deployment running a version of Anbox Cloud that is earlier than 1.25.0, it couldn't be updated after upgrading to the 1.25.0 version.
-* [LP 2099983](https://bugs.launchpad.net/anbox-cloud/+bug/2099983) Since 1.25.0, Anbox runtime doesn't recognize the metrics server specified in `/var/lib/anbox/session.json`.
-* [LP 2098835](https://bugs.launchpad.net/anbox-cloud/+bug/2098835) With a charmed Anbox Cloud deployment where the AMS charm is upgraded from 1.24.0 to 1.25.0, a `image not found` error occurs when you try to create an application.
-* [LP 2097809](https://bugs.launchpad.net/anbox-cloud/+bug/2097809) The deletion operation for sharing a session doesn't wait for completion.
-* [LP 2097753](https://bugs.launchpad.net/anbox-cloud/+bug/2097753) The charms on the `1.25/beta` channel do not reflect the correct public IP address.
-* [LP 2097743](https://bugs.launchpad.net/anbox-cloud/+bug/2097743) `anbox_sync` kernel module is not loaded by the LXD charm.
-* [LP 2097741](https://bugs.launchpad.net/anbox-cloud/+bug/2097741) Before 1.25.0, the LXD charm had support to set the LXD node's failure domain based on the value of `JUJU_AVAILABILITY_ZONE`. This was not possible with the 1.25.0 charm leading to AMS assuming an incorrect placement of nodes across availability zones and potentially cause unexpected down time.
-* [LP 2097749](https://bugs.launchpad.net/anbox-cloud/+bug/2097749) When AMS is configured by the AAR charm with a certificate and fingerprint for accessing the application registry, it does not internally reload the certificate for validating the AAR endpoint and results in an error.
-* [LP 2097742](https://bugs.launchpad.net/anbox-cloud/+bug/2097742) When cluster members are no longer available, the LXD charm fails to remove them forcefully.
-* [LP 2093904](https://bugs.launchpad.net/anbox-cloud/+bug/2093904) Setting a top or bottom value for the `verticalAlignment` option of the streaming SDK doesn't work as expected.
-* [LP 2077598](https://bugs.launchpad.net/anbox-cloud/+bug/2077598) When the dashboard requests camera access, but no camera is available, the stream stops and the dashboard displays a `camera not found` error.
-* [LP 2091636](https://bugs.launchpad.net/anbox-cloud/+bug/2091636) The example in the AMS API for `/1.0/instances/{id_or_name}/exec` incorrectly shows that the `command` field expects a string while it is actually expecting an array.
-* [LP 2068690](https://bugs.launchpad.net/anbox-cloud/+bug/2068690) Prometheus collects invalid instance boot up times.
-* [LP 2091609](https://bugs.launchpad.net/anbox-cloud/+bug/2091609) Private bug
+- [LP 2100576](https://bugs.launchpad.net/anbox-cloud/+bug/2100576) If an app was created in a deployment running a version of Anbox Cloud that is earlier than 1.25.0, it couldn't be updated after upgrading to the 1.25.0 version.
+- [LP 2099983](https://bugs.launchpad.net/anbox-cloud/+bug/2099983) Since 1.25.0, Anbox runtime doesn't recognize the metrics server specified in `/var/lib/anbox/session.json`.
+- [LP 2098835](https://bugs.launchpad.net/anbox-cloud/+bug/2098835) With a charmed Anbox Cloud deployment where the AMS charm is upgraded from 1.24.0 to 1.25.0, a `image not found` error occurs when you try to create an application.
+- [LP 2097809](https://bugs.launchpad.net/anbox-cloud/+bug/2097809) The deletion operation for sharing a session doesn't wait for completion.
+- [LP 2097753](https://bugs.launchpad.net/anbox-cloud/+bug/2097753) The charms on the `1.25/beta` channel do not reflect the correct public IP address.
+- [LP 2097743](https://bugs.launchpad.net/anbox-cloud/+bug/2097743) `anbox_sync` kernel module is not loaded by the LXD charm.
+- [LP 2097741](https://bugs.launchpad.net/anbox-cloud/+bug/2097741) Before 1.25.0, the LXD charm had support to set the LXD node's failure domain based on the value of `JUJU_AVAILABILITY_ZONE`. This was not possible with the 1.25.0 charm leading to AMS assuming an incorrect placement of nodes across availability zones and potentially cause unexpected down time.
+- [LP 2097749](https://bugs.launchpad.net/anbox-cloud/+bug/2097749) When AMS is configured by the AAR charm with a certificate and fingerprint for accessing the application registry, it does not internally reload the certificate for validating the AAR endpoint and results in an error.
+- [LP 2097742](https://bugs.launchpad.net/anbox-cloud/+bug/2097742) When cluster members are no longer available, the LXD charm fails to remove them forcefully.
+- [LP 2093904](https://bugs.launchpad.net/anbox-cloud/+bug/2093904) Setting a top or bottom value for the `verticalAlignment` option of the streaming SDK doesn't work as expected.
+- [LP 2077598](https://bugs.launchpad.net/anbox-cloud/+bug/2077598) When the dashboard requests camera access, but no camera is available, the stream stops and the dashboard displays a `camera not found` error.
+- [LP 2091636](https://bugs.launchpad.net/anbox-cloud/+bug/2091636) The example in the AMS API for `/1.0/instances/{id_or_name}/exec` incorrectly shows that the `command` field expects a string while it is actually expecting an array.
+- [LP 2068690](https://bugs.launchpad.net/anbox-cloud/+bug/2068690) Prometheus collects invalid instance boot up times.
+- [LP 2091609](https://bugs.launchpad.net/anbox-cloud/+bug/2091609) Private bug
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.25.2.md
+++ b/reference/release-notes/1.25.2.md
@@ -15,7 +15,7 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 ## New features & improvements
 
-* You can now change the authorization for the AMS API after your initialize the appliance with the following commands:
+- You can now change the authorization for the AMS API after your initialize the appliance with the following commands:
 
 For a `sudo` user to authorize and register their UID, run:
 
@@ -34,12 +34,12 @@ To deauthorize and remove a user's UID, run:
 
 ### Other
 
-* Android security updates for April 2025 (see [Android Security Bulletin - April 2025](https://source.android.com/docs/security/bulletin/2025-04-01)).
-* The Android WebView has been updated to 135.0.7049.38.
+- Android security updates for April 2025 (see [Android Security Bulletin - April 2025](https://source.android.com/docs/security/bulletin/2025-04-01)).
+- The Android WebView has been updated to 135.0.7049.38.
 
 ## Known issues
 
-* The fix for [CVE-2025-30215](https://nvd.nist.gov/vuln/detail/CVE-2025-30215) is not included in this release.
+- The fix for [CVE-2025-30215](https://nvd.nist.gov/vuln/detail/CVE-2025-30215) is not included in this release.
 
 ## CVEs
 
@@ -85,13 +85,13 @@ cherry-picking the commits to CVEs tagged with *Critical* severity from the upst
 
 ## Bug fixes
 
-* [LP 2103746](https://bugs.launchpad.net/anbox-cloud/+bug/2103746) AMS provides a *panic* warning because of a concurrent write to the WebSocket connection.
-* [LP 2103485](https://bugs.launchpad.net/anbox-cloud/+bug/2103485) Links to some charms on the [Charmhub page for the Anbox Cloud Core bundle](https://charmhub.io/anbox-cloud-core?channel=1.25/stable) are broken and the bundle does not deploy correctly.
-* [LP 2101806](https://bugs.launchpad.net/anbox-cloud/+bug/2101806) Two different images have the same size when they should have been of different sizes.
-* [LP 2105468](https://bugs.launchpad.net/anbox-cloud/+bug/2105468) When deploying the AMS with `prometheus_extra_labels` configured, the AMS unit ends up with an error status.
-* [LP 2106349](https://bugs.launchpad.net/anbox-cloud/+bug/2106349) When a user deploys AMS and AAR using a single `juju deploy` command, Juju deploys them at the same time. However, this results in AMS running into a hook error while AAR is deployed properly.
-* [LP 2106384](https://bugs.launchpad.net/anbox-cloud/+bug/2106384) Sporadically, the Anbox stream gateway gets stuck with `Waiting for certificates` status.
-* [LP 2091609](https://bugs.launchpad.net/anbox-cloud/+bug/2091609) Private bug
+- [LP 2103746](https://bugs.launchpad.net/anbox-cloud/+bug/2103746) AMS provides a *panic* warning because of a concurrent write to the WebSocket connection.
+- [LP 2103485](https://bugs.launchpad.net/anbox-cloud/+bug/2103485) Links to some charms on the [Charmhub page for the Anbox Cloud Core bundle](https://charmhub.io/anbox-cloud-core?channel=1.25/stable) are broken and the bundle does not deploy correctly.
+- [LP 2101806](https://bugs.launchpad.net/anbox-cloud/+bug/2101806) Two different images have the same size when they should have been of different sizes.
+- [LP 2105468](https://bugs.launchpad.net/anbox-cloud/+bug/2105468) When deploying the AMS with `prometheus_extra_labels` configured, the AMS unit ends up with an error status.
+- [LP 2106349](https://bugs.launchpad.net/anbox-cloud/+bug/2106349) When a user deploys AMS and AAR using a single `juju deploy` command, Juju deploys them at the same time. However, this results in AMS running into a hook error while AAR is deployed properly.
+- [LP 2106384](https://bugs.launchpad.net/anbox-cloud/+bug/2106384) Sporadically, the Anbox stream gateway gets stuck with `Waiting for certificates` status.
+- [LP 2091609](https://bugs.launchpad.net/anbox-cloud/+bug/2091609) Private bug
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.26.0.md
+++ b/reference/release-notes/1.26.0.md
@@ -17,48 +17,48 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 ### Deployment and Operations
 
-* You can now deploy Anbox Cloud using a reference Terraform plan in non-production environments. See {ref}`howto-deploy-anbox-terraform` for detailed instructions. It is worth noting that this is an alpha release of the Terraform plan and that it is not meant for production environments.
-* To allow open source charms better integrate with our charms, we no longer block the installation of snaps within the charms if your Ubuntu Pro token in not attached. The deployment will proceed with a warning instead of failing. However, remember that without attaching an Ubuntu Pro token, you won't be able to access images when the deployment is complete.<!--AC-3308-->
-* The Anbox Cloud charms now have support for Ubuntu 24.04 LTS (Noble Numbat).
-* For the appliance deployment, service restarts now ask for your confirmation, unless you are using non-interactive mode. If you are using non-interactive mode, use the `--no-restart` flag to disable automatic restart of AMS and other required services.<!--AC-3283-->
-* Appliance initialization now gives clearer guidance on acceptable block devices.<!--AC-3321-->
-* If you use Juju 3.0 or later for your deployment, confidential data like private keys, API tokens, credentials managed by a charm, credentials passed between different charms via [Juju relations](https://documentation.ubuntu.com/juju/latest/reference/relation/) is securely managed using [Juju secrets](https://documentation.ubuntu.com/juju/latest/reference/secret/).
+- You can now deploy Anbox Cloud using a reference Terraform plan in non-production environments. See {ref}`howto-deploy-anbox-terraform` for detailed instructions. It is worth noting that this is an alpha release of the Terraform plan and that it is not meant for production environments.
+- To allow open source charms better integrate with our charms, we no longer block the installation of snaps within the charms if your Ubuntu Pro token in not attached. The deployment will proceed with a warning instead of failing. However, remember that without attaching an Ubuntu Pro token, you won't be able to access images when the deployment is complete.<!--AC-3308-->
+- The Anbox Cloud charms now have support for Ubuntu 24.04 LTS (Noble Numbat).
+- For the appliance deployment, service restarts now ask for your confirmation, unless you are using non-interactive mode. If you are using non-interactive mode, use the `--no-restart` flag to disable automatic restart of AMS and other required services.<!--AC-3283-->
+- Appliance initialization now gives clearer guidance on acceptable block devices.<!--AC-3321-->
+- If you use Juju 3.0 or later for your deployment, confidential data like private keys, API tokens, credentials managed by a charm, credentials passed between different charms via [Juju relations](https://documentation.ubuntu.com/juju/latest/reference/relation/) is securely managed using [Juju secrets](https://documentation.ubuntu.com/juju/latest/reference/secret/).
 
 ### Instance management
 
-* You can now specify your GPU type when launching an instance by using the `--gpu-type` flag (Possible values:`amd`, `intel`, `nvidia`).<!--AC-3259-->
-* Default version for NVIDIA driver is 570.<!--AC-3246-->
-* AMS can now automatically determine if the instance is based on an application or an image. So you don't have to use the `--raw` flag every time you launch an instance based on an image. Using `amc launch <image_name>` should launch the corresponding instance automatically.<!--AC-3192-->
+- You can now specify your GPU type when launching an instance by using the `--gpu-type` flag (Possible values:`amd`, `intel`, `nvidia`).<!--AC-3259-->
+- Default version for NVIDIA driver is 570.<!--AC-3246-->
+- AMS can now automatically determine if the instance is based on an application or an image. So you don't have to use the `--raw` flag every time you launch an instance based on an image. Using `amc launch <image_name>` should launch the corresponding instance automatically.<!--AC-3192-->
 
 ### Logging
 
-* The Anbox log level can be changed at runtime using the [Anbox HTTP API](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/anbox-https-api/). This is helpful in situations when you want to avoid a restart of the Anbox runtime.<!--AC-3183-->
+- The Anbox log level can be changed at runtime using the [Anbox HTTP API](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/anbox-https-api/). This is helpful in situations when you want to avoid a restart of the Anbox runtime.<!--AC-3183-->
 
 ### Dashboard enhancements
 
 We have the following enhancements to the Anbox Cloud dashboard:
 
-* Overhaul of the registry page
-* Customization of instance resources including CPU, GPU, memory
-* Authentication using Keycloak and Hydra. See {ref}`howto-set-up-idp` for setup instructions.
-* Ability to revoke of a session share via ADB and also extend the validity of a share.
-* Notifications via websockets providing a reliable way to notify about asynchronous operations.
+- Overhaul of the registry page
+- Customization of instance resources including CPU, GPU, memory
+- Authentication using Keycloak and Hydra. See {ref}`howto-set-up-idp` for setup instructions.
+- Ability to revoke of a session share via ADB and also extend the validity of a share.
+- Notifications via websockets providing a reliable way to notify about asynchronous operations.
 
 ### Images
 
-* VM images now use hardware enablement kernels.<!--AC-3304-->
-* With this release, Android 15 (AOSP and AAOS) images are available.
-* Unused packages including `netcat-openbsd`, `xxd`, `cron` are removed from Android images.<!--AC-3158-->
+- VM images now use hardware enablement kernels.<!--AC-3304-->
+- With this release, Android 15 (AOSP and AAOS) images are available.
+- Unused packages including `netcat-openbsd`, `xxd`, `cron` are removed from Android images.<!--AC-3158-->
 
 ### Streaming
 
-* We have upgraded to use the WebRTC revision 7049.<!--AC-3310-->
-* You can now explicitly disable certain video codecs (AV1, H264, VP8) even if they are supported by the client. Use the `video.disabled_codecs` option in the {ref}`WebRTC streamer configuration file <ref-webrtc>`.<!--AC-3314-->
+- We have upgraded to use the WebRTC revision 7049.<!--AC-3310-->
+- You can now explicitly disable certain video codecs (AV1, H264, VP8) even if they are supported by the client. Use the `video.disabled_codecs` option in the {ref}`WebRTC streamer configuration file <ref-webrtc>`.<!--AC-3314-->
 
 ### Other
 
-* Android security updates for May 2025 (see [Android Security Bulletin - May 2025](https://source.android.com/docs/security/bulletin/2025-05-01)).<!--AC-3176-->
-* The Android WebView has been updated to [136.0.7103.60](https://chromereleases.googleblog.com/2025/04/chrome-for-android-update_29.html).<!--AC-3316-->
+- Android security updates for May 2025 (see [Android Security Bulletin - May 2025](https://source.android.com/docs/security/bulletin/2025-05-01)).<!--AC-3176-->
+- The Android WebView has been updated to [136.0.7103.60](https://chromereleases.googleblog.com/2025/04/chrome-for-android-update_29.html).<!--AC-3316-->
 
 ## Deprecations
 
@@ -68,9 +68,9 @@ The [AMS node controller charm](https://charmhub.io/ams-node-controller) is depr
 
 The following issues exist in the 1.26.0 release and we are working to fix them for the 1.26.1 patch release:
 
-* A `program was killed: context canceled` error occurs during appliance initialization even though all services are active. ([LP 2110321](https://bugs.launchpad.net/anbox-cloud/+bug/2110321)).
-* Security patch level for AOSP 15 and AAOS 15 remains unchanged at `2025-05-05` despite applying the latest security patches.([LP 2110323](https://bugs.launchpad.net/anbox-cloud/+bug/2110323)).
-* Unable to stream an instance after deploying the regular Anbox Cloud using Juju([LP 2110194](https://bugs.launchpad.net/anbox-cloud/+bug/2110194)). This issues exists since the 1.25.0 release. Run the following command to work around this issue:
+- A `program was killed: context canceled` error occurs during appliance initialization even though all services are active. ([LP 2110321](https://bugs.launchpad.net/anbox-cloud/+bug/2110321)).
+- Security patch level for AOSP 15 and AAOS 15 remains unchanged at `2025-05-05` despite applying the latest security patches.([LP 2110323](https://bugs.launchpad.net/anbox-cloud/+bug/2110323)).
+- Unable to stream an instance after deploying the regular Anbox Cloud using Juju([LP 2110194](https://bugs.launchpad.net/anbox-cloud/+bug/2110194)). This issues exists since the 1.25.0 release. Run the following command to work around this issue:
 
     ```
     juju ssh anbox-cloud-dashboard/0 -- "sudo sed -i '/^ASG_API_SERVER_CERTIFICATE: /d' /var/snap/anbox-cloud-dashboard/common/service/config.yaml"
@@ -125,14 +125,14 @@ The Anbox Cloud 1.26.0 release includes fixes from the respective upstreams and 
 
 ## Bug fixes
 
-* [LP 2107357](https://bugs.launchpad.net/anbox-cloud/+bug/2107357) The image size for a new image version is displayed incorrectly.
-* [LP 2109318](https://bugs.launchpad.net/anbox-cloud/+bug/2109318) A segmentation fault was discovered in anbox-connect when trying to connect anbox instance.
-* [LP 2106422](https://bugs.launchpad.net/anbox-cloud/+bug/2106422) `anbox-fs` randomly fails at startup on instances.
-* [LP 2101030](https://bugs.launchpad.net/anbox-cloud/+bug/2101030) Telegraf unable to handle `anbox_webrtc_frame_renderer_pending_buffers`.
-* [LP 2106106](https://bugs.launchpad.net/anbox-cloud/+bug/2106106) Feature flags that have a `.` character in the name are not allowed in the dashboard.
-* [LP 2109582](https://bugs.launchpad.net/anbox-cloud/+bug/2109582) When removing a node, the hook fails because of a certificate not found error. When Juju reruns the hook, no issues occur.
-* [LP 2106447](https://bugs.launchpad.net/anbox-cloud/+bug/2106447) Private bug
-* [LP 2108221](https://bugs.launchpad.net/anbox-cloud/+bug/2108221) Private bug
+- [LP 2107357](https://bugs.launchpad.net/anbox-cloud/+bug/2107357) The image size for a new image version is displayed incorrectly.
+- [LP 2109318](https://bugs.launchpad.net/anbox-cloud/+bug/2109318) A segmentation fault was discovered in anbox-connect when trying to connect anbox instance.
+- [LP 2106422](https://bugs.launchpad.net/anbox-cloud/+bug/2106422) `anbox-fs` randomly fails at startup on instances.
+- [LP 2101030](https://bugs.launchpad.net/anbox-cloud/+bug/2101030) Telegraf unable to handle `anbox_webrtc_frame_renderer_pending_buffers`.
+- [LP 2106106](https://bugs.launchpad.net/anbox-cloud/+bug/2106106) Feature flags that have a `.` character in the name are not allowed in the dashboard.
+- [LP 2109582](https://bugs.launchpad.net/anbox-cloud/+bug/2109582) When removing a node, the hook fails because of a certificate not found error. When Juju reruns the hook, no issues occur.
+- [LP 2106447](https://bugs.launchpad.net/anbox-cloud/+bug/2106447) Private bug
+- [LP 2108221](https://bugs.launchpad.net/anbox-cloud/+bug/2108221) Private bug
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.26.1.md
+++ b/reference/release-notes/1.26.1.md
@@ -19,9 +19,9 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 ## New features & improvements
 
-* The [HAProxy charm](https://charmhub.io/haproxy) now is also deployed on Ubuntu 22.04 LTS. This helps us offer the charm with the same Ubuntu version as the other charms that are part of the Anbox Cloud bundle.<!--AC-3329-->
-* Android security updates for June 2025 (see [Android Security Bulletin - June 2025](https://source.android.com/docs/security/bulletin/2025-06-01)).
-* The Android WebView has been updated to [136.0.7103.60](https://chromereleases.googleblog.com/2025/04/chrome-for-android-update_29.html).<!--AC-3316-->
+- The [HAProxy charm](https://charmhub.io/haproxy) now is also deployed on Ubuntu 22.04 LTS. This helps us offer the charm with the same Ubuntu version as the other charms that are part of the Anbox Cloud bundle.<!--AC-3329-->
+- Android security updates for June 2025 (see [Android Security Bulletin - June 2025](https://source.android.com/docs/security/bulletin/2025-06-01)).
+- The Android WebView has been updated to [136.0.7103.60](https://chromereleases.googleblog.com/2025/04/chrome-for-android-update_29.html).<!--AC-3316-->
 
 ## CVEs
 
@@ -50,43 +50,43 @@ This release includes fixes from the respective upstreams and components for the
 
 The following bugs were fixed as part of the 1.26.1 release:
 
-* [LP 2106113](https://bugs.launchpad.net/anbox-cloud/+bug/2106113) There were two commands in AMC that looked similar but had different purposes - `show-log` and `logs`. This was confusing about when to use these commands. The help text is now clarified to facilitate better understanding that `show-logs` is to obtain logs from an instance that is stopped or in an error state while `logs` is to obtain logs from a started or a running instance.<!--AC-3293-->
-* [LP 2111893](https://bugs.launchpad.net/anbox-cloud/+bug/2111893) Stream can not be initiated due to intermittent TLS handshake failures.
-* [LP 2100933](https://bugs.launchpad.net/anbox-cloud/+bug/2100933) AMS HTTP API documentation was missing information regarding the `/1.0/registry` endpoints.
-* [LP 2097511](https://bugs.launchpad.net/anbox-cloud/+bug/2097511) The `minidumper` thread in the Anbox runtime is responsible for handling crashes in the Anbox runtime. When profiling, this thread was seen consuming excess CPU time even when a crash had not been detected yet.<!--AC-3330-->
-* [LP 2106104](https://bugs.launchpad.net/anbox-cloud/+bug/2106104) The appliance initialization fails on a new machine that has an NVIDIA GPU but the driver is not yet installed. You see the following error when you try to initialize the appliance:<!--AC-3332-->
+- [LP 2106113](https://bugs.launchpad.net/anbox-cloud/+bug/2106113) There were two commands in AMC that looked similar but had different purposes - `show-log` and `logs`. This was confusing about when to use these commands. The help text is now clarified to facilitate better understanding that `show-logs` is to obtain logs from an instance that is stopped or in an error state while `logs` is to obtain logs from a started or a running instance.<!--AC-3293-->
+- [LP 2111893](https://bugs.launchpad.net/anbox-cloud/+bug/2111893) Stream can not be initiated due to intermittent TLS handshake failures.
+- [LP 2100933](https://bugs.launchpad.net/anbox-cloud/+bug/2100933) AMS HTTP API documentation was missing information regarding the `/1.0/registry` endpoints.
+- [LP 2097511](https://bugs.launchpad.net/anbox-cloud/+bug/2097511) The `minidumper` thread in the Anbox runtime is responsible for handling crashes in the Anbox runtime. When profiling, this thread was seen consuming excess CPU time even when a crash had not been detected yet.<!--AC-3330-->
+- [LP 2106104](https://bugs.launchpad.net/anbox-cloud/+bug/2106104) The appliance initialization fails on a new machine that has an NVIDIA GPU but the driver is not yet installed. You see the following error when you try to initialize the appliance:<!--AC-3332-->
 
         Error: failed to parse NVIDIA driver version: strconv.ParseUint: parsing "": invalid syntax
-* [LP 2111486](https://bugs.launchpad.net/anbox-cloud/+bug/2111486) The LXD charm was updated recently to avoid queries to the snap store to get the version information when the snap is already installed. Instead, the charm retrieves the necessary snap information using `snap list`.
+- [LP 2111486](https://bugs.launchpad.net/anbox-cloud/+bug/2111486) The LXD charm was updated recently to avoid queries to the snap store to get the version information when the snap is already installed. Instead, the charm retrieves the necessary snap information using `snap list`.
 However, the lookup sometimes fails and falls back to querying the snap store. This results in timeout exceptions from time to time, especially when a snap proxy is configured behind the store.<!--AC-3364-->
 
 <!-- vale off -->
-* [LP 2106114](https://bugs.launchpad.net/anbox-cloud/+bug/2106114) When you attempt to rotate the screen from portrait to landscape by setting `user_rotation` using `adb`, there is no error observed but the screen does not rotate for AOSP images. It works as expected for AAOS images, though.<!--AC-3370-->
+- [LP 2106114](https://bugs.launchpad.net/anbox-cloud/+bug/2106114) When you attempt to rotate the screen from portrait to landscape by setting `user_rotation` using `adb`, there is no error observed but the screen does not rotate for AOSP images. It works as expected for AAOS images, though.<!--AC-3370-->
   <!-- vale on -->
-* [LP 2106106](https://bugs.launchpad.net/anbox-cloud/+bug/2106106) Feature flags with a `.` in the name were not validated properly and displayed the following error:
+- [LP 2106106](https://bugs.launchpad.net/anbox-cloud/+bug/2106106) Feature flags with a `.` in the name were not validated properly and displayed the following error:
 
         This field should be a comma separated list of words
 
-* [LP 2111555](https://bugs.launchpad.net/anbox-cloud/+bug/2111555) If the database leadership within the LXD cluster changes during the interval between two `update-status` hook runs, the reported status could be outdated.
+- [LP 2111555](https://bugs.launchpad.net/anbox-cloud/+bug/2111555) If the database leadership within the LXD cluster changes during the interval between two `update-status` hook runs, the reported status could be outdated.
 This leads to temporarily incorrect status displays and could lead to decisions that may adversely impact your cluster. For example, if you decide a unit is not the database leader based on the status output and remove it, you could unintentionally be removing the actual database leader.
-* [LP 2111597](https://bugs.launchpad.net/anbox-cloud/+bug/2111597) The *Settings* app crashes on Android 15 images when trying to access the *Accessibility* settings or the *Connected devices* section. This crash was caused because Anbox Cloud does not support Bluetooth.
+- [LP 2111597](https://bugs.launchpad.net/anbox-cloud/+bug/2111597) The *Settings* app crashes on Android 15 images when trying to access the *Accessibility* settings or the *Connected devices* section. This crash was caused because Anbox Cloud does not support Bluetooth.
 
 **The following bugs were known issues in 1.26.0 and are fixed with this release:**
 
-* [LP 2110194](https://bugs.launchpad.net/anbox-cloud/+bug/2110194) An instance could not be streamed after deploying Anbox Cloud using charms. You see the following error when trying to stream an instance using the dashboard:<!--AC-3335-->
+- [LP 2110194](https://bugs.launchpad.net/anbox-cloud/+bug/2110194) An instance could not be streamed after deploying Anbox Cloud using charms. You see the following error when trying to stream an instance using the dashboard:<!--AC-3335-->
 
     Anbox stream failed
     connector failed to connect: Cannot read properties of undefined (reading 'stun_servers')
 This was a known issue from 1.25.0 till 1.26.0 release due to an invalid certificate used by the dashboard. Streaming did not work until the stream was edited, the invalid certificate removed, and the dashboard restarted.
-* [LP 2110321](https://bugs.launchpad.net/anbox-cloud/+bug/2110321) There was a misleading error `program was killed: context canceled` after initializing the appliance. This error is misleading because you see it even when the initialization was successful and all services were active.<!--AC-3371-->
-* [LP 2110323](https://bugs.launchpad.net/anbox-cloud/+bug/2110323) For the 1.26.0 release, the security patch level was not updated to the correct date even after the necessary security patches were applied for Android 15.
+- [LP 2110321](https://bugs.launchpad.net/anbox-cloud/+bug/2110321) There was a misleading error `program was killed: context canceled` after initializing the appliance. This error is misleading because you see it even when the initialization was successful and all services were active.<!--AC-3371-->
+- [LP 2110323](https://bugs.launchpad.net/anbox-cloud/+bug/2110323) For the 1.26.0 release, the security patch level was not updated to the correct date even after the necessary security patches were applied for Android 15.
 
 (known-issues)=
 ## Known issues
 
 The following known issues exist in Anbox Cloud and are planned to be fixed in subsequent releases:
 
-* [LP 2114950](https://bugs.launchpad.net/anbox-cloud/+bug/2114950) Even when the screen orientation is changed by the Android application, the device's [runtime configuration](https://developer.android.com/guide/topics/resources/runtime-changes) does not change. To work around this issue until a fix is available, [create an addon](https://documentation.ubuntu.com/anbox-cloud/howto/addons/create-addon/) with a pre-start [hook](https://documentation.ubuntu.com/anbox-cloud/reference/hooks/) containing the following script that clears the display settings causing the issue and use the addon in your application:
+- [LP 2114950](https://bugs.launchpad.net/anbox-cloud/+bug/2114950) Even when the screen orientation is changed by the Android application, the device's [runtime configuration](https://developer.android.com/guide/topics/resources/runtime-changes) does not change. To work around this issue until a fix is available, [create an addon](https://documentation.ubuntu.com/anbox-cloud/howto/addons/create-addon/) with a pre-start [hook](https://documentation.ubuntu.com/anbox-cloud/reference/hooks/) containing the following script that clears the display settings causing the issue and use the addon in your application:
 
 ```
 #!/bin/bash -ex
@@ -103,7 +103,7 @@ if [[ $ANBOX_VERSION == "1.26.1" ]] ; then
 fi
 ```
 
-* [LP 2113771](https://bugs.launchpad.net/anbox-cloud/+bug/2113771) This issue and workaround are applicable only when upgrading from 1.26.0 to 1.26.1. When upgrading charms from 1.26.0 to 1.26.1, the AMS node controller ends up in an error state. You don't have to worry about this as the AMS node controller is deprecated since 1.26.0 and the port forwarding is instead done by LXD.
+- [LP 2113771](https://bugs.launchpad.net/anbox-cloud/+bug/2113771) This issue and workaround are applicable only when upgrading from 1.26.0 to 1.26.1. When upgrading charms from 1.26.0 to 1.26.1, the AMS node controller ends up in an error state. You don't have to worry about this as the AMS node controller is deprecated since 1.26.0 and the port forwarding is instead done by LXD.
 
 We suggest the following workaround for this issue until it is fixed:
 
@@ -135,9 +135,9 @@ Reapply the port configuration if a port range was specified for the LXD charm:
 
         juju config lxd exposed_instance_ports=<port_range>
 
-* [LP 2112098](https://bugs.launchpad.net/anbox-cloud/+bug/2112098) While upgrading from 1.25.2 to 1.26.0, the dashboard displays the error `Ubuntu Pro token is not attached` even when the Ubuntu Pro token is already attached. This error is misleading and can be ignored. You can run `pro status` if you still wish to confirm.
-* [LP 2111598](https://bugs.launchpad.net/anbox-cloud/+bug/2111598) For instances with NVIDIA GPUs, opening the *System* section of the *Settings* app in Android 15 with developer settings enabled, causes the app to crash.
-* [LP 2112542](https://bugs.launchpad.net/anbox-cloud/+bug/2112542) Occasionally, when creating or deleting instances in a quick succession, an instance doesn't start. Instead, you see this error:
+- [LP 2112098](https://bugs.launchpad.net/anbox-cloud/+bug/2112098) While upgrading from 1.25.2 to 1.26.0, the dashboard displays the error `Ubuntu Pro token is not attached` even when the Ubuntu Pro token is already attached. This error is misleading and can be ignored. You can run `pro status` if you still wish to confirm.
+- [LP 2111598](https://bugs.launchpad.net/anbox-cloud/+bug/2111598) For instances with NVIDIA GPUs, opening the *System* section of the *Settings* app in Android 15 with developer settings enabled, causes the app to crash.
+- [LP 2112542](https://bugs.launchpad.net/anbox-cloud/+bug/2112542) Occasionally, when creating or deleting instances in a quick succession, an instance doesn't start. Instead, you see this error:
 
         Failed start validation for device "eth0": IP address "192.168.96.5" already defined on another NIC
 

--- a/reference/release-notes/1.26.2.md
+++ b/reference/release-notes/1.26.2.md
@@ -15,8 +15,8 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 ## Release updates
 
-* The [Android Security Bulletin - July 2025](https://source.android.com/docs/security/bulletin/2025-07-01) notes that there are no Android security patches for this month.
-* The Android WebView has been updated to [138.0.7204.63](https://chromereleases.googleblog.com/2025/06/chrome-for-android-update_30.html).
+- The [Android Security Bulletin - July 2025](https://source.android.com/docs/security/bulletin/2025-07-01) notes that there are no Android security patches for this month.
+- The Android WebView has been updated to [138.0.7204.63](https://chromereleases.googleblog.com/2025/06/chrome-for-android-update_30.html).
 
 ## CVEs
 
@@ -30,13 +30,13 @@ This release includes fixes from the respective upstreams and components for the
 
 The following bug fixes are available as part of this release:
 
-* [LP 2115297](https://bugs.launchpad.net/anbox-cloud/+bug/2115297) After upgrading to version 1.26.0 or later, streaming a session did not work for deployments with an NVIDIA GPU.
-* [LP 2114967](https://bugs.launchpad.net/anbox-cloud/+bug/2114967) With multiple Android users, setting [`enable_virtual_keyboard`](https://documentation.ubuntu.com/anbox-cloud/reference/feature-flags/#enable-virtual-keyboard) or [`enable_anbox_ime`](https://documentation.ubuntu.com/anbox-cloud/reference/feature-flags/#enable-anbox-ime) feature flags fails. When set, the feature will be enabled, but starting Anbox results in a timeout the values are not set for the correct user.
-* [LP 2114227](https://bugs.launchpad.net/anbox-cloud/+bug/2114227) When deploying with Terraform, when the Anbox kernel modules package is installed, an Ubuntu Pro token is required. However, attaching an Ubuntu Pro token is no longer mandatory to complete the deployment.
-* [LP 2115938](https://bugs.launchpad.net/anbox-cloud/+bug/2115938) When joining an existing session, if the resolution has width or height as an odd number, the session is aborted and the Anbox instance end up with an error status.
+- [LP 2115297](https://bugs.launchpad.net/anbox-cloud/+bug/2115297) After upgrading to version 1.26.0 or later, streaming a session did not work for deployments with an NVIDIA GPU.
+- [LP 2114967](https://bugs.launchpad.net/anbox-cloud/+bug/2114967) With multiple Android users, setting [`enable_virtual_keyboard`](https://documentation.ubuntu.com/anbox-cloud/reference/feature-flags/#enable-virtual-keyboard) or [`enable_anbox_ime`](https://documentation.ubuntu.com/anbox-cloud/reference/feature-flags/#enable-anbox-ime) feature flags fails. When set, the feature will be enabled, but starting Anbox results in a timeout the values are not set for the correct user.
+- [LP 2114227](https://bugs.launchpad.net/anbox-cloud/+bug/2114227) When deploying with Terraform, when the Anbox kernel modules package is installed, an Ubuntu Pro token is required. However, attaching an Ubuntu Pro token is no longer mandatory to complete the deployment.
+- [LP 2115938](https://bugs.launchpad.net/anbox-cloud/+bug/2115938) When joining an existing session, if the resolution has width or height as an odd number, the session is aborted and the Anbox instance end up with an error status.
 This issue occurs only when the [join API](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/gateway-api/#/session/handle-join-session) is used with a resolution that has width or height as an odd number.
-* [LP 2112351](https://bugs.launchpad.net/anbox-cloud/+bug/2112351) The deployment fails with the LXD unit in error status. If you run `juju status`, you could see an error similar to: `unit-lxd/0* error idle hook failed: "config-changed"`.
-* Dashboard bug fixes:
+- [LP 2112351](https://bugs.launchpad.net/anbox-cloud/+bug/2112351) The deployment fails with the LXD unit in error status. If you run `juju status`, you could see an error similar to: `unit-lxd/0* error idle hook failed: "config-changed"`.
+- Dashboard bug fixes:
   * [LP 2101043](https://bugs.launchpad.net/anbox-cloud/+bug/2101043) The dashboard's *Images* page displayed a misaligned pagination footer.
   * [LP 2112098](https://bugs.launchpad.net/anbox-cloud/+bug/2112098) While upgrading from 1.25.2 to 1.26.0, the dashboard displays the error `Ubuntu Pro token is not attached` even when the Ubuntu Pro token is already attached.
   * [LP 2112538](https://bugs.launchpad.net/anbox-cloud/+bug/2112538) When using Firefox, the dashboard's *Statistics* page does not show any RTT time.
@@ -47,12 +47,12 @@ This issue occurs only when the [join API](https://documentation.ubuntu.com/anbo
 
 **The following bugs were known issues in 1.26.1 and are fixed with this release:**
 
-* [LP 2112542](https://bugs.launchpad.net/anbox-cloud/+bug/2112542) Occasionally, when creating or deleting instances in a quick succession, an instance doesn't start. Instead, you see this error:
+- [LP 2112542](https://bugs.launchpad.net/anbox-cloud/+bug/2112542) Occasionally, when creating or deleting instances in a quick succession, an instance doesn't start. Instead, you see this error:
 
         Failed start validation for device "eth0": IP address "192.168.96.5" already defined on another NIC
 
-* [LP 2114950](https://bugs.launchpad.net/anbox-cloud/+bug/2114950) Even when the screen orientation is changed by the Android application, the device's [runtime configuration](https://developer.android.com/guide/topics/resources/runtime-changes) does not change.
-* [LP 2113771](https://bugs.launchpad.net/anbox-cloud/+bug/2113771) When upgrading charms from 1.26.0 to 1.26.1, the AMS node controller ends up in an error state.
+- [LP 2114950](https://bugs.launchpad.net/anbox-cloud/+bug/2114950) Even when the screen orientation is changed by the Android application, the device's [runtime configuration](https://developer.android.com/guide/topics/resources/runtime-changes) does not change.
+- [LP 2113771](https://bugs.launchpad.net/anbox-cloud/+bug/2113771) When upgrading charms from 1.26.0 to 1.26.1, the AMS node controller ends up in an error state.
 
 ## Known issues
 

--- a/reference/release-notes/1.27.0.md
+++ b/reference/release-notes/1.27.0.md
@@ -25,17 +25,17 @@ For command line clients, this feature is an alpha release and still in active d
 
 ### Dashboard
 
-* System administrators have a new *Operations* page to monitor all asynchronous, long-running operations. This page provides all information that you can obtain when running `amc operation ls`.
-* A notification center that displays queued notifications is available. These notifications are persistent until dismissed and can be filtered.
+- System administrators have a new *Operations* page to monitor all asynchronous, long-running operations. This page provides all information that you can obtain when running `amc operation ls`.
+- A notification center that displays queued notifications is available. These notifications are persistent until dismissed and can be filtered.
 
 ### Other
 
-* The Android WebView has been updated to [138.0.7204.179](https://chromereleases.googleblog.com/2025/07/chrome-for-android-update_29.html).
+- The Android WebView has been updated to [138.0.7204.179](https://chromereleases.googleblog.com/2025/07/chrome-for-android-update_29.html).
 
 ## Deprecations and removed functionality
 
-* Support for Juju 2.9 was deprecated in 1.25.1 and is removed with this release. Instead, upgrade to the latest Juju version, 3.6. See {ref}`sec-juju-version-requirements` for more information.
-* Support for kernels older than 6.8 was deprecated in 1.25.0 and is removed with this release.
+- Support for Juju 2.9 was deprecated in 1.25.1 and is removed with this release. Instead, upgrade to the latest Juju version, 3.6. See {ref}`sec-juju-version-requirements` for more information.
+- Support for kernels older than 6.8 was deprecated in 1.25.0 and is removed with this release.
 
 ## Known issues
 
@@ -58,15 +58,15 @@ We assessed the following CVEs from the `2025-08-01` patch level for their sever
 
 ## Bug fixes
 
-* [LP 2110219](https://bugs.launchpad.net/anbox-cloud/+bug/2110219) When running an Anbox instance with an NVIDIA GPU and utilizing it for rendering and video encoding, the `lxcfs` process on the host shows an unusually high CPU consumption (~60% for a single Anbox instance).
-* [LP 2113943](https://bugs.launchpad.net/anbox-cloud/+bug/2113943) Easy-RSA does not handle URLs with protocols correctly.
-* [LP 2116159](https://bugs.launchpad.net/anbox-cloud/+bug/2116159) At times, setting the AMS config `cpu.limit_mode` to `scheduler` prevents instances from starting.
-* [LP 2117094](https://bugs.launchpad.net/anbox-cloud/+bug/2117094) For Android 15, trying to access developer options in the *Settings* app causes an OS-level crash.
-* [LP 2097514](https://bugs.launchpad.net/anbox-cloud/+bug/2097514) When using the Android 14 images, trying to reset mobile network settings causes an OS-level crash.
-* [LP 2112562](https://bugs.launchpad.net/anbox-cloud/+bug/2112562) A crash in the hardware composer causes the Android system to restart.
-* [LP 2117082](https://bugs.launchpad.net/anbox-cloud/+bug/2117082) The `/1.0/shares` GET endpoint of {term}`Stream gateway` API supports a `session_id` query parameter that is currently not documented.
-* [LP 2101035](https://bugs.launchpad.net/anbox-cloud/+bug/2101035) Newly created instances are not on the top of the instance list, making it hard to find them.
-* [LP 2101036](https://bugs.launchpad.net/anbox-cloud/+bug/2101036) The dashboard UI did not allow few operations to be opened in a separate browser tab.
+- [LP 2110219](https://bugs.launchpad.net/anbox-cloud/+bug/2110219) When running an Anbox instance with an NVIDIA GPU and utilizing it for rendering and video encoding, the `lxcfs` process on the host shows an unusually high CPU consumption (~60% for a single Anbox instance).
+- [LP 2113943](https://bugs.launchpad.net/anbox-cloud/+bug/2113943) Easy-RSA does not handle URLs with protocols correctly.
+- [LP 2116159](https://bugs.launchpad.net/anbox-cloud/+bug/2116159) At times, setting the AMS config `cpu.limit_mode` to `scheduler` prevents instances from starting.
+- [LP 2117094](https://bugs.launchpad.net/anbox-cloud/+bug/2117094) For Android 15, trying to access developer options in the *Settings* app causes an OS-level crash.
+- [LP 2097514](https://bugs.launchpad.net/anbox-cloud/+bug/2097514) When using the Android 14 images, trying to reset mobile network settings causes an OS-level crash.
+- [LP 2112562](https://bugs.launchpad.net/anbox-cloud/+bug/2112562) A crash in the hardware composer causes the Android system to restart.
+- [LP 2117082](https://bugs.launchpad.net/anbox-cloud/+bug/2117082) The `/1.0/shares` GET endpoint of {term}`Stream gateway` API supports a `session_id` query parameter that is currently not documented.
+- [LP 2101035](https://bugs.launchpad.net/anbox-cloud/+bug/2101035) Newly created instances are not on the top of the instance list, making it hard to find them.
+- [LP 2101036](https://bugs.launchpad.net/anbox-cloud/+bug/2101036) The dashboard UI did not allow few operations to be opened in a separate browser tab.
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.27.1.md
+++ b/reference/release-notes/1.27.1.md
@@ -15,8 +15,8 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 ## New features & improvements
 
-* Android security updates for September 2025 (see [Android Security Bulletin - September 2025](https://source.android.com/docs/security/bulletin/2025-09-01)).
-* The Android WebView has been updated to [140.0.7339.51](https://chromereleases.googleblog.com/2025/09/chrome-beta-for-android-update.html).
+- Android security updates for September 2025 (see [Android Security Bulletin - September 2025](https://source.android.com/docs/security/bulletin/2025-09-01)).
+- The Android WebView has been updated to [140.0.7339.51](https://chromereleases.googleblog.com/2025/09/chrome-beta-for-android-update.html).
 
 ## Deprecations and removed functionality
 
@@ -145,20 +145,20 @@ The fixes for the following CVEs are included with the 1.27.1 release:
 
 ## Bug fixes
 
-* [LP 2119495](https://bugs.launchpad.net/anbox-cloud/+bug/2119495) Changing screen resolution causes significant video stutter.
-* [LP 2121502](https://bugs.launchpad.net/anbox-cloud/+bug/2121502) With recent support for OIDC authentication, running `amc exec` causes AMC to crash.
-* [LP 2121526](https://bugs.launchpad.net/anbox-cloud/+bug/2121526) If an instance is being scheduled on a particular node, the worker node in AMS will stop scheduling it . If the scheduling happens while a node is temporarily off but the worker is running, the AMS worker becomes blocked until AMS is restarted.
-* [LP 2097515](https://bugs.launchpad.net/anbox-cloud/+bug/2097515) The `SyncSensor` thread is using up more than necessary CPU resources.
-* [LP 2119723](https://bugs.launchpad.net/anbox-cloud/+bug/2119723) While trying to delete an identity, AMC asks the user to confirm the deletion and then fails with a `not found` error. AMC doesn't verify if the identity existed before confirming whether to delete it.
-* [LP 2119726](https://bugs.launchpad.net/anbox-cloud/+bug/2119726) The email address value for OIDC identities is not properly validated.
-* [LP 2120611](https://bugs.launchpad.net/anbox-cloud/+bug/2120611) Watchdog was triggered when launching 1.27.0 images.
-* [LP 2119279](https://bugs.launchpad.net/anbox-cloud/+bug/2119279) After restarting the AMS service, the metrics for number of containers in error status (`ams_cluster_containers_per_status_total{status="error"}`) will disappear for some time while the other metrics are available.
-* [LP 2120677](https://bugs.launchpad.net/anbox-cloud/+bug/2120677) On a machine with the `nouveau` driver installed and loaded, running the appliance prepare-node-script fails with a return code of 6. Rebooting fixes the problem, and the rest of the appliance can be initialized without any issue.
-* [LP 2115864](https://bugs.launchpad.net/anbox-cloud/+bug/2115864) Responsiveness of the dashboard's side navigation when resizing windows is not good.
-* [LP 2119724](https://bugs.launchpad.net/anbox-cloud/+bug/2119724) The dashboard interface does not have a separator between the profile button and other buttons so that the action buttons can be viewed clearly.
-* [LP 2119036](https://bugs.launchpad.net/anbox-cloud/+bug/2119036) The [Anbox Stream Gateway API for ADB shares GET call](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/gateway-api/#/share/handle-get-shares) is incorrect.
-* [LP 2109658](https://bugs.launchpad.net/anbox-cloud/+bug/2109658) Private bug
-* [LP 2118370](https://bugs.launchpad.net/anbox-cloud/+bug/2118370) Private bug
+- [LP 2119495](https://bugs.launchpad.net/anbox-cloud/+bug/2119495) Changing screen resolution causes significant video stutter.
+- [LP 2121502](https://bugs.launchpad.net/anbox-cloud/+bug/2121502) With recent support for OIDC authentication, running `amc exec` causes AMC to crash.
+- [LP 2121526](https://bugs.launchpad.net/anbox-cloud/+bug/2121526) If an instance is being scheduled on a particular node, the worker node in AMS will stop scheduling it . If the scheduling happens while a node is temporarily off but the worker is running, the AMS worker becomes blocked until AMS is restarted.
+- [LP 2097515](https://bugs.launchpad.net/anbox-cloud/+bug/2097515) The `SyncSensor` thread is using up more than necessary CPU resources.
+- [LP 2119723](https://bugs.launchpad.net/anbox-cloud/+bug/2119723) While trying to delete an identity, AMC asks the user to confirm the deletion and then fails with a `not found` error. AMC doesn't verify if the identity existed before confirming whether to delete it.
+- [LP 2119726](https://bugs.launchpad.net/anbox-cloud/+bug/2119726) The email address value for OIDC identities is not properly validated.
+- [LP 2120611](https://bugs.launchpad.net/anbox-cloud/+bug/2120611) Watchdog was triggered when launching 1.27.0 images.
+- [LP 2119279](https://bugs.launchpad.net/anbox-cloud/+bug/2119279) After restarting the AMS service, the metrics for number of containers in error status (`ams_cluster_containers_per_status_total{status="error"}`) will disappear for some time while the other metrics are available.
+- [LP 2120677](https://bugs.launchpad.net/anbox-cloud/+bug/2120677) On a machine with the `nouveau` driver installed and loaded, running the appliance prepare-node-script fails with a return code of 6. Rebooting fixes the problem, and the rest of the appliance can be initialized without any issue.
+- [LP 2115864](https://bugs.launchpad.net/anbox-cloud/+bug/2115864) Responsiveness of the dashboard's side navigation when resizing windows is not good.
+- [LP 2119724](https://bugs.launchpad.net/anbox-cloud/+bug/2119724) The dashboard interface does not have a separator between the profile button and other buttons so that the action buttons can be viewed clearly.
+- [LP 2119036](https://bugs.launchpad.net/anbox-cloud/+bug/2119036) The [Anbox Stream Gateway API for ADB shares GET call](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/gateway-api/#/share/handle-get-shares) is incorrect.
+- [LP 2109658](https://bugs.launchpad.net/anbox-cloud/+bug/2109658) Private bug
+- [LP 2118370](https://bugs.launchpad.net/anbox-cloud/+bug/2118370) Private bug
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.27.2.md
+++ b/reference/release-notes/1.27.2.md
@@ -15,7 +15,7 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 ## New features & improvements
 
-* The Android WebView has been updated to [141.0.7390.70](https://chromereleases.googleblog.com/2025/10/chrome-for-android-update.html).
+- The Android WebView has been updated to [141.0.7390.70](https://chromereleases.googleblog.com/2025/10/chrome-for-android-update.html).
 
 ## Deprecations and removed functionality
 
@@ -40,13 +40,13 @@ The fixes for the following CVEs are included with the 1.27.2 release:
 
 ## Bug fixes
 
-* [LP 2125636](https://bugs.launchpad.net/anbox-cloud/+bug/2125636) The Grafana dashboard for Anbox Cloud does not display information for some panels.
-* [LP 2125640](https://bugs.launchpad.net/anbox-cloud/+bug/2125640) Running `amc benchmark` with `--fps` results in a segmentation fault (SIGSEGV panic).
-* [LP 2125643](https://bugs.launchpad.net/anbox-cloud/+bug/2125643) When integrating Canonical Observability Stack (COS) with Anbox Stream Gateway, an alert "failed to scrape" is always triggered and metrics aren't scraped.
-* [LP 2116925](https://bugs.launchpad.net/anbox-cloud/+bug/2116925) The Android security patch level for the 1.26.2 candidate image is incorrect even though the latest security patches were included.
-* [LP 2122012](https://bugs.launchpad.net/anbox-cloud/+bug/2122012) Load balancer does not work with Coturn on Google Cloud.
-* [LP 2122028](https://bugs.launchpad.net/anbox-cloud/+bug/2122028) When streaming from a GPU instance on Google Cloud, streaming fails and the error `Invalid codec for media type video` is displayed.
-* [LP 2125961](https://bugs.launchpad.net/anbox-cloud/+bug/2125961) Private bug
+- [LP 2125636](https://bugs.launchpad.net/anbox-cloud/+bug/2125636) The Grafana dashboard for Anbox Cloud does not display information for some panels.
+- [LP 2125640](https://bugs.launchpad.net/anbox-cloud/+bug/2125640) Running `amc benchmark` with `--fps` results in a segmentation fault (SIGSEGV panic).
+- [LP 2125643](https://bugs.launchpad.net/anbox-cloud/+bug/2125643) When integrating Canonical Observability Stack (COS) with Anbox Stream Gateway, an alert "failed to scrape" is always triggered and metrics aren't scraped.
+- [LP 2116925](https://bugs.launchpad.net/anbox-cloud/+bug/2116925) The Android security patch level for the 1.26.2 candidate image is incorrect even though the latest security patches were included.
+- [LP 2122012](https://bugs.launchpad.net/anbox-cloud/+bug/2122012) Load balancer does not work with Coturn on Google Cloud.
+- [LP 2122028](https://bugs.launchpad.net/anbox-cloud/+bug/2122028) When streaming from a GPU instance on Google Cloud, streaming fails and the error `Invalid codec for media type video` is displayed.
+- [LP 2125961](https://bugs.launchpad.net/anbox-cloud/+bug/2125961) Private bug
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.28.0.md
+++ b/reference/release-notes/1.28.0.md
@@ -53,18 +53,18 @@ sensor: {
 
 ### Other
 
-* The Android WebView has been updated to [142.0.7444.48](https://chromereleases.googleblog.com/2025/10/chrome-beta-for-android-update_22.html).
+- The Android WebView has been updated to [142.0.7444.48](https://chromereleases.googleblog.com/2025/10/chrome-beta-for-android-update_22.html).
 
 ## Deprecations
 
 The 1.28.0 release deprecates the following artifacts. These artifacts will become unsupported starting with the 1.30.0 release.
 
-* [Anbox Cloud](https://charmhub.io/anbox-cloud) and [Anbox Cloud Core](https://charmhub.io/anbox-cloud-core)  bundles
-* VM images of Anbox Cloud
+- [Anbox Cloud](https://charmhub.io/anbox-cloud) and [Anbox Cloud Core](https://charmhub.io/anbox-cloud-core)  bundles
+- VM images of Anbox Cloud
 
 ## Removed functionality
 
-* Support for the [AMS node controller charm](https://charmhub.io/ams-node-controller) is removed in 1.28.0. The `ams-lxd` charm will install the AMS node controller going forward.
+- Support for the [AMS node controller charm](https://charmhub.io/ams-node-controller) is removed in 1.28.0. The `ams-lxd` charm will install the AMS node controller going forward.
 
 ## Known issues
 
@@ -74,23 +74,23 @@ The security patch from Android for CVE-2025-48593 is not included in this relea
 
 ## Bug fixes
 
-* [LP 2101034](https://bugs.launchpad.net/anbox-cloud/+bug/2101034) VM images are listed in the dashboard view even though the server does not support them.
-* [LP 2122020](https://bugs.launchpad.net/anbox-cloud/+bug/2122020) Occasionally, images fail to download on a freshly deployed appliance and end up in the error state with the error: `Alias "ams-<id>-0" already exists`.
-* [LP 2126748](https://bugs.launchpad.net/anbox-cloud/+bug/2126748) Running `amc auth group show <group_name>` does not display the identities in the group.
-* [LP 2126776](https://bugs.launchpad.net/anbox-cloud/+bug/2126776) The GET `/1.0/auth/identities` endpoint does not return a name even when the identity provider configuration has users with a name added to their profile.
-* [LP 2129004](https://bugs.launchpad.net/anbox-cloud/+bug/2129004) AMS does not recognize already trusted servers even when the server certificates are available in the local trust store.
-* [LP 2115863](https://bugs.launchpad.net/anbox-cloud/+bug/2115863) The dashboard does not render the streaming page correctly, this issue can be noticed after saving changes to the VHAL properties while keeping the *Developer tools* terminal open. This issue can be noticed on both Firefox and Chrome browsers.
-* [LP 2119444](https://bugs.launchpad.net/anbox-cloud/+bug/2119444) When having some latency with the server, the dashboard may show a spurious error message that an instance with the name already exists. This error message is seen only for a split second, and appears even though no instance with the same name exists.
-* [LP 2123900](https://bugs.launchpad.net/anbox-cloud/+bug/2123900) When `prepare-node-script` runs and `nvidia-smi` fails, the script does not indicate whether it succeeded unless we check the exit code.
-* [LP 1983428](https://bugs.launchpad.net/anbox-cloud/+bug/1983428) Unable to simulate SMS messaging on Android.
-* [LP 2101032](https://bugs.launchpad.net/anbox-cloud/+bug/2101032) The *Create* button in the instance creation view continuously toggles between enabled and disabled states when typing the instance name.
-* [LP 2101037](https://bugs.launchpad.net/anbox-cloud/+bug/2101037) We can customize the disk size when creating an instance but afterwards there is no way of checking the information in the *Instance detail* page.
-* [LP 2101048](https://bugs.launchpad.net/anbox-cloud/+bug/2101048) Dashboard does not handle invalid tokens gracefully and instead shows a full stack trace when an invalid token is given.
-* [LP 2112536](https://bugs.launchpad.net/anbox-cloud/+bug/2112536) When creating an instance in the dashboard, the instance details validation flickers when changing the selected image in the dropdown.
-* [LP 2115867](https://bugs.launchpad.net/anbox-cloud/+bug/2115867) In the dashboard, edit mode does not reset when you change your search query in the *Configuration* page.
-* [LP 2119727](https://bugs.launchpad.net/anbox-cloud/+bug/2119727) In the *Instances* page of the dashboard, the *Start* button is still enabled for instances in the "prepared" status.
-* [LP 2123913](https://bugs.launchpad.net/anbox-cloud/+bug/2123913) Private bug
-* [LP 2127959](https://bugs.launchpad.net/anbox-cloud/+bug/2127959) Private bug
+- [LP 2101034](https://bugs.launchpad.net/anbox-cloud/+bug/2101034) VM images are listed in the dashboard view even though the server does not support them.
+- [LP 2122020](https://bugs.launchpad.net/anbox-cloud/+bug/2122020) Occasionally, images fail to download on a freshly deployed appliance and end up in the error state with the error: `Alias "ams-<id>-0" already exists`.
+- [LP 2126748](https://bugs.launchpad.net/anbox-cloud/+bug/2126748) Running `amc auth group show <group_name>` does not display the identities in the group.
+- [LP 2126776](https://bugs.launchpad.net/anbox-cloud/+bug/2126776) The GET `/1.0/auth/identities` endpoint does not return a name even when the identity provider configuration has users with a name added to their profile.
+- [LP 2129004](https://bugs.launchpad.net/anbox-cloud/+bug/2129004) AMS does not recognize already trusted servers even when the server certificates are available in the local trust store.
+- [LP 2115863](https://bugs.launchpad.net/anbox-cloud/+bug/2115863) The dashboard does not render the streaming page correctly, this issue can be noticed after saving changes to the VHAL properties while keeping the *Developer tools* terminal open. This issue can be noticed on both Firefox and Chrome browsers.
+- [LP 2119444](https://bugs.launchpad.net/anbox-cloud/+bug/2119444) When having some latency with the server, the dashboard may show a spurious error message that an instance with the name already exists. This error message is seen only for a split second, and appears even though no instance with the same name exists.
+- [LP 2123900](https://bugs.launchpad.net/anbox-cloud/+bug/2123900) When `prepare-node-script` runs and `nvidia-smi` fails, the script does not indicate whether it succeeded unless we check the exit code.
+- [LP 1983428](https://bugs.launchpad.net/anbox-cloud/+bug/1983428) Unable to simulate SMS messaging on Android.
+- [LP 2101032](https://bugs.launchpad.net/anbox-cloud/+bug/2101032) The *Create* button in the instance creation view continuously toggles between enabled and disabled states when typing the instance name.
+- [LP 2101037](https://bugs.launchpad.net/anbox-cloud/+bug/2101037) We can customize the disk size when creating an instance but afterwards there is no way of checking the information in the *Instance detail* page.
+- [LP 2101048](https://bugs.launchpad.net/anbox-cloud/+bug/2101048) Dashboard does not handle invalid tokens gracefully and instead shows a full stack trace when an invalid token is given.
+- [LP 2112536](https://bugs.launchpad.net/anbox-cloud/+bug/2112536) When creating an instance in the dashboard, the instance details validation flickers when changing the selected image in the dropdown.
+- [LP 2115867](https://bugs.launchpad.net/anbox-cloud/+bug/2115867) In the dashboard, edit mode does not reset when you change your search query in the *Configuration* page.
+- [LP 2119727](https://bugs.launchpad.net/anbox-cloud/+bug/2119727) In the *Instances* page of the dashboard, the *Start* button is still enabled for instances in the "prepared" status.
+- [LP 2123913](https://bugs.launchpad.net/anbox-cloud/+bug/2123913) Private bug
+- [LP 2127959](https://bugs.launchpad.net/anbox-cloud/+bug/2127959) Private bug
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.28.1.md
+++ b/reference/release-notes/1.28.1.md
@@ -15,9 +15,9 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 ## New features & improvements
 
-* The [LXD charm](https://charmhub.io/ams-lxd) in Anbox Cloud can be configured to use [Ceph storage](https://ceph.io/en/) in addition to the default local storage options. This helps deployments that require shared storage, improved scalability and better resource utilization.
-* Android security updates for December 2025 (see [Android Security Bulletin - December 2025](https://source.android.com/docs/security/bulletin/2025-12-01)).
-* The Android WebView has been updated to [143.0.7499.52](https://chromereleases.googleblog.com/2025/12/chrome-for-android-update.html).
+- The [LXD charm](https://charmhub.io/ams-lxd) in Anbox Cloud can be configured to use [Ceph storage](https://ceph.io/en/) in addition to the default local storage options. This helps deployments that require shared storage, improved scalability and better resource utilization.
+- Android security updates for December 2025 (see [Android Security Bulletin - December 2025](https://source.android.com/docs/security/bulletin/2025-12-01)).
+- The Android WebView has been updated to [143.0.7499.52](https://chromereleases.googleblog.com/2025/12/chrome-for-android-update.html).
 
 ## Known issues
 
@@ -115,10 +115,10 @@ The fixes for the following CVEs are included with the 1.28.1 release:
 
 ## Bug fixes
 
-* [LP 2127155](https://bugs.launchpad.net/anbox-cloud/+bug/2127155) Streaming an Android 15 instance gets disrupted unexpectedly with the instance in an error state. You might see an Android runtime error with a message similar to `Abort message: 'trackInputEvent: device 'anbox-pointer' received invalid EV_ABS event code: ABS_X value: 359`.
-* [LP 2130609](https://bugs.launchpad.net/anbox-cloud/+bug/2130609) AMS instance metrics are incorrect for the number of containers per node.
-* [LP 2131645](https://bugs.launchpad.net/anbox-cloud/+bug/2131645) When configuring the Anbox Application Registry (AAR), after an update to an application-level field in the app metadata, the application metadata remains outdated even after the updated application is pushed to the registry by the publisher.
-* [LP 2123735](https://bugs.launchpad.net/anbox-cloud/+bug/2123735) Instance name is not validated before download the corresponding image.
+- [LP 2127155](https://bugs.launchpad.net/anbox-cloud/+bug/2127155) Streaming an Android 15 instance gets disrupted unexpectedly with the instance in an error state. You might see an Android runtime error with a message similar to `Abort message: 'trackInputEvent: device 'anbox-pointer' received invalid EV_ABS event code: ABS_X value: 359`.
+- [LP 2130609](https://bugs.launchpad.net/anbox-cloud/+bug/2130609) AMS instance metrics are incorrect for the number of containers per node.
+- [LP 2131645](https://bugs.launchpad.net/anbox-cloud/+bug/2131645) When configuring the Anbox Application Registry (AAR), after an update to an application-level field in the app metadata, the application metadata remains outdated even after the updated application is pushed to the registry by the publisher.
+- [LP 2123735](https://bugs.launchpad.net/anbox-cloud/+bug/2123735) Instance name is not validated before download the corresponding image.
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.28.2.md
+++ b/reference/release-notes/1.28.2.md
@@ -15,7 +15,7 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 ## New features & improvements
 
-* The Android WebView has been updated to [144.0.7559.76](https://chromereleases.googleblog.com/2026/01/chrome-for-android-update_14.html).
+- The Android WebView has been updated to [144.0.7559.76](https://chromereleases.googleblog.com/2026/01/chrome-for-android-update_14.html).
 
 ## Deprecations and removed functionality
 
@@ -36,10 +36,10 @@ The fixes for the following CVEs are included with the 1.28.2 release:
 
 ## Bug fixes
 
-* [LP 2135083](https://bugs.launchpad.net/anbox-cloud/+bug/2135083) Ubuntu Pro token is not attached - anbox-cloud-terraform
-* [LP 2129036](https://bugs.launchpad.net/anbox-cloud/+bug/2129036) Removing anbox-stream-agent unit will remove the agent related ams config
-* [LP 2129717](https://bugs.launchpad.net/anbox-cloud/+bug/2129717) When assigning permissions on objects only ids can be used
-* [LP 2137106](https://bugs.launchpad.net/anbox-cloud/+bug/2137106) A FATAL EXCEPTION: `java.lang.IllegalArgumentException`: `subscriptionId` 1 is not in the list of valid subscriptions was raised during Android 14 boot
+- [LP 2135083](https://bugs.launchpad.net/anbox-cloud/+bug/2135083) Ubuntu Pro token is not attached - anbox-cloud-terraform
+- [LP 2129036](https://bugs.launchpad.net/anbox-cloud/+bug/2129036) Removing anbox-stream-agent unit will remove the agent related ams config
+- [LP 2129717](https://bugs.launchpad.net/anbox-cloud/+bug/2129717) When assigning permissions on objects only ids can be used
+- [LP 2137106](https://bugs.launchpad.net/anbox-cloud/+bug/2137106) A FATAL EXCEPTION: `java.lang.IllegalArgumentException`: `subscriptionId` 1 is not in the list of valid subscriptions was raised during Android 14 boot
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.29.0.md
+++ b/reference/release-notes/1.29.0.md
@@ -36,8 +36,8 @@ The AMS scheduler now uses a two-tier disk quota validation to prevent 'false ex
 Since the 1.29 release, Anbox Cloud deployment has migrated its dependencies from legacy charms to modernized ones.
 This includes:
 
-* Support [charmed-etcd](https://charmhub.io/charmed-etcd) to replace the legacy etcd charm.
-* Replaced easyrsa with the self-signed-certificates charm.
+- Support [charmed-etcd](https://charmhub.io/charmed-etcd) to replace the legacy etcd charm.
+- Replaced easyrsa with the self-signed-certificates charm.
 Also following this change, the base for Anbox Cloud deployment has been upgraded to Ubuntu 24.04 LTS.
 
 ### Fine grained authorization
@@ -46,9 +46,9 @@ This release introduces [fine-grained authorization](https://documentation.ubunt
 
 ### Other
 
-* The Android WebView has been updated to [145.0.7632.26](https://chromereleases.googleblog.com/2026/01/chrome-for-android-update_01981585122.html).
-* The WebRTC version has been updated to [7499](https://chromium.googlesource.com/chromium/src.git/+log/refs/branch-heads/7499).
-* Anbox Cloud continues to require NVIDIA driver series 570 for deployments using NVIDIA GPUs.
+- The Android WebView has been updated to [145.0.7632.26](https://chromereleases.googleblog.com/2026/01/chrome-for-android-update_01981585122.html).
+- The WebRTC version has been updated to [7499](https://chromium.googlesource.com/chromium/src.git/+log/refs/branch-heads/7499).
+- Anbox Cloud continues to require NVIDIA driver series 570 for deployments using NVIDIA GPUs.
 Although driver series 570 is end-of-life, newer driver series (including 580) are currently not yet supported and may not function correctly on some GPUs.
 
 ### Legacy Charm deprecation
@@ -74,10 +74,10 @@ The fixes for the following CVEs are included with the 1.29.0 release:
 
 ## Bug fixes
 
-* [LP 2133137](https://bugs.launchpad.net/anbox-cloud/+bug/2133137) better handling of location value in anbox-cloud-dashboard charm
-* [LP 2137635](https://bugs.launchpad.net/anbox-cloud/+bug/2137635) Stale entitlements prevent adding additional permissions to groups
-* [LP 2137713](https://bugs.launchpad.net/anbox-cloud/+bug/2137713) Delete group button not accessible via keyboard
-* [LP 2133867](https://bugs.launchpad.net/anbox-cloud/+bug/2133867) Missing documentation about application version initialization and its effect on the application status
+- [LP 2133137](https://bugs.launchpad.net/anbox-cloud/+bug/2133137) better handling of location value in anbox-cloud-dashboard charm
+- [LP 2137635](https://bugs.launchpad.net/anbox-cloud/+bug/2137635) Stale entitlements prevent adding additional permissions to groups
+- [LP 2137713](https://bugs.launchpad.net/anbox-cloud/+bug/2137713) Delete group button not accessible via keyboard
+- [LP 2133867](https://bugs.launchpad.net/anbox-cloud/+bug/2133867) Missing documentation about application version initialization and its effect on the application status
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.29.1.md
+++ b/reference/release-notes/1.29.1.md
@@ -15,7 +15,7 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 ## New features & improvements
 
-* The Android WebView has been updated to [146.0.7680.65](https://chromereleases.googleblog.com/2026/03/chrome-for-android-update_5.html).
+- The Android WebView has been updated to [146.0.7680.65](https://chromereleases.googleblog.com/2026/03/chrome-for-android-update_5.html).
 
 ## Deprecations and removed functionality
 
@@ -23,7 +23,7 @@ There are no deprecations or removal of support for features in this release.
 
 ## Known issues
 
-* [LP 2144724](https://bugs.launchpad.net/anbox-cloud/+bug/2144724) Image name not showing on instance page edit
+- [LP 2144724](https://bugs.launchpad.net/anbox-cloud/+bug/2144724) Image name not showing on instance page edit
 
 See our [open bugs in Launchpad](https://bugs.launchpad.net/anbox-cloud/+bugs?field.searchtext=&orderby=-importance&field.status%3Alist=NEW&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.status%3Alist=INPROGRESS&field.status%3Alist=INCOMPLETE_WITH_RESPONSE&field.status%3Alist=INCOMPLETE_WITHOUT_RESPONSE&assignee_option=any&field.assignee=&field.bug_reporter=&field.bug_commenter=&field.subscriber=&field.structural_subscriber=&field.tag=&field.tags_combinator=ANY&field.has_cve.used=&field.omit_dupes.used=&field.omit_dupes=on&field.affects_me.used=&field.has_patch.used=&field.has_branches.used=&field.has_branches=on&field.has_no_branches.used=&field.has_no_branches.on&search=Search).
 
@@ -80,11 +80,11 @@ The fixes for the following CVEs are included with the 1.29.1 release:
 
 ## Bug fixes
 
-* [LP 2141804](https://bugs.launchpad.net/anbox-cloud/+bug/2141804) Deleting a non-existent instance returns 403
-* [LP 2133868](https://bugs.launchpad.net/anbox-cloud/+bug/2133868) Application version gets created twice when changing base image
-* [LP 2138856](https://bugs.launchpad.net/anbox-cloud/+bug/2138856) The accumulation of leftover artifact files has exhausted the disk space
-* [LP 2142017](https://bugs.launchpad.net/anbox-cloud/+bug/2142017) Inverted colors in stream for instances using AOSP images
-* [LP 2142088](https://bugs.launchpad.net/anbox-cloud/+bug/2142088) Publish button is enabled when instance not ready
+- [LP 2141804](https://bugs.launchpad.net/anbox-cloud/+bug/2141804) Deleting a non-existent instance returns 403
+- [LP 2133868](https://bugs.launchpad.net/anbox-cloud/+bug/2133868) Application version gets created twice when changing base image
+- [LP 2138856](https://bugs.launchpad.net/anbox-cloud/+bug/2138856) The accumulation of leftover artifact files has exhausted the disk space
+- [LP 2142017](https://bugs.launchpad.net/anbox-cloud/+bug/2142017) Inverted colors in stream for instances using AOSP images
+- [LP 2142088](https://bugs.launchpad.net/anbox-cloud/+bug/2142088) Publish button is enabled when instance not ready
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.29.2.md
+++ b/reference/release-notes/1.29.2.md
@@ -15,7 +15,7 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 ## New features & improvements
 
-* The Android WebView has been updated to [147.0.7727.49](https://chromereleases.googleblog.com/2026/04/chrome-for-android-update_8.html).
+- The Android WebView has been updated to [147.0.7727.49](https://chromereleases.googleblog.com/2026/04/chrome-for-android-update_8.html).
 
 ## Deprecations and removed functionality
 
@@ -48,14 +48,14 @@ The fixes for the following CVEs are included with the 1.29.2 release:
 ## Bug fixes
 
 <!-- List Bugs fixed in 1.29.2 here -->
-* [LP 2141268](https://bugs.launchpad.net/anbox-cloud/+bug/2141268) Support of open driver modules for AWS EC2 instance types with new GPUs
-* [LP 2144724](https://bugs.launchpad.net/anbox-cloud/+bug/2144724) Image Name not showing on Instance page
-* [LP 2143714](https://bugs.launchpad.net/anbox-cloud/+bug/2143714) Not possible to pro enable anbox due to missing Resolute package
-* [LP 2143876](https://bugs.launchpad.net/anbox-cloud/+bug/2143876) Issues when updating cert in Anbox Cloud dashboard
-* [LP 2145173](https://bugs.launchpad.net/anbox-cloud/+bug/2145173) amc shell and amc exec only work on the first AMS node
-* [LP 2145197](https://bugs.launchpad.net/anbox-cloud/+bug/2145197) Cannot list images in ams
-* [LP 2146988](https://bugs.launchpad.net/anbox-cloud/+bug/2146988) Anbox-cloud-dashboard fails to validate the AMS certificate through a pass-through load-balancer
-* [LP 2143306](https://bugs.launchpad.net/anbox-cloud/+bug/2143306) Instance should fail to start if the version of the application/image it is based on has been deleted
+- [LP 2141268](https://bugs.launchpad.net/anbox-cloud/+bug/2141268) Support of open driver modules for AWS EC2 instance types with new GPUs
+- [LP 2144724](https://bugs.launchpad.net/anbox-cloud/+bug/2144724) Image Name not showing on Instance page
+- [LP 2143714](https://bugs.launchpad.net/anbox-cloud/+bug/2143714) Not possible to pro enable anbox due to missing Resolute package
+- [LP 2143876](https://bugs.launchpad.net/anbox-cloud/+bug/2143876) Issues when updating cert in Anbox Cloud dashboard
+- [LP 2145173](https://bugs.launchpad.net/anbox-cloud/+bug/2145173) amc shell and amc exec only work on the first AMS node
+- [LP 2145197](https://bugs.launchpad.net/anbox-cloud/+bug/2145197) Cannot list images in ams
+- [LP 2146988](https://bugs.launchpad.net/anbox-cloud/+bug/2146988) Anbox-cloud-dashboard fails to validate the AMS certificate through a pass-through load-balancer
+- [LP 2143306](https://bugs.launchpad.net/anbox-cloud/+bug/2143306) Instance should fail to start if the version of the application/image it is based on has been deleted
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.3.0.md
+++ b/reference/release-notes/1.3.0.md
@@ -5,18 +5,18 @@ orphan: true
 
 ## New features & improvements
 
-* Images are now only distributed via the official image server and no longer available for download
-* The application registry received a dedicated CLI command to manage trusted clients
-* A dedicated charm now takes care of deploying the Anbox Application Registry
-* The disk space available to a container was reduced from 5GB to 3GB for all instance types
-* Android ANR and tombstone crash logs are now pulled from a container when it fails at runtime or on startup
-* Gamepad support was added to Anbox and the Platform SDK
-* Sensor support was added to Anbox and the Platform SDK
-* AMS now supports marking a single image as the default one which will be used if no other is specified for raw container launches or applications
-* Initial support for event monitoring of the AMS service via `amc monitor` and the REST API
-* The `swrast` platform is now part of the default image and doesn't need to be installed via an addon
-* The `binder` and `ashmem` kernel modules are now supported on the HWE 5.0 kernel coming with Ubuntu 18.04.3
-* Services a container provides can now be named to help identifying them
-* The Android container is now further secured with a more narrow [`seccomp`](https://www.kernel.org/doc/Documentation/prctl/seccomp_filter.txt) profile than the outer Anbox container.
-* Addons can now declare that they add support for specific Android ABIs not supported by the hardware via software based binary translation
-* Integrated Android security fixes until July 2019. See the [Android Security Bulletins](https://source.android.com/security/bulletin) for more information.
+- Images are now only distributed via the official image server and no longer available for download
+- The application registry received a dedicated CLI command to manage trusted clients
+- A dedicated charm now takes care of deploying the Anbox Application Registry
+- The disk space available to a container was reduced from 5GB to 3GB for all instance types
+- Android ANR and tombstone crash logs are now pulled from a container when it fails at runtime or on startup
+- Gamepad support was added to Anbox and the Platform SDK
+- Sensor support was added to Anbox and the Platform SDK
+- AMS now supports marking a single image as the default one which will be used if no other is specified for raw container launches or applications
+- Initial support for event monitoring of the AMS service via `amc monitor` and the REST API
+- The `swrast` platform is now part of the default image and doesn't need to be installed via an addon
+- The `binder` and `ashmem` kernel modules are now supported on the HWE 5.0 kernel coming with Ubuntu 18.04.3
+- Services a container provides can now be named to help identifying them
+- The Android container is now further secured with a more narrow [`seccomp`](https://www.kernel.org/doc/Documentation/prctl/seccomp_filter.txt) profile than the outer Anbox container.
+- Addons can now declare that they add support for specific Android ABIs not supported by the hardware via software based binary translation
+- Integrated Android security fixes until July 2019. See the [Android Security Bulletins](https://source.android.com/security/bulletin) for more information.

--- a/reference/release-notes/1.3.1.md
+++ b/reference/release-notes/1.3.1.md
@@ -5,14 +5,14 @@ orphan: true
 
 ## New features & improvements
 
-* Allow underlying image of an application to be changed
-* Support for applications without an APK
-* An Anbox platform can now specify the display refresh rate
-* Integrated Android security fixes for August 2019. See the [Android Security Bulletins](https://source.android.com/security/bulletin) for more information.
+- Allow underlying image of an application to be changed
+- Support for applications without an APK
+- An Anbox platform can now specify the display refresh rate
+- Integrated Android security fixes for August 2019. See the [Android Security Bulletins](https://source.android.com/security/bulletin) for more information.
 
 ## Bug fixes
 
-* Refresh the LXD snap on demand when the configuration is changed
-* Don't use embedded etcd when a real etcd is available
-* Correctly determine the maximum OpenGL ES version the host GL driver supports
-* Support for gamepad devices in Anbox and the platform SDK
+- Refresh the LXD snap on demand when the configuration is changed
+- Don't use embedded etcd when a real etcd is available
+- Correctly determine the maximum OpenGL ES version the host GL driver supports
+- Support for gamepad devices in Anbox and the platform SDK

--- a/reference/release-notes/1.3.2.md
+++ b/reference/release-notes/1.3.2.md
@@ -3,12 +3,12 @@ orphan: true
 ---
 # New features & improvements
 
-* Increased maximum allowed startup time for containers to 15 minutes
-* Containers can now started with additional disk space added
-* Nodes can be marked as unschedulable to allow rebooting them for maintenance
-* `amc` supports deleting containers on a specific node (e.g. `$ amc delete --node=lxd0 --all`)
-* The default deployment configuration now allows deploying AMS and LXD on the same machine
-* Integrated Android security fixes for September and October 2019. See the
+- Increased maximum allowed startup time for containers to 15 minutes
+- Containers can now started with additional disk space added
+- Nodes can be marked as unschedulable to allow rebooting them for maintenance
+- `amc` supports deleting containers on a specific node (e.g. `$ amc delete --node=lxd0 --all`)
+- The default deployment configuration now allows deploying AMS and LXD on the same machine
+- Integrated Android security fixes for September and October 2019. See the
 [Android Security Bulletins](https://source.android.com/security/bulletin) for more information.
-* Added `prepare` hook to allow customizing Android while it's running as part of the bootstrap process
-* Updated LXD charm to install latest NVIDIA CUDA drivers
+- Added `prepare` hook to allow customizing Android while it's running as part of the bootstrap process
+- Updated LXD charm to install latest NVIDIA CUDA drivers

--- a/reference/release-notes/1.3.3.md
+++ b/reference/release-notes/1.3.3.md
@@ -5,9 +5,9 @@ orphan: true
 
 ## New features & improvements
 
-* Generating thumbnails within `libstagefright` in the Android 7 images is now working reliable where it was generating single colored images at times before.
-* Error messages are now presented via the AMS REST API for application versions.
-* The configuration of a container was created with (platform, boot package, ...) was added to the container REST API object which makes it visible with `$ amc show <container id>` for later inspection
-* Life-cycle events are now returned from the monitor endpoint the AMS REST API provides
-* Download of addons is now retried up to three times during the container bootstrap to workaround busy network environments
-* The addon prepare hook is now correctly executed while the container is running and before the bootstrap process finishes
+- Generating thumbnails within `libstagefright` in the Android 7 images is now working reliable where it was generating single colored images at times before.
+- Error messages are now presented via the AMS REST API for application versions.
+- The configuration of a container was created with (platform, boot package, ...) was added to the container REST API object which makes it visible with `$ amc show <container id>` for later inspection
+- Life-cycle events are now returned from the monitor endpoint the AMS REST API provides
+- Download of addons is now retried up to three times during the container bootstrap to workaround busy network environments
+- The addon prepare hook is now correctly executed while the container is running and before the bootstrap process finishes

--- a/reference/release-notes/1.4.0.md
+++ b/reference/release-notes/1.4.0.md
@@ -5,12 +5,12 @@ orphan: true
 
 ## New features & improvements
 
-* Support for Android 10 including latest security updates
-* Inclusion of an alpha version of the WebRTC based Streaming Stack
-* Updated and improve OpenGL/EGL layer to provide better performance and API support up to OpenGL ES 3.2 and EGL 1.4
-* Nested Android container is now using a nested user namespace with its own user id range to further isolate the Android system from the host system.
-* Support for [explicit graphics synchronization](https://source.android.com/devices/graphics/sync)
-* Automatic GPU detection on deployment and at runtime
-* Default LXD version changed to 3.21 for shiftfs and extended GPU support
-* Container life-cycle events are now reported via `amc monitor` and the corresponding REST API
-* Support for VNC was removed as [scrcpy](https://github.com/Genymobile/scrcpy) offers a good alternative
+- Support for Android 10 including latest security updates
+- Inclusion of an alpha version of the WebRTC based Streaming Stack
+- Updated and improve OpenGL/EGL layer to provide better performance and API support up to OpenGL ES 3.2 and EGL 1.4
+- Nested Android container is now using a nested user namespace with its own user id range to further isolate the Android system from the host system.
+- Support for [explicit graphics synchronization](https://source.android.com/devices/graphics/sync)
+- Automatic GPU detection on deployment and at runtime
+- Default LXD version changed to 3.21 for shiftfs and extended GPU support
+- Container life-cycle events are now reported via `amc monitor` and the corresponding REST API
+- Support for VNC was removed as [scrcpy](https://github.com/Genymobile/scrcpy) offers a good alternative

--- a/reference/release-notes/1.5.0.md
+++ b/reference/release-notes/1.5.0.md
@@ -5,18 +5,18 @@ orphan: true
 
 ## New features & improvements
 
-* Support for Android 10 including latest security updates
-* Updated software rendering to work on Android 10
-* Applications can now have encoder requirements (e.g. whether or not they require a GPU or are fine on a CPU encoder) and are scheduled accordingly
-* Use [Dqlite](https://dqlite.io/) in the Stream Gateway for High Availability
-* HTTP/HTTPS proxy support in AMS
-* Highly Availability support for Anbox Stream Gateway via [Dqlite](https://dqlite.io/)
-* Charms now properly work with DNS names when adding machines
-* Updated Android WebView to [80.0.3987.132](https://chromereleases.googleblog.com/2020/03/stable-channel-update-for-desktop.html)
-* Preliminary support for Ubuntu 20.04 LTS
-* Software rendering and video encoding support for the streaming stack
-* GPUs are now identified by their PCI address in order for a correct mapping inside containers
+- Support for Android 10 including latest security updates
+- Updated software rendering to work on Android 10
+- Applications can now have encoder requirements (e.g. whether or not they require a GPU or are fine on a CPU encoder) and are scheduled accordingly
+- Use [Dqlite](https://dqlite.io/) in the Stream Gateway for High Availability
+- HTTP/HTTPS proxy support in AMS
+- Highly Availability support for Anbox Stream Gateway via [Dqlite](https://dqlite.io/)
+- Charms now properly work with DNS names when adding machines
+- Updated Android WebView to [80.0.3987.132](https://chromereleases.googleblog.com/2020/03/stable-channel-update-for-desktop.html)
+- Preliminary support for Ubuntu 20.04 LTS
+- Software rendering and video encoding support for the streaming stack
+- GPUs are now identified by their PCI address in order for a correct mapping inside containers
 
 ## Deprecations
 
-* Android 7 images are now deprecated and will be dropped with the next release of Anbox Cloud
+- Android 7 images are now deprecated and will be dropped with the next release of Anbox Cloud

--- a/reference/release-notes/1.5.1.md
+++ b/reference/release-notes/1.5.1.md
@@ -5,10 +5,10 @@ orphan: true
 
 ## New features & improvements
 
-* Fix timeout issue when adding or removing LXD nodes from the cluster in AMS
-* Containers are now gracefully terminated to ensure the backup hook is executed
-* Support to start a container with one specific application version from Anbox Stream Gateway UI
-* Support numpad and mouse wheel input for the WebRTC based Streaming Stack
-* Collecting basic statistics (FPS, RTT and bandwidth) while streaming and display them in Anbox Stream Gateway UI
-* Stream Gateway will not directly be exposed to the public network but only accessible via a reverse proxy
-* Dropped the monitoring stack from the default Juju bundle. It is now available via an overlay
+- Fix timeout issue when adding or removing LXD nodes from the cluster in AMS
+- Containers are now gracefully terminated to ensure the backup hook is executed
+- Support to start a container with one specific application version from Anbox Stream Gateway UI
+- Support numpad and mouse wheel input for the WebRTC based Streaming Stack
+- Collecting basic statistics (FPS, RTT and bandwidth) while streaming and display them in Anbox Stream Gateway UI
+- Stream Gateway will not directly be exposed to the public network but only accessible via a reverse proxy
+- Dropped the monitoring stack from the default Juju bundle. It is now available via an overlay

--- a/reference/release-notes/1.5.2.md
+++ b/reference/release-notes/1.5.2.md
@@ -5,6 +5,6 @@ orphan: true
 
 ## New features & improvements
 
-* Fix infinite loading screen issue when streaming from Anbox Stream Gateway UI
-* Fix SDK documentation for Anbox Stream Gateway and all API routes are prefixed with "/1.0"
-* Reconfigure Anbox Stream Gateway upon charm upgrade
+- Fix infinite loading screen issue when streaming from Anbox Stream Gateway UI
+- Fix SDK documentation for Anbox Stream Gateway and all API routes are prefixed with "/1.0"
+- Reconfigure Anbox Stream Gateway upon charm upgrade

--- a/reference/release-notes/1.6.0.md
+++ b/reference/release-notes/1.6.0.md
@@ -5,18 +5,18 @@ orphan: true
 
 ## New features & improvements
 
-* Watchdog can now be disabled via the application manifest or configured to allow additional packages to provide a foreground activity
-* Service endpoints can now be defined in the application manifest
-* Full HA support for the streaming stack
-* Rejoining a streaming session when the initial client left is now possible and can be configured via the stream gateway API when a new session is created
-* GPU acceleration support for Tensorflow Lite via the [GPU delegate](https://www.tensorflow.org/lite/performance/gpu) on supported GPUs (requires OpenGL ES >= 3.1)
-* GPS support in the Anbox Platform SDK
-* GPS position can be statically configured before the Android system boots
-* Application resources (CPU, memory, disk, GPUs) can now be declared in the application manifest as an alternative to predefined instance types
-* Updated Android WebView to 83.0.4103.96
-* Latest security updates for Android 10 (patch level [2020-06-05](https://source.android.com/security/bulletin/2020-06-01))
-* Manual mode for the Anbox Application Registry (AAR) which allows pushing and pulling applications via the REST API or the `amc` command line client to or from the registry
-* Improved audio latency for the streaming protocol implementation
-* Various fixes for improved Android system stability
-* Increased [Android CTS](https://source.android.com/compatibility/cts) test coverage
-* The Anbox Streaming SDK now comes with an Android example to demonstrate how to utilize streaming within an Android application.
+- Watchdog can now be disabled via the application manifest or configured to allow additional packages to provide a foreground activity
+- Service endpoints can now be defined in the application manifest
+- Full HA support for the streaming stack
+- Rejoining a streaming session when the initial client left is now possible and can be configured via the stream gateway API when a new session is created
+- GPU acceleration support for Tensorflow Lite via the [GPU delegate](https://www.tensorflow.org/lite/performance/gpu) on supported GPUs (requires OpenGL ES >= 3.1)
+- GPS support in the Anbox Platform SDK
+- GPS position can be statically configured before the Android system boots
+- Application resources (CPU, memory, disk, GPUs) can now be declared in the application manifest as an alternative to predefined instance types
+- Updated Android WebView to 83.0.4103.96
+- Latest security updates for Android 10 (patch level [2020-06-05](https://source.android.com/security/bulletin/2020-06-01))
+- Manual mode for the Anbox Application Registry (AAR) which allows pushing and pulling applications via the REST API or the `amc` command line client to or from the registry
+- Improved audio latency for the streaming protocol implementation
+- Various fixes for improved Android system stability
+- Increased [Android CTS](https://source.android.com/compatibility/cts) test coverage
+- The Anbox Streaming SDK now comes with an Android example to demonstrate how to utilize streaming within an Android application.

--- a/reference/release-notes/1.6.1.md
+++ b/reference/release-notes/1.6.1.md
@@ -5,5 +5,5 @@ orphan: true
 
 ## Bug fixes
 
-* LP #1885257: Fix high CPU usage for Anbox daemon
-* LP #1885972: Fix watchdog, services and video encoder settings out of sync when updating an application
+- LP #1885257: Fix high CPU usage for Anbox daemon
+- LP #1885972: Fix watchdog, services and video encoder settings out of sync when updating an application

--- a/reference/release-notes/1.6.2.md
+++ b/reference/release-notes/1.6.2.md
@@ -5,9 +5,9 @@ orphan: true
 
 ## New features & improvements
 
-* Applications without an APK can now specify a boot activity in their application manifest
+- Applications without an APK can now specify a boot activity in their application manifest
 
 ## Bug fixes
 
-* LP #1885107: Automatic application updates were missing configured resources, watchdog or service information
-* LP #1885257: `anboxd` was using 100% of a single CPU core due to a spinning loop
+- LP #1885107: Automatic application updates were missing configured resources, watchdog or service information
+- LP #1885257: `anboxd` was using 100% of a single CPU core due to a spinning loop

--- a/reference/release-notes/1.6.3.md
+++ b/reference/release-notes/1.6.3.md
@@ -5,4 +5,4 @@ orphan: true
 
 ## Bug fixes
 
-* LP #1885726: Fix the mouse and touch displacement issue for Anbox Stream Gateway UI
+- LP #1885726: Fix the mouse and touch displacement issue for Anbox Stream Gateway UI

--- a/reference/release-notes/1.7.0.md
+++ b/reference/release-notes/1.7.0.md
@@ -5,18 +5,18 @@ orphan: true
 
 ## New features & improvements
 
-* Anbox Cloud is now fully integrated with [Ubuntu Advantage](https://ubuntu.com/advantage)
-* TLS certificates are now managed through a common CA for all components ([Easy-RSA](https://charmhub.io/containers-easyrsa))
-* GPS position updates can now be provided via a new  HTTP API endpoint Anbox exposes within the container or via the streaming SDK
-* Removed [KSM](https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html) support
-* Allow streams started via the stream gateway UI to use 1080p as display resolution
-* Deprecated the Anbox Cloud Doctor in favor of [Juju crashdump](https://github.com/juju/juju-crashdump)
+- Anbox Cloud is now fully integrated with [Ubuntu Advantage](https://ubuntu.com/advantage)
+- TLS certificates are now managed through a common CA for all components ([Easy-RSA](https://charmhub.io/containers-easyrsa))
+- GPS position updates can now be provided via a new  HTTP API endpoint Anbox exposes within the container or via the streaming SDK
+- Removed [KSM](https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html) support
+- Allow streams started via the stream gateway UI to use 1080p as display resolution
+- Deprecated the Anbox Cloud Doctor in favor of [Juju crashdump](https://github.com/juju/juju-crashdump)
 
 ## Bug fixes
 
-* LP #1890573: Always delete the base container even when an application failed to be bootstrapped
-* LP #1847226 Fixed a bug that prevented the Dev UI to be run in fullscreen in some cases
-* LP #1890573: Stop the signaling session when a container no longer exists to avoid hanging the client for too long
-* LP #1886200: Fixed issues that appeared when displaying web pages on a software rendering backend (`swrast` and `webrtc` without GPU) after upgrading the system WebView to 84.0.4147.89.
-* Reduced resource consumption of the WebRTC platform by avoiding unnecessary screen refresh cycles
-* Fixed timing issue which resulted in locked databases in some cases on the Stream Gateway
+- LP #1890573: Always delete the base container even when an application failed to be bootstrapped
+- LP #1847226 Fixed a bug that prevented the Dev UI to be run in fullscreen in some cases
+- LP #1890573: Stop the signaling session when a container no longer exists to avoid hanging the client for too long
+- LP #1886200: Fixed issues that appeared when displaying web pages on a software rendering backend (`swrast` and `webrtc` without GPU) after upgrading the system WebView to 84.0.4147.89.
+- Reduced resource consumption of the WebRTC platform by avoiding unnecessary screen refresh cycles
+- Fixed timing issue which resulted in locked databases in some cases on the Stream Gateway

--- a/reference/release-notes/1.7.1.md
+++ b/reference/release-notes/1.7.1.md
@@ -7,13 +7,13 @@ The Anbox Cloud team is pleased to announce the release of Anbox Cloud 1.7.1
 
 ## New Features & Improvements
 
-* Switched to [LLVMpipe](https://docs.mesa3d.org/gallium/drivers/llvmpipe.html) based software rendering in favor of [swiftshader](https://swiftshader.googlesource.com/SwiftShader/) to mitigate memory corruption during rendering in the [Android WebView](https://developer.android.com/reference/android/webkit/WebView) on both ARM and x86
+- Switched to [LLVMpipe](https://docs.mesa3d.org/gallium/drivers/llvmpipe.html) based software rendering in favor of [swiftshader](https://swiftshader.googlesource.com/SwiftShader/) to mitigate memory corruption during rendering in the [Android WebView](https://developer.android.com/reference/android/webkit/WebView) on both ARM and x86
 
 ## Bug Fixes
 
-* LP #1892149:  `anbox-shell pm install`  fails in the prepare hook of an addon when bootstrapping an application
-* LP #1889747: Coturn should not run as root
-* LP #1891746: Some ARM applications crash because of failing `cacheflush` syscall
+- LP #1892149:  `anbox-shell pm install`  fails in the prepare hook of an addon when bootstrapping an application
+- LP #1889747: Coturn should not run as root
+- LP #1891746: Some ARM applications crash because of failing `cacheflush` syscall
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.7.2.md
+++ b/reference/release-notes/1.7.2.md
@@ -7,16 +7,16 @@ The Anbox Cloud team is pleased to announce the release of Anbox Cloud 1.7.2
 
 ## New Features & Improvements
 
-* Various improvements for HA support in the Anbox Stream Gateway and its [Dqlite](https://dqlite.io) integration
-* The Anbox Stream Gateway now exposes a `/1.0/status` endpoint to allow simple health checks
-* The number of registered stream agents is now exported via the Prometheus endpoint of the Anbox Stream Gateway
-* The LXD charm can now use Juju storage (AWS EBS, ..) at deployment time as base for the LXD storage pool
-* Coturn can now be manually configured via the Anbox Stream Agent charm configuration
+- Various improvements for HA support in the Anbox Stream Gateway and its [Dqlite](https://dqlite.io) integration
+- The Anbox Stream Gateway now exposes a `/1.0/status` endpoint to allow simple health checks
+- The number of registered stream agents is now exported via the Prometheus endpoint of the Anbox Stream Gateway
+- The LXD charm can now use Juju storage (AWS EBS, ..) at deployment time as base for the LXD storage pool
+- Coturn can now be manually configured via the Anbox Stream Agent charm configuration
 
 ## Bug Fixes
 
-* Various fixes around interoperability of the various charms in an Anbox Cloud deployment
-* Updated and verified NRPE checks for all service components
+- Various fixes around interoperability of the various charms in an Anbox Cloud deployment
+- Updated and verified NRPE checks for all service components
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.7.3.md
+++ b/reference/release-notes/1.7.3.md
@@ -7,8 +7,8 @@ The Anbox Cloud team is pleased to announce the release of Anbox Cloud 1.7.3
 
 ## New Features & Improvements
 
-* Android security fixes from September 2020 (patch level `2020-09-05`, see [here](https://source.android.com/security/bulletin/2020-09-01) for more details)
-* WebView update to upstream release `85.0.4183.101` (see [here](https://chromereleases.googleblog.com/2020/09/chrome-for-android-update.html) for more details)
+- Android security fixes from September 2020 (patch level `2020-09-05`, see [here](https://source.android.com/security/bulletin/2020-09-01) for more details)
+- WebView update to upstream release `85.0.4183.101` (see [here](https://chromereleases.googleblog.com/2020/09/chrome-for-android-update.html) for more details)
 
 ## Bug Fixes
 

--- a/reference/release-notes/1.7.4.md
+++ b/reference/release-notes/1.7.4.md
@@ -7,8 +7,8 @@ The Anbox Cloud team is pleased to announce the release of Anbox Cloud 1.7.4
 
 ## New Features & Improvements
 
-* Android security fixes from October 2020 (patch level  `2020-10-05` , see [here](https://source.android.com/security/bulletin/2020-10-01) for more details)
-* WebView update to upstream release  `86.0.4240.75`  (see [here](https://chromereleases.googleblog.com/2020/10/chrome-for-android-update.html) for more details)
+- Android security fixes from October 2020 (patch level  `2020-10-05` , see [here](https://source.android.com/security/bulletin/2020-10-01) for more details)
+- WebView update to upstream release  `86.0.4240.75`  (see [here](https://chromereleases.googleblog.com/2020/10/chrome-for-android-update.html) for more details)
 
 ## Bug Fixes
 

--- a/reference/release-notes/1.8.0.md
+++ b/reference/release-notes/1.8.0.md
@@ -7,53 +7,53 @@ The Anbox Cloud team is pleased to announce the release of Anbox Cloud 1.8.0.
 
 ## New Features & Improvements
 
-* Camera can now be provided with video and static images as content via the Anbox HTTP API
-* A new `ANBOX_EXIT_CODE` environment variable is provided to the `backup` hook of addons to provide information if Anbox terminate correctly or not
-* [Crashpad](https://chromium.googlesource.com/crashpad/crashpad/) is now used for crash dump reporting in Anbox
-* Sensors exposed to Android can now be provided with data via the Anbox HTTP API
-* Prometheus endpoint of the Anbox Stream Gateway now supports TLS and HTTP basic authentication.
-* AMS now supports multiple architectures in the connected LXD cluster
-* NVIDIA GPU support for ARM (rendering only, encode will come with 1.9)
-* Upgrade to etcd 3.4
-* Anbox Stream SDK now supports native applications (Linux, Android)
-* Anbox provides support for [Perfetto](https://perfetto.dev/) based tracing via its HTTP API
-* A custom expiration timeout can now be set for service accounts created for the Anbox Stream Gateway
-* HA support in the Anbox Stream Gateway was improved and stabilized
-* The Coturn charm now supports HA
-* Applications in AMS can now provide a free-form version field in their manifest to allow users to identify which application version is based on which APK version
+- Camera can now be provided with video and static images as content via the Anbox HTTP API
+- A new `ANBOX_EXIT_CODE` environment variable is provided to the `backup` hook of addons to provide information if Anbox terminate correctly or not
+- [Crashpad](https://chromium.googlesource.com/crashpad/crashpad/) is now used for crash dump reporting in Anbox
+- Sensors exposed to Android can now be provided with data via the Anbox HTTP API
+- Prometheus endpoint of the Anbox Stream Gateway now supports TLS and HTTP basic authentication.
+- AMS now supports multiple architectures in the connected LXD cluster
+- NVIDIA GPU support for ARM (rendering only, encode will come with 1.9)
+- Upgrade to etcd 3.4
+- Anbox Stream SDK now supports native applications (Linux, Android)
+- Anbox provides support for [Perfetto](https://perfetto.dev/) based tracing via its HTTP API
+- A custom expiration timeout can now be set for service accounts created for the Anbox Stream Gateway
+- HA support in the Anbox Stream Gateway was improved and stabilized
+- The Coturn charm now supports HA
+- Applications in AMS can now provide a free-form version field in their manifest to allow users to identify which application version is based on which APK version
 
 ## Bugs
 
-* LP #1898180 AMS fails when related to Anbox registry due to missing certificate
-* LP #1901513 Don't join Dqlite cluster if gateway is not able to start
-* LP #1901573 Coturn charm does not remove Debian package and configuration
-* LP #1900704 HA attach fails if other application was already attached on same machine
-* LP #1901185 Manually pulling an application from registry crashes AMS
-* LP #1901511 UA layer fails in HA
-* LP #1884526 Dqlite shouldn't start in cluster if its certs aren't setup
-* LP #1889923 Stream stops when browser window is resized
-* LP #1895009 UA Token is printed when attach failed
-* LP #1896813 Picture recorded via the camera app is corrupted
-* LP #1896953 Make `getevent` Android tool work with Unix sockets in `/dev/input`
-* LP #1897085 Take a picture from the Uber driver application causes the application crash
-* LP #1897277 Streaming gives a black screen on iOS Safari
-* LP #1898220 A native crash occurs when doing a video recording from camera applications
-* LP #1898698 Video stream is empty after joining existing session
-* LP #1898740 LXD unit fails to stop when storage pool still has containers
-* LP #1899324 Video recording doesn't work out on swrast platform
-* LP #1899658 SensorManager thread run into a busy loop
-* LP #1901021 checksum of `dmp` file is different from the original log file pulled out from the LXD container
-* LP #1901194 Anbox Stream Gateway doesn't register dashboard with Grafana
-* LP #1901197 Android streaming example freezes after adding the audio support
-* LP #1901668 Stream SDK should time out if WebRTC connection is not established in time
-* LP #1901744 Anbox freezes at time when container is terminated
-* LP #1884498 Improve error when application has an APK with unsupported ABIs
-* LP #1888383 Supply `extra-properties` upon Anbox session startup broke the Android container startup
-* LP #1892410 Containers freezes after `anbox-system-update` failed
-* LP #1896789 `uiautomator` crashes in `anbox-shell`
-* LP #1897790 Read `ua-token` from `include-file://`
-* LP #1898697 `anbox-stream-sdk. _unregisterControls` is not working correctly
-* LP #1894978 Sanitize prepare hook upon an addon creation
+- LP #1898180 AMS fails when related to Anbox registry due to missing certificate
+- LP #1901513 Don't join Dqlite cluster if gateway is not able to start
+- LP #1901573 Coturn charm does not remove Debian package and configuration
+- LP #1900704 HA attach fails if other application was already attached on same machine
+- LP #1901185 Manually pulling an application from registry crashes AMS
+- LP #1901511 UA layer fails in HA
+- LP #1884526 Dqlite shouldn't start in cluster if its certs aren't setup
+- LP #1889923 Stream stops when browser window is resized
+- LP #1895009 UA Token is printed when attach failed
+- LP #1896813 Picture recorded via the camera app is corrupted
+- LP #1896953 Make `getevent` Android tool work with Unix sockets in `/dev/input`
+- LP #1897085 Take a picture from the Uber driver application causes the application crash
+- LP #1897277 Streaming gives a black screen on iOS Safari
+- LP #1898220 A native crash occurs when doing a video recording from camera applications
+- LP #1898698 Video stream is empty after joining existing session
+- LP #1898740 LXD unit fails to stop when storage pool still has containers
+- LP #1899324 Video recording doesn't work out on swrast platform
+- LP #1899658 SensorManager thread run into a busy loop
+- LP #1901021 checksum of `dmp` file is different from the original log file pulled out from the LXD container
+- LP #1901194 Anbox Stream Gateway doesn't register dashboard with Grafana
+- LP #1901197 Android streaming example freezes after adding the audio support
+- LP #1901668 Stream SDK should time out if WebRTC connection is not established in time
+- LP #1901744 Anbox freezes at time when container is terminated
+- LP #1884498 Improve error when application has an APK with unsupported ABIs
+- LP #1888383 Supply `extra-properties` upon Anbox session startup broke the Android container startup
+- LP #1892410 Containers freezes after `anbox-system-update` failed
+- LP #1896789 `uiautomator` crashes in `anbox-shell`
+- LP #1897790 Read `ua-token` from `include-file://`
+- LP #1898697 `anbox-stream-sdk. _unregisterControls` is not working correctly
+- LP #1894978 Sanitize prepare hook upon an addon creation
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.8.1.md
+++ b/reference/release-notes/1.8.1.md
@@ -7,26 +7,26 @@ The Anbox Cloud team is pleased to announce the release of Anbox Cloud 1.8.1.
 
 ## New Features & Improvements
 
-* Android security fixes from November 2020 (patch level `2020-11-05`, see [here](https://source.android.com/security/bulletin/2020-11-01) for more details)
-* WebView update to upstream release `86.0.4240.185` (see [here](https://chromereleases.googleblog.com/2020/11/chrome-for-android-update.html) for more details)
-* AMS now allows locking image updates to it's own minor version. For example if AMS is at 1.8 it wont pull a 1.9 image but only patch releases for 1.8. This can be configured with the `images.version_lockstep` configuration option
+- Android security fixes from November 2020 (patch level `2020-11-05`, see [here](https://source.android.com/security/bulletin/2020-11-01) for more details)
+- WebView update to upstream release `86.0.4240.185` (see [here](https://chromereleases.googleblog.com/2020/11/chrome-for-android-update.html) for more details)
+- AMS now allows locking image updates to it's own minor version. For example if AMS is at 1.8 it wont pull a 1.9 image but only patch releases for 1.8. This can be configured with the `images.version_lockstep` configuration option
 
 ## Bugs
 
-* LP #1903510 `nagios_context` and `nagios_servicegroups` are never used in any charm
-* LP #1885926 One touch point always stays when another touch event was fired
-* LP #1902282 Idle timer in the WebRTC platform is not reinitialized after the first client disconnected
-* LP #1902494 A malformed `ua-source` blocked the Anbox Cloud deployment on AWS
-* LP #1902665 The latest `anbox-stream-sdk.js` broke the keyboard/mouse/touch input events to be propagated to the container
-* LP #1902693 `inhibit-auto-updates` setting never worked
-* LP #1902996 Time doesn't get refreshed in the status bar but the it does in the System settings
-* LP #1903492 charm-upgrade hook implementation is missing apt update call
-* LP #1903525 Invalid service directory permissions for the stream gateway
-* LP #1903559 Gateway service is restarted when new units are added
-* LP #1903676 Failed to remove LXD charm because zpool command is missing
-* LP #1903747 Host composition is causing flickering in Anbox when streaming with LLVMpipe
-* LP #1903672 Application bootstrap fails due to malformed addon name
-* LP #1902650 The error message needs to be simplified when ABI is unmatched
+- LP #1903510 `nagios_context` and `nagios_servicegroups` are never used in any charm
+- LP #1885926 One touch point always stays when another touch event was fired
+- LP #1902282 Idle timer in the WebRTC platform is not reinitialized after the first client disconnected
+- LP #1902494 A malformed `ua-source` blocked the Anbox Cloud deployment on AWS
+- LP #1902665 The latest `anbox-stream-sdk.js` broke the keyboard/mouse/touch input events to be propagated to the container
+- LP #1902693 `inhibit-auto-updates` setting never worked
+- LP #1902996 Time doesn't get refreshed in the status bar but the it does in the System settings
+- LP #1903492 charm-upgrade hook implementation is missing apt update call
+- LP #1903525 Invalid service directory permissions for the stream gateway
+- LP #1903559 Gateway service is restarted when new units are added
+- LP #1903676 Failed to remove LXD charm because zpool command is missing
+- LP #1903747 Host composition is causing flickering in Anbox when streaming with LLVMpipe
+- LP #1903672 Application bootstrap fails due to malformed addon name
+- LP #1902650 The error message needs to be simplified when ABI is unmatched
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.8.2.md
+++ b/reference/release-notes/1.8.2.md
@@ -9,14 +9,14 @@ There are no charm upgrades for 1.8.2. Only new images are provided which should
 
 ## New Features & Improvements
 
-* Android security fixes from December 2020 (patch level `2020-12-05`, see [here](https://source.android.com/security/bulletin/2020-12-01) for more details)
-* WebView update to upstream release `87.0.4280.86` (see [here](https://chromereleases.googleblog.com/2020/12/chrome-for-android-update.html) for more details)
+- Android security fixes from December 2020 (patch level `2020-12-05`, see [here](https://source.android.com/security/bulletin/2020-12-01) for more details)
+- WebView update to upstream release `87.0.4280.86` (see [here](https://chromereleases.googleblog.com/2020/12/chrome-for-android-update.html) for more details)
 
 ## Bugs
 
-* LP #1907464 NvEnc fails to encode when stream is in portrait mode (720x1280)
-* LP #1904078 Garbled image/video generated when taking a picture/recording a video when screen orientation is in portrait mode
-* LP #1904417 [REGRESSION] `adb screenrecord` output has incorrect orientation
+- LP #1907464 NvEnc fails to encode when stream is in portrait mode (720x1280)
+- LP #1904078 Garbled image/video generated when taking a picture/recording a video when screen orientation is in portrait mode
+- LP #1904417 [REGRESSION] `adb screenrecord` output has incorrect orientation
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.8.3.md
+++ b/reference/release-notes/1.8.3.md
@@ -7,14 +7,14 @@ The Anbox Cloud team is pleased to announce the release of Anbox Cloud 1.8.3.
 
 ## New Features & Improvements
 
-* Android security fixes from January 2021 (patch level `2021-01-05`, see [here](https://source.android.com/security/bulletin/2021-01-01) for more details)
-* WebView update to upstream release `87.0.4280.141` (see [here](https://chromereleases.googleblog.com/2021/01/chrome-for-android-update.html) for more details)
-* Various improvements to the Coturn charm to allow proper use behind [AWS Elastic Load Balancers](https://aws.amazon.com/elasticloadbalancing/)
+- Android security fixes from January 2021 (patch level `2021-01-05`, see [here](https://source.android.com/security/bulletin/2021-01-01) for more details)
+- WebView update to upstream release `87.0.4280.141` (see [here](https://chromereleases.googleblog.com/2021/01/chrome-for-android-update.html) for more details)
+- Various improvements to the Coturn charm to allow proper use behind [AWS Elastic Load Balancers](https://aws.amazon.com/elasticloadbalancing/)
 
 ## Bugs
 
-* LP #1910583 Anbox-stream-gateway gets stuck and demands restart after some time of use
-* LP #1912342 Gateway reports database locked errors for various operations
+- LP #1910583 Anbox-stream-gateway gets stuck and demands restart after some time of use
+- LP #1912342 Gateway reports database locked errors for various operations
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.9.0.md
+++ b/reference/release-notes/1.9.0.md
@@ -7,93 +7,93 @@ The Anbox Cloud team is pleased to announce the release of Anbox Cloud 1.9.0
 
 ## Deprecations
 
-* The Android 7 (`bionic:android7:arm64` and `bionic:android7:amd64`) images are now deprecated and will no longer be available starting with Anbox Cloud 1.10 which will be released in April 2021
-* The UI included in the Anbox Stream Gateway service will be dropped in Anbox Cloud 1.10 as it's being replaced with the new dashboard
+- The Android 7 (`bionic:android7:arm64` and `bionic:android7:amd64`) images are now deprecated and will no longer be available starting with Anbox Cloud 1.10 which will be released in April 2021
+- The UI included in the Anbox Stream Gateway service will be dropped in Anbox Cloud 1.10 as it's being replaced with the new dashboard
 
 ## Known Issues
 
-* At times the `anbox-cloud-dashboard` charm reports a `error` as workload status due to too many units trying to use `apt` on the machine at the same time. Juju will retry the installation after some time automatically and the problem will fix itself. The issue can be identified in the output of `juju debug-log --include anbox-cloud-dashboard`. This will be improved in the upcoming 1.9.1 release
-* If for the initial deployment not Ubuntu Advantage token is configured via an `overlay.yaml` the status messages reported by the charms once they become idle is not set to `UA token missing`. There is no impact in terms of functionality. Applying the UA token via `juju config <application> ua_token=<token>` will work as usual.
+- At times the `anbox-cloud-dashboard` charm reports a `error` as workload status due to too many units trying to use `apt` on the machine at the same time. Juju will retry the installation after some time automatically and the problem will fix itself. The issue can be identified in the output of `juju debug-log --include anbox-cloud-dashboard`. This will be improved in the upcoming 1.9.1 release
+- If for the initial deployment not Ubuntu Advantage token is configured via an `overlay.yaml` the status messages reported by the charms once they become idle is not set to `UA token missing`. There is no impact in terms of functionality. Applying the UA token via `juju config <application> ua_token=<token>` will work as usual.
 
 ## New Features & Improvements
 
-* New web based dashboard to manage applications and streaming sessions in Anbox Cloud
-* WebView based on [upstream 88.0.4324.152 release](https://chromereleases.googleblog.com/2021/02/chrome-for-android-update_4.html)
-* Android security updates for February 2021 (see [here](https://source.android.com/security/bulletin/2021-02-01) for more details)
-* Out of band data allowing to send custom data from applications running inside the Android container to the client connected over WebRTC
-* Support for streaming the clients camera to the Android container over WebRTC
-* Hardware video encoding support for NVIDIA on Arm
-* Support in AMS for existing LXD clusters
-* New recursive=<bool> parameter to GET /sessions on the Stream Gateway to return the full session objects rather than just their ID
-* Streaming sessions can now be deleted in batch and asynchronously
-* Introduce the container.features config item in AMS to enable specified features in Android container
-* Bump key size to 4096 to work with 20.04 stronger security defaults
-* Anbox now uses Vulkan as a backend renderer API on NVIDIA GPUs on both x86 and Arm. This improves performance, stability and compatibility.
-* Improved density on NVIDIA Tesla T4 cards. With Anbox Cloud < 1.9.0 the maximum of containers possible was around 10-12 due to bugs in the GPU firmware when using the OpenGL ES client API. With the switch to Vulkan the firmware bugs are no longer triggered and up to a maximum of 32 simultaneous containers are possible (subject to their actual use of the GPU)
-* Updated NVIDIA GPU driver to the 460 series for both x86 and Arm
-* A default virtual keyboard is now included in the provided Android images and can be conditionally enabled
-* A launch activity can now be specified when new sessions are created or existing joined. This allows switching to specific activities within the application.
-* Stripped down unnecessary dependencies to speed up deployment time
-* Session objects in the gateway now contain information about failed container
-* The AMS charm now sets up access to the Anbox Cloud image server via the Ubuntu Advantage subscription the machine is attached to. It’s no longer necessary to supply individual user+password authentication details
-* Added API measurements to metrics
-* Various fields of an application can now be updated via the AMS HTTP API without providing a new APK file
-* The Anbox Stream Gateway has now support for HTTP rate limit which can be configured via a charm configuration option
-* AMS can be configured to use pre-existing storage pools and networks
-* AMS now exposes the `scheduler.strategy` configuration item to allow choosing between `binpack` and `spread` strategies
-* AMS now exposes two configuration items `node.queue_size` and `node.workers_per_queue` to allow fine tuning how AMS processes container launch requests for optimal throughput
-* The Google STUN server is no longer used
-* Streaming sessions are now ephemeral by default and will be automatically removed when the container it belongs to terminates
+- New web based dashboard to manage applications and streaming sessions in Anbox Cloud
+- WebView based on [upstream 88.0.4324.152 release](https://chromereleases.googleblog.com/2021/02/chrome-for-android-update_4.html)
+- Android security updates for February 2021 (see [here](https://source.android.com/security/bulletin/2021-02-01) for more details)
+- Out of band data allowing to send custom data from applications running inside the Android container to the client connected over WebRTC
+- Support for streaming the clients camera to the Android container over WebRTC
+- Hardware video encoding support for NVIDIA on Arm
+- Support in AMS for existing LXD clusters
+- New recursive=<bool> parameter to GET /sessions on the Stream Gateway to return the full session objects rather than just their ID
+- Streaming sessions can now be deleted in batch and asynchronously
+- Introduce the container.features config item in AMS to enable specified features in Android container
+- Bump key size to 4096 to work with 20.04 stronger security defaults
+- Anbox now uses Vulkan as a backend renderer API on NVIDIA GPUs on both x86 and Arm. This improves performance, stability and compatibility.
+- Improved density on NVIDIA Tesla T4 cards. With Anbox Cloud < 1.9.0 the maximum of containers possible was around 10-12 due to bugs in the GPU firmware when using the OpenGL ES client API. With the switch to Vulkan the firmware bugs are no longer triggered and up to a maximum of 32 simultaneous containers are possible (subject to their actual use of the GPU)
+- Updated NVIDIA GPU driver to the 460 series for both x86 and Arm
+- A default virtual keyboard is now included in the provided Android images and can be conditionally enabled
+- A launch activity can now be specified when new sessions are created or existing joined. This allows switching to specific activities within the application.
+- Stripped down unnecessary dependencies to speed up deployment time
+- Session objects in the gateway now contain information about failed container
+- The AMS charm now sets up access to the Anbox Cloud image server via the Ubuntu Advantage subscription the machine is attached to. It’s no longer necessary to supply individual user+password authentication details
+- Added API measurements to metrics
+- Various fields of an application can now be updated via the AMS HTTP API without providing a new APK file
+- The Anbox Stream Gateway has now support for HTTP rate limit which can be configured via a charm configuration option
+- AMS can be configured to use pre-existing storage pools and networks
+- AMS now exposes the `scheduler.strategy` configuration item to allow choosing between `binpack` and `spread` strategies
+- AMS now exposes two configuration items `node.queue_size` and `node.workers_per_queue` to allow fine tuning how AMS processes container launch requests for optimal throughput
+- The Google STUN server is no longer used
+- Streaming sessions are now ephemeral by default and will be automatically removed when the container it belongs to terminates
 
 ## Bugs
 
-* LP #1868945 Android: failed to get memory consumption info
-* LP #1873393 Close of unknown file descriptor in `gralloc` modules causes crash
-* LP #1892693 Provide better error message when websocket connect to gateway fails
-* LP #1897300 Rare ICE errors on iOS Safari when streaming
-* LP #1901035 NVIDIA GPUs cannot host more than 12-13 Anbox containers
-* LP #1903518 Inconsistent Session object returned by the Gateway API
-* LP #1903991 Coturn reports Unauthorized for users when stream was already established
-* LP #1905734 WebRTC streaming fails in Firefox
-* LP #1908240 AMS timing issue when fetching an image before assigning it an alias
-* LP #1908404 Images are not synchronized from `images.anbox-cloud.io`
-* LP #1910203 Dashboard charm crashes with KeyError on certificates relation
-* LP #1911202 Container delete fails with ZFS busy error
-* LP #1912113 WebRTC platform aborts with unhandled exception
-* LP #1912143 Port 3000 will not get opened after exposing AAR (AMS registry)
-* LP #1912146 when nrpe relation is added to AAR, 'Check AAR HTTPS endpoint' will always fail with 401 Unauthorized
-* LP #1912267 WebRTC platform crashes in `eglReleaseThread` in `libEGL_mesa.so.0` on termination
-* LP #1912302 Container doesn't not terminate correctly
-* LP #1912470 The latest WebRTC platform is broken on NVIDIA based GPU machine
-* LP #1912521 Dashboard charm does not set application version
-* LP #1912588 `anbox-cloud-tests` for gateway, sometime fails to launch container
-* LP #1912732 Anbox Cloud dashboard does not show all of the panes correctly
-* LP #1912784 Dashboard register URL is still on HTTP
-* LP #1912785 AMC failed to create container with error, however in LXD it was successfully created
-* LP #1912787 Status message of a session with status error is empty when container crashed
-* LP #1912932 CTS tests claims `EGL_KHR_image` extension is missing
-* LP #1912956 Native SDK example crashes when trying to lock destroyed mutex
-* LP #1913017 SEGV when terminating the streaming on Android client built against native SDK
-* LP #1913020 FORTIFY: `pthread_mutex_lock` called on a destroyed mutex on AudioTrack thread
-* LP #1913058 `gpu-support.sh` script unloads kernel drivers when current driver is already the correct one
-* LP #1913264 Anbox Cloud Dashboard stuck on `waiting for UA` even with UA source configured
-* LP #1913305 Charm stays in blocked when `ua attach` failed
-* LP #1913364 Meaningless/Invalid resource is listed in the response when deleting an addon version
-* LP #1913391 Coturn uses location as external address when external_address_from_location is set to false
-* LP #1913403 AMS crashed when exporting an application version
-* LP #1913436 Update the command description of `amc config set`
-* LP #1913457 LXD container cgroup metrics are not reported via subordinate telegraf charm
-* LP #1913462 On ARM64 systems not loaded `nvidia_uvm` kernel module crashes containers
-* LP #1913524 AMS crashed when executing a command within a container by posting a body
-* LP #1913528 The timestamp of event shows `0001-01-01T00:00:00Z`
-* LP #1914008 Juju fails to attach storage to LXD unit
-* LP #1914036 Dashboard sets 5min idle timeout
-* LP #1914188 Opened port is closed when port hasn't changed for gateway
-* LP #1914276 JS SDK reports "Unknown message type error" at times in Firefox
-* LP #1914435 Anbox Stream JS SDK always get `rear` facing mode no matter people switch the camera face mode to "front" or "rear"
-* LP #1914448 Dashboard register command gives private IP instead of public one
-* LP #1914811 NVIDIA kernel modules are not loaded after deployment
-* LP #1914991 Latest gateway API changes break dashboard
+- LP #1868945 Android: failed to get memory consumption info
+- LP #1873393 Close of unknown file descriptor in `gralloc` modules causes crash
+- LP #1892693 Provide better error message when websocket connect to gateway fails
+- LP #1897300 Rare ICE errors on iOS Safari when streaming
+- LP #1901035 NVIDIA GPUs cannot host more than 12-13 Anbox containers
+- LP #1903518 Inconsistent Session object returned by the Gateway API
+- LP #1903991 Coturn reports Unauthorized for users when stream was already established
+- LP #1905734 WebRTC streaming fails in Firefox
+- LP #1908240 AMS timing issue when fetching an image before assigning it an alias
+- LP #1908404 Images are not synchronized from `images.anbox-cloud.io`
+- LP #1910203 Dashboard charm crashes with KeyError on certificates relation
+- LP #1911202 Container delete fails with ZFS busy error
+- LP #1912113 WebRTC platform aborts with unhandled exception
+- LP #1912143 Port 3000 will not get opened after exposing AAR (AMS registry)
+- LP #1912146 when nrpe relation is added to AAR, 'Check AAR HTTPS endpoint' will always fail with 401 Unauthorized
+- LP #1912267 WebRTC platform crashes in `eglReleaseThread` in `libEGL_mesa.so.0` on termination
+- LP #1912302 Container doesn't not terminate correctly
+- LP #1912470 The latest WebRTC platform is broken on NVIDIA based GPU machine
+- LP #1912521 Dashboard charm does not set application version
+- LP #1912588 `anbox-cloud-tests` for gateway, sometime fails to launch container
+- LP #1912732 Anbox Cloud dashboard does not show all of the panes correctly
+- LP #1912784 Dashboard register URL is still on HTTP
+- LP #1912785 AMC failed to create container with error, however in LXD it was successfully created
+- LP #1912787 Status message of a session with status error is empty when container crashed
+- LP #1912932 CTS tests claims `EGL_KHR_image` extension is missing
+- LP #1912956 Native SDK example crashes when trying to lock destroyed mutex
+- LP #1913017 SEGV when terminating the streaming on Android client built against native SDK
+- LP #1913020 FORTIFY: `pthread_mutex_lock` called on a destroyed mutex on AudioTrack thread
+- LP #1913058 `gpu-support.sh` script unloads kernel drivers when current driver is already the correct one
+- LP #1913264 Anbox Cloud Dashboard stuck on `waiting for UA` even with UA source configured
+- LP #1913305 Charm stays in blocked when `ua attach` failed
+- LP #1913364 Meaningless/Invalid resource is listed in the response when deleting an addon version
+- LP #1913391 Coturn uses location as external address when external_address_from_location is set to false
+- LP #1913403 AMS crashed when exporting an application version
+- LP #1913436 Update the command description of `amc config set`
+- LP #1913457 LXD container cgroup metrics are not reported via subordinate telegraf charm
+- LP #1913462 On ARM64 systems not loaded `nvidia_uvm` kernel module crashes containers
+- LP #1913524 AMS crashed when executing a command within a container by posting a body
+- LP #1913528 The timestamp of event shows `0001-01-01T00:00:00Z`
+- LP #1914008 Juju fails to attach storage to LXD unit
+- LP #1914036 Dashboard sets 5min idle timeout
+- LP #1914188 Opened port is closed when port hasn't changed for gateway
+- LP #1914276 JS SDK reports "Unknown message type error" at times in Firefox
+- LP #1914435 Anbox Stream JS SDK always get `rear` facing mode no matter people switch the camera face mode to "front" or "rear"
+- LP #1914448 Dashboard register command gives private IP instead of public one
+- LP #1914811 NVIDIA kernel modules are not loaded after deployment
+- LP #1914991 Latest gateway API changes break dashboard
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.9.1.md
+++ b/reference/release-notes/1.9.1.md
@@ -9,36 +9,36 @@ The Anbox Cloud team is pleased to announce the release of Anbox Cloud 1.9.1
 
 ## New Features & Improvements
 
-* The Coturn charm is now able to figure out the public address of a manually added machine in a Juju model when deployed on AWS
-* The Coturn charm does now allow customizing the UDP relay port range
-* The AMS charm now has a `storage_pool` configuration option allowing AMS to configure LXD to use an existing storage pool
-* WebView based on [upstream 88.0.4324.181 release](https://chromereleases.googleblog.com/2021/02/chrome-for-android-update_16.html)
-* Android security updates for March 2021 (see [here](https://source.android.com/security/bulletin/2021-03-01) for more details)
+- The Coturn charm is now able to figure out the public address of a manually added machine in a Juju model when deployed on AWS
+- The Coturn charm does now allow customizing the UDP relay port range
+- The AMS charm now has a `storage_pool` configuration option allowing AMS to configure LXD to use an existing storage pool
+- WebView based on [upstream 88.0.4324.181 release](https://chromereleases.googleblog.com/2021/02/chrome-for-android-update_16.html)
+- Android security updates for March 2021 (see [here](https://source.android.com/security/bulletin/2021-03-01) for more details)
 
 ## Bugs
 
-* LP #1917578 Dashboards crashes in CI when ran on AWS because it can't reach metadata service
-* LP #1913565 Exposing services on private endpoint makes them not accessible
-* LP #1915183 [RFE] Support Manual Provider on top of AWS
-* LP #1915244 Dashboard should not listen on 0.0.0.0
-* LP #1915258 Camera support does not work in dashboard
-* LP #1915461 Dashboard missed an APT update before upgrading
-* LP #1915564 Container launch is not aborted when no free port is found
-* LP #1915691 Gateway fails to update session status to error due to timeout
-* LP #1915720 Anbox does not fallback to software encoder when all GPU encoder slots are used
-* LP #1915812 Dashboard charm fails to deploy with AttributeError
-* LP #1916006 Session cannot be connected again after gateway is restarted
-* LP #1916474 The 1.9 benchmark fails to collect any metrics
-* LP #1916535 Unable to locate package `cuda-libraries-11-0`
-* LP #1916894 Multiple AMS instances race around cluster cert generation
-* LP #1917281 A wrong camera(front) is used by WebRTC platform when a camera-based application is open up
-* LP #1917296 Touch doesn't work on safari when streaming on IOS
-* LP #1917434 Native Stream SDK crashes when stopped
-* LP #1917526 Native SDK crashes when signaling server uses DNS name instead of IP address
-* LP #1915245 UA layer doesn't print the "Missing UA Token" when deploying Anbox Cloud
-* LP #1915600 AMS configuration is not updated when port range is changed
-* LP #1917053 `linux-modules-extra` package should be installed as the dependency of `anbox-module-dkms` when bootstrapping LXD charm
-* LP #1917286 no audio output for streaming on IOS and Mac OS
+- LP #1917578 Dashboards crashes in CI when ran on AWS because it can't reach metadata service
+- LP #1913565 Exposing services on private endpoint makes them not accessible
+- LP #1915183 [RFE] Support Manual Provider on top of AWS
+- LP #1915244 Dashboard should not listen on 0.0.0.0
+- LP #1915258 Camera support does not work in dashboard
+- LP #1915461 Dashboard missed an APT update before upgrading
+- LP #1915564 Container launch is not aborted when no free port is found
+- LP #1915691 Gateway fails to update session status to error due to timeout
+- LP #1915720 Anbox does not fallback to software encoder when all GPU encoder slots are used
+- LP #1915812 Dashboard charm fails to deploy with AttributeError
+- LP #1916006 Session cannot be connected again after gateway is restarted
+- LP #1916474 The 1.9 benchmark fails to collect any metrics
+- LP #1916535 Unable to locate package `cuda-libraries-11-0`
+- LP #1916894 Multiple AMS instances race around cluster cert generation
+- LP #1917281 A wrong camera(front) is used by WebRTC platform when a camera-based application is open up
+- LP #1917296 Touch doesn't work on safari when streaming on IOS
+- LP #1917434 Native Stream SDK crashes when stopped
+- LP #1917526 Native SDK crashes when signaling server uses DNS name instead of IP address
+- LP #1915245 UA layer doesn't print the "Missing UA Token" when deploying Anbox Cloud
+- LP #1915600 AMS configuration is not updated when port range is changed
+- LP #1917053 `linux-modules-extra` package should be installed as the dependency of `anbox-module-dkms` when bootstrapping LXD charm
+- LP #1917286 no audio output for streaming on IOS and Mac OS
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.9.2.md
+++ b/reference/release-notes/1.9.2.md
@@ -9,18 +9,18 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New Features & Improvements
 
-* Stability and reliability improvements in AMS and the Juju charms for auto scaling of the LXD cluster. See the {ref}`sec-lxd-auto-scaling` for recommendations and guidelines on how to implement auto scaling.
+- Stability and reliability improvements in AMS and the Juju charms for auto scaling of the LXD cluster. See the {ref}`sec-lxd-auto-scaling` for recommendations and guidelines on how to implement auto scaling.
 
 ## Bugs
 
-* LP #1910676 AMS leaks file descriptors
-* LP #1917862 AMS charm tries to add/remove node when AMS service is not available
-* LP #1917867 LXD charm doesn't respect configured channel
-* LP #1917869 AMS fails to get started due to error `tls: private key does not match public key` when multiple AMS units are deployed
-* LP #1918089 Failed to remove LXD node from cluster
-* LP #1918431 Container logs are missing in a HA AMS
-* LP #1918675 Image synchronization is not triggered in AMS when relevant config items change
-* LP #1918676 Image server configuration can be stale in HA AMS
+- LP #1910676 AMS leaks file descriptors
+- LP #1917862 AMS charm tries to add/remove node when AMS service is not available
+- LP #1917867 LXD charm doesn't respect configured channel
+- LP #1917869 AMS fails to get started due to error `tls: private key does not match public key` when multiple AMS units are deployed
+- LP #1918089 Failed to remove LXD node from cluster
+- LP #1918431 Container logs are missing in a HA AMS
+- LP #1918675 Image synchronization is not triggered in AMS when relevant config items change
+- LP #1918676 Image server configuration can be stale in HA AMS
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.9.3.md
+++ b/reference/release-notes/1.9.3.md
@@ -9,36 +9,36 @@ Please see {ref}`ref-component-versions` for a list of updated components.
 
 ## New Features & Improvements
 
-* The LXD charm can now take a `lxd-binary` resource which allows attaching and detaching custom build LXD binaries
-* `amc delete` has now a `--force` flag which allows deleting container without gracefully stopping them
-* The number of internal workers in AMS responsible to delete and stop containers in parallel is now increased to 10
-* The Android `rild` service is now disabled but default as it was never intended to be active
-* WebView based on [upstream 89.0.4389.105 release](https://chromereleases.googleblog.com/2021/03/chrome-for-android-update_22.html)
-* Android security updates for April 2021 (see [here](https://source.android.com/security/bulletin/2021-04-01) for more details)
+- The LXD charm can now take a `lxd-binary` resource which allows attaching and detaching custom build LXD binaries
+- `amc delete` has now a `--force` flag which allows deleting container without gracefully stopping them
+- The number of internal workers in AMS responsible to delete and stop containers in parallel is now increased to 10
+- The Android `rild` service is now disabled but default as it was never intended to be active
+- WebView based on [upstream 89.0.4389.105 release](https://chromereleases.googleblog.com/2021/03/chrome-for-android-update_22.html)
+- Android security updates for April 2021 (see [here](https://source.android.com/security/bulletin/2021-04-01) for more details)
 
 ## Bugs
 
-* LP #1917768 A crash occurred in the `glib` main loop thread during the streaming
-* LP #1918601 Metrics reported by AMS are out-of-sync
-* LP #1919443 LXD charm fails to stop when unit has active containers
-* LP #1920129 Allow mounts to be injected into Android container at runtime
-* LP #1920207 `ImagesSuite.TestDoesntUpdateWhenNoNewVersion` fails at times
-* LP #1921060 Application can't access its isolated folder under `SDcard` even after it's granted `android.permission.WRITE_EXTERNAL_STORAGE` and `android.permission.READ_EXTERNAL_STORAGE` permissions
-* LP #1921372 Anbox freezes on shutdown after crash
-* LP #1922198 Gateway patch application is racy in 1.9.x
-* LP #1922343 Native crash happened at time in WebRTC platform when restarting a session
-* LP #1922655 Configured GPU slots are overridden
-* LP #1922722 Backup hook doesn't get executed properly when a container ran into an error
-* LP #1923411 None active sensors shown up after Android fully get started
-* LP #1923414 WebRTC session gets restarted in a busy loop even after a session has gone
-* LP #1923623 AMS end up with embedded etcd when deployed in HA
-* LP #1875542 The spread test `aam-backup-restore:exclude_files` is flaky sometimes
-* LP #1899948 Stream gateway: DB patches can run into race conditions
-* LP #1912757 Anbox Streaming Stack dashboard does not show "Agents" pane
-* LP #1920120 AMS charm should not try to manage the cluster when related to `lxd-integrator`
-* LP #1922311 Anbox HTTP API server accepts empty sensor data
-* LP #1922313 `rild` service auto started when Android system fully boots up
-* LP #1916047 Daemon subcommand of the appliance is not hidden
+- LP #1917768 A crash occurred in the `glib` main loop thread during the streaming
+- LP #1918601 Metrics reported by AMS are out-of-sync
+- LP #1919443 LXD charm fails to stop when unit has active containers
+- LP #1920129 Allow mounts to be injected into Android container at runtime
+- LP #1920207 `ImagesSuite.TestDoesntUpdateWhenNoNewVersion` fails at times
+- LP #1921060 Application can't access its isolated folder under `SDcard` even after it's granted `android.permission.WRITE_EXTERNAL_STORAGE` and `android.permission.READ_EXTERNAL_STORAGE` permissions
+- LP #1921372 Anbox freezes on shutdown after crash
+- LP #1922198 Gateway patch application is racy in 1.9.x
+- LP #1922343 Native crash happened at time in WebRTC platform when restarting a session
+- LP #1922655 Configured GPU slots are overridden
+- LP #1922722 Backup hook doesn't get executed properly when a container ran into an error
+- LP #1923411 None active sensors shown up after Android fully get started
+- LP #1923414 WebRTC session gets restarted in a busy loop even after a session has gone
+- LP #1923623 AMS end up with embedded etcd when deployed in HA
+- LP #1875542 The spread test `aam-backup-restore:exclude_files` is flaky sometimes
+- LP #1899948 Stream gateway: DB patches can run into race conditions
+- LP #1912757 Anbox Streaming Stack dashboard does not show "Agents" pane
+- LP #1920120 AMS charm should not try to manage the cluster when related to `lxd-integrator`
+- LP #1922311 Anbox HTTP API server accepts empty sensor data
+- LP #1922313 `rild` service auto started when Android system fully boots up
+- LP #1916047 Daemon subcommand of the appliance is not hidden
 
 ## Upgrade Instructions
 

--- a/reference/release-notes/1.9.5.md
+++ b/reference/release-notes/1.9.5.md
@@ -13,7 +13,7 @@ No features were added in this release.
 
 ## Bugs
 
-* LP #1927676 No image is imported in AMS when deploying 1.9.x based Anbox Cloud
+- LP #1927676 No image is imported in AMS when deploying 1.9.x based Anbox Cloud
 
     With Anbox Cloud 1.10 packages are now version specific which allows users to deploy older versions of Anbox Cloud while a newer version is available. Due to a bug in AMS 1.9.x no images were imported as the 1.10 ones were always seen as newer (when `images.version_lockstep` is set to `true`) and older 1.9.x images were not considered. With 1.9.5 AMS will now correctly download the latest 1.9.x image and ignore any newer one.
 

--- a/reference/release-notes/release-notes-template.md
+++ b/reference/release-notes/release-notes-template.md
@@ -19,8 +19,8 @@ See [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/refere
 
 < Remember to include the below information >
 
-* Android security updates for < insert-month-year > (see Android Security Bulletin - < insert-month-year along with the link to bulletin > for more information).
-* The Android WebView has been updated to < insert-version-along-with-link >.
+- Android security updates for < insert-month-year > (see Android Security Bulletin - < insert-month-year along with the link to bulletin > for more information).
+- The Android WebView has been updated to < insert-version-along-with-link >.
 
 ## Removed functionality
 

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -47,13 +47,13 @@ If you are looking for additional support, see [Ubuntu Pro](https://ubuntu.com/s
 
 Along with bug fixes and general improvements, Anbox Cloud 1.29.x includes:
 
-* New instance copy feature for near-instantaneous cloning of existing instances
-* Instance publishing support to create reusable images from running or stopped instances
-* Runtime bitrate control for WebRTC streaming
-* Optimized disk quota with two-tier validation
-* Migration to modernized charms, including charmed-etcd and self-signed-certificates
-* Fine-grained authorization through OpenFGA integration
-* Bug fixes
+- New instance copy feature for near-instantaneous cloning of existing instances
+- Instance publishing support to create reusable images from running or stopped instances
+- Runtime bitrate control for WebRTC streaming
+- Optimized disk quota with two-tier validation
+- Migration to modernized charms, including charmed-etcd and self-signed-certificates
+- Fine-grained authorization through OpenFGA integration
+- Bug fixes
 
 <details><summary>Click to view earlier releases' notes</summary>
 

--- a/reference/requirements.md
+++ b/reference/requirements.md
@@ -29,8 +29,8 @@ Ensure that your deployment environment uses a CPU architecture officially suppo
 
 The appliance supports the following Ubuntu versions:
 
-* Ubuntu 22.04 LTS (Jammy Jellyfish)
-* Ubuntu 24.04 LTS (Noble Numbat)
+- Ubuntu 22.04 LTS (Jammy Jellyfish)
+- Ubuntu 24.04 LTS (Noble Numbat)
 
 ### LXD
 
@@ -44,10 +44,10 @@ If LXD is already installed but the version is earlier than 5.0, run `snap refre
 
 The following hardware specifications are required for running the appliance:
 
-* 64 bit x86 or Arm CPU with >= 4 CPU cores
-* 8 GB of memory
-* 30 GB of free disk space on the main disk
-* (optional) 100GB block volume to host instance storage
+- 64 bit x86 or Arm CPU with >= 4 CPU cores
+- 8 GB of memory
+- 30 GB of free disk space on the main disk
+- (optional) 100GB block volume to host instance storage
 
 The above recommendation is the minimum requirement to run the appliance. As Anbox Cloud is dependent on available resources to launch its Android containers, the available resources dictate the maximum number of possible Android containers. See {ref}`exp-capacity-planning` for an explanation on how to plan for a specific capacity on your appliance.
 
@@ -63,8 +63,8 @@ Anbox Cloud deployments are managed by Juju. They can be created on all the [sup
 
 Charmed Anbox Cloud supports the following Ubuntu versions:
 
-* Ubuntu 22.04 LTS (Jammy Jellyfish)
-* Ubuntu 24.04 LTS (Noble Numbat)
+- Ubuntu 22.04 LTS (Jammy Jellyfish)
+- Ubuntu 24.04 LTS (Noble Numbat)
 
 ```{note}
 Currently, the Juju bundle uses Ubuntu 20.04 for the machine that runs a [HAProxy load balancer](https://charmhub.io/haproxy). However, all supported Anbox Cloud charms use Ubuntu 22.04 or 24.04. So if you are using a load balancer, you should manually upgrade the revision of your HAProxy charm.
@@ -129,7 +129,7 @@ Some additional information:
 
 Applications not maintained by Anbox Cloud may have different hardware recommendations:
 
-* **etcd**: [Hardware recommendations](https://etcd.io/docs/v3.5/op-guide/hardware/)
-* **HAProxy** (load balancer for the Stream Gateway and the dashboard): [Installation](https://www.haproxy.com/documentation/haproxy-enterprise/getting-started/installation/linux/)
+- **etcd**: [Hardware recommendations](https://etcd.io/docs/v3.5/op-guide/hardware/)
+- **HAProxy** (load balancer for the Stream Gateway and the dashboard): [Installation](https://www.haproxy.com/documentation/haproxy-enterprise/getting-started/installation/linux/)
 
 Please note that these are just baselines and should be adapted to your workload. No matter the application, monitoring and tuning the performance is always important. See {ref}`exp-performance` for more information.

--- a/reference/sdks.md
+++ b/reference/sdks.md
@@ -28,8 +28,8 @@ You need the following build dependencies:
 
 The Anbox Platform SDK provides a collection of example platform plugins to help developers get started with plugin development. The following examples are included:
 
-* `minimal` - A platform plugin that provides a sample implementation of a minimal platform plugin to demonstrate the general plugin layout.
-* `audio_streaming` - A platform plugin that provides a more advanced example of how a platform plugin can process audio and input data.
+- `minimal` - A platform plugin that provides a sample implementation of a minimal platform plugin to demonstrate the general plugin layout.
+- `audio_streaming` - A platform plugin that provides a more advanced example of how a platform plugin can process audio and input data.
 
 (sec-ams-sdk)=
 ## AMS SDK
@@ -61,8 +61,8 @@ The Anbox Cloud streaming SDK allows the development of custom streaming clients
 
 Under the hood, the SDK is actually comprised of two components:
 
-* The connector that communicates to the stream backend (either the stream gateway or your own middleware) and initiates the WebRTC setup.
-* The stream class that displays the video and audio feed, handle controls, life-cycle events and more.
+- The connector that communicates to the stream backend (either the stream gateway or your own middleware) and initiates the WebRTC setup.
+- The stream class that displays the video and audio feed, handle controls, life-cycle events and more.
 
 Having these two components makes it easier to plug your own software in the SDK rather than having to re-write everything again.
 

--- a/reference/supported-codecs.md
+++ b/reference/supported-codecs.md
@@ -7,9 +7,9 @@ Not all codecs are supported by one or more of the supported GPU models, neither
 
 The supported video codecs are:
 
-* H.264 - The use of H.264 requires a license from the [MPEG LA](https://www.via-la.com/). Ensure you have the rights to stream H.264 encoded video content to your users.
-* AV1 - Depending on the GPU model used in the deployment, AV1 hardware encoding is the default preference over H.264 on supported GPUs, such as NVIDIA Ada Lovelace Architecture-based GPUs like L4. Otherwise, it will fallback to AV1 software encoding.
-* VP8
+- H.264 - The use of H.264 requires a license from the [MPEG LA](https://www.via-la.com/). Ensure you have the rights to stream H.264 encoded video content to your users.
+- AV1 - Depending on the GPU model used in the deployment, AV1 hardware encoding is the default preference over H.264 on supported GPUs, such as NVIDIA Ada Lovelace Architecture-based GPUs like L4. Otherwise, it will fallback to AV1 software encoding.
+- VP8
 
 Anbox Cloud currently supports the Opus audio codec.
 

--- a/reference/supported-rendering-resources.md
+++ b/reference/supported-rendering-resources.md
@@ -12,9 +12,9 @@ Currently Anbox Cloud does not support GPU for virtual machines.
 
 Being a cloud solution, Anbox Cloud is optimized for GPUs that are designed for a data center. We currently support the following GPU vendors:
 
-* NVIDIA
-* Intel
-* AMD
+- NVIDIA
+- Intel
+- AMD
 
 Mixing GPUs from different vendors is not supported.
 
@@ -69,10 +69,10 @@ Support for API extensions on all supported GPUs depends on the availability of 
 
 The following OpenGL ES extensions are known to be unsupported by all used GPU drivers:
 
-* [`GL_EXT_shader_framebuffer_fetch`](https://registry.khronos.org/OpenGL/extensions/EXT/EXT_shader_framebuffer_fetch.txt)
-* [`GL_EXT_shader_framebuffer_fetch_non_coherent`](https://registry.khronos.org/OpenGL/extensions/EXT/EXT_shader_framebuffer_fetch.txt)
+- [`GL_EXT_shader_framebuffer_fetch`](https://registry.khronos.org/OpenGL/extensions/EXT/EXT_shader_framebuffer_fetch.txt)
+- [`GL_EXT_shader_framebuffer_fetch_non_coherent`](https://registry.khronos.org/OpenGL/extensions/EXT/EXT_shader_framebuffer_fetch.txt)
 
 ## Related topics
 
-* {ref}`exp-rendering-architecture`
-* {ref}`exp-platforms`
+- {ref}`exp-rendering-architecture`
+- {ref}`exp-platforms`

--- a/reference/webrtc-streamer.md
+++ b/reference/webrtc-streamer.md
@@ -27,8 +27,8 @@ As different resolutions require different bitrates, the bitrate limits allow de
 
 The WebRTC streamer will pick the closest limit for the configured resolution by comparing the number of pixels and frame rate. The following rules apply:
 
-* If more than one limit is specified, the WebRTC streamer selects the nearest limit with a number of pixels higher than the number of pixels that a frame of the given resolution has.
-* If multiple limits have the same number of pixels, the streamer will sort limits descending by frame rate and apply the nearest.
+- If more than one limit is specified, the WebRTC streamer selects the nearest limit with a number of pixels higher than the number of pixels that a frame of the given resolution has.
+- If multiple limits have the same number of pixels, the streamer will sort limits descending by frame rate and apply the nearest.
 
 The JSON object defining a bitrate limit has the following possible fields:
 


### PR DESCRIPTION
# Documentation changes

List bullet markers (* vs -) across the docs are now consistent and  standardized to (-) per [the reference](https://canonical-starter-pack.readthedocs-hosted.com/stable/reference/myst-syntax-reference/#lists) 

The files not affected:

- docs cheat sheet
- auto-generated content

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,

- [ ] Run `make spelling` and fix any spelling issues.
- [ ] Run `make linkcheck` and fix any broken links.
- [ ] Run `make lint-md` and fix any linting issues.
- [ ] Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]
