### PR TITLE
added release notes draft for Anbox Cloud 1.30.0 

### DIFF
--- a/howto/install/enable-high-availability.md
+++ b/howto/install/enable-high-availability.md
@@ -10,7 +10,7 @@ myst:
 Anbox Cloud comes with support for high availability (HA) for both Core and the Streaming Stack.
 In addition to Juju's support for high availability of the Juju controller (see [Juju documentation](https://documentation.ubuntu.com/juju/latest/howto/manage-controllers#make-a-controller-highly-available)), you can add HA for the Anbox Management Service (AMS) and the Anbox Stream Gateway to ensure fault tolerance and higher uptime.
 
-Enabling high availability (HA for short) is achieved by adding new units via Juju (see [Juju documentation](https://documentation.ubuntu.com/juju/latest/howto/manage-applications#scale-an-application)).
+Enabling high availability (HA for short) is achieved by adding new units via Juju (see [Juju documentation](https://canonical.com/juju/docs/terraform-provider-juju/2.0/howto/manage-applications/#scale-an-application)).
 This will allocate a new machine, run new instances of the scaled application and configure the cluster automatically.
 
 Adding a unit is done with the following syntax:
@@ -85,7 +85,7 @@ anbox-stream-gateway/2      active    idle   4       10.212.218.136  4000/tcp,70
 
 ## Scaling down
 
-Scaling down can be done by removing units via Juju (see [Juju documentation](https://documentation.ubuntu.com/terraform-provider-juju/latest/howto/manage-applications/#scale-an-application)). You have to specifically target the unit that you want to remove:
+Scaling down can be done by removing units via Juju (see [Juju documentation](https://canonical.com/juju/docs/terraform-provider-juju/2.0/howto/manage-applications/#scale-an-application)). You have to specifically target the unit that you want to remove:
 
     juju remove-unit anbox-stream-agent/2
 

--- a/reference/component-versions.md
+++ b/reference/component-versions.md
@@ -57,6 +57,23 @@ Not all components are updated with each release. When components are not update
 | anbox-cloud-dashboard | 1.30/stable | 4712 | 4711 | 1.30.0-2c0be4f6c |
 | anbox-connect | latest/stable | 2037 | 2036 | 1.30.0-2c0be4f6c |
 
+### Anbox images
+
+| Name | Version | Execution environment |
+|----------------------------|---------------------------------|---------------------|
+| `jammy:android14:amd64` | `1.30.0-20260610021926.git353c487` | Containerized |
+| `jammy:android14:arm64` | `1.30.0-20260610021926.git353c487` | Containerized |
+| `jammy:android15:amd64` | `1.30.0-20260610021926.git353c487` | Containerized |
+| `jammy:android15:arm64` | `1.30.0-20260610021926.git353c487` | Containerized |
+| `jammy:aaos14:amd64` | `1.30.0-20260610021926.git353c487` | Containerized |
+| `jammy:aaos14:arm64` | `1.30.0-20260610021926.git353c487` | Containerized |
+| `jammy:aaos15:amd64` | `1.30.0-20260610021926.git353c487` | Containerized |
+| `jammy:aaos15:arm64` | `1.30.0-20260610021926.git353c487` | Containerized |
+| `resolute:android16-cf:amd64` | `1.30.0-20260610021926.git353c487` | Virtualized |
+| `resolute:android16-cf:arm64` | `1.30.0-20260610021926.git353c487` | Virtualized |
+| `resolute:aaos16-cf:amd64` | `1.30.0-20260610021926.git353c487` | Virtualized |
+| `resolute:aaos16-cf:arm64` | `1.30.0-20260610021926.git353c487` | Virtualized |
+
 ## 1.29.2
 
 ### Charms

--- a/reference/component-versions.md
+++ b/reference/component-versions.md
@@ -11,6 +11,52 @@ This documents the versions of the different components for each Anbox Cloud rel
 
 Not all components are updated with each release. When components are not updated, they are marked with `n/a` below.
 
+## 1.30.0
+
+### Charms
+
+#### Ubuntu 22.04 LTS
+
+| Name | Channel | Revision (AMD64) | Revision (ARM64) | Version |
+|------|---------|------------------|------------------|---------|
+| ams | 1.30/stable | 1531 | 1532 | 1.30.0-2eb8312 |
+| ams-lxd | 1.30/stable | 1390 | 1391 | 1.30.0-2eb8312 |
+| coturn | 1.30/stable | 1315 | 1316 | 1.30.0-2eb8312 |
+| anbox-stream-gateway | 1.30/stable | 1438 | 1439 | 1.30.0-2eb8312 |
+| anbox-stream-agent | 1.30/stable | 1431 | 1432 | 1.30.0-2eb8312 |
+| anbox-cloud-dashboard | 1.30/stable | 1356 | 1357 | 1.30.0-2eb8312 |
+| aar | 1.30/stable | 1532 | 1533 | 1.30.0-2eb8312 |
+| lxd-integrator | 1.30/stable | 784 | 785 | 1.30.0-2eb8312 |
+| anbox-cloud-cos-configuration | 1.30/stable | 642 | 643 | 1.30.0-2eb8312 |
+
+#### Ubuntu 24.04 LTS
+
+| Name | Channel | Revision (AMD64) | Revision (ARM64) | Version |
+|------|---------|------------------|------------------|---------|
+| ams | 1.30/stable | 1533 | 1534 | 1.30.0-2eb8312 |
+| ams-lxd | 1.30/stable | 1392 | 1393 | 1.30.0-2eb8312 |
+| coturn | 1.30/stable | 1317 | 1318 | 1.30.0-2eb8312 |
+| anbox-stream-gateway | 1.30/stable | 1440 | 1441 | 1.30.0-2eb8312 |
+| anbox-stream-agent | 1.30/stable | 1433 | 1434 | 1.30.0-2eb8312 |
+| anbox-cloud-dashboard | 1.30/stable | 1358 | 1359 | 1.30.0-2eb8312 |
+| aar | 1.30/stable | 1534 | 1535 | 1.30.0-2eb8312 |
+| lxd-integrator | 1.30/stable | 786 | 787 | 1.30.0-2eb8312 |
+| anbox-cloud-cos-configuration | 1.30/stable | 644 | 645 | 1.30.0-2eb8312 |
+
+### Snaps
+
+| Name | Channel | Revision (AMD64) | Revision (ARM64) | Version |
+|------|---------|------------------|------------------|---------|
+| ams | 1.30/stable | 3031 | 3030 | 1.30.0-2c0be4f6c |
+| ams-node-controller | 1.30/stable | 2604 | 2603 | 1.30.0-2c0be4f6c |
+| amc | latest/stable | 2822 | 2821 | 1.30.0-2c0be4f6c |
+| aar | 1.30/stable | 2975 | 2974 | 1.30.0-2c0be4f6c |
+| anbox-stream-agent | 1.30/stable | 3245 | 3244 | 1.30.0-2c0be4f6c |
+| anbox-stream-gateway | 1.30/stable | 3210 | 3209 | 1.30.0-2c0be4f6c |
+| anbox-cloud-appliance | 1.30/stable | 2885 | 2884 | 1.30.0-2c0be4f6c |
+| anbox-cloud-dashboard | 1.30/stable | 4712 | 4711 | 1.30.0-2c0be4f6c |
+| anbox-connect | latest/stable | 2037 | 2036 | 1.30.0-2c0be4f6c |
+
 ## 1.29.2
 
 ### Charms

--- a/reference/release-notes/1.30.0.md
+++ b/reference/release-notes/1.30.0.md
@@ -1,0 +1,47 @@
+---
+orphan: true
+---
+# 1.30.0
+
+These release notes cover new features and changes in Anbox Cloud 1.30.0.
+
+Anbox Cloud 1.30.0 is a minor release. To understand minor and patch releases, see [Release notes](https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/release-notes/release-notes).
+
+Please see [Component versions](https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/component-versions/) for a list of updated components.
+
+## Requirements
+
+See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/requirements/) for details on general and deployment specific requirements to run Anbox Cloud.
+
+## New features & improvements
+
+<!-- List features here as sub-sections -->
+
+## Removed functionality
+
+There are no removed functionalities in this release.
+
+## Deprecations
+
+There are no deprecations in this release.
+
+## Known issues
+
+See our [open bugs in Launchpad](https://bugs.launchpad.net/anbox-cloud/+bugs?field.searchtext=&orderby=-importance&field.status%3Alist=NEW&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.status%3Alist=INPROGRESS&field.status%3Alist=INCOMPLETE_WITH_RESPONSE&field.status%3Alist=INCOMPLETE_WITHOUT_RESPONSE&assignee_option=any&field.assignee=&field.bug_reporter=&field.bug_commenter=&field.subscriber=&field.structural_subscriber=&field.tag=&field.tags_combinator=ANY&field.has_cve.used=&field.omit_dupes.used=&field.omit_dupes=on&field.affects_me.used=&field.has_patch.used=&field.has_branches.used=&field.has_branches=on&field.has_no_branches.used=&field.has_no_branches=on&field.has_blueprints.used=&field.has_blueprints=on&field.has_no_blueprints.used=&field.has_no_blueprints=on&search=Search).
+
+## CVEs
+
+The fixes for the following CVEs are included with the 1.30.0 release:
+
+<!-- List CVEs fixed in 1.30.0 here -->
+
+| CVE | Affected components |
+|-----|-------------------|
+
+## Bug fixes
+
+<!-- List bugs fixed in 1.30.0 here -->
+
+## Upgrade instructions
+
+See [How to upgrade Anbox Cloud](https://documentation.ubuntu.com/anbox-cloud/en/latest/howto/update/upgrade-anbox/#howto-upgrade-anbox-cloud) and [How to upgrade the Anbox Cloud Appliance](https://documentation.ubuntu.com/anbox-cloud/en/latest/howto/update/upgrade-appliance/#howto-upgrade-appliance) for instructions on how to update your Anbox Cloud deployment to the 1.30.0 release.

--- a/reference/release-notes/1.30.0.md
+++ b/reference/release-notes/1.30.0.md
@@ -15,11 +15,41 @@ See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/re
 
 ## New features & improvements
 
-<!-- List features here as sub-sections -->
+### Stream controls overhaul
+
+The stream page of the dashboard now features a vertical controls bar. In addition to the existing actions, the following new controls have been added:
+
+- Resize
+- Rotate left/right
+- Volume up/down
+- Power
+- Home
+- Back
+- Keyboard capture toggle
+- Screenshot
+- Screen recording
+
+### Instance copy support in the dashboard
+
+You can now create an instance using another existing instance as a source, inheriting its disk state and metadata configuration. When an instance is selected as a source, form fields are pre-filled with the data of the source instance, reducing both provision time and network load.
+
+
+### Anbox Cloud Terraform plan
+
+The [Anbox Cloud Terraform plan](https://github.com/canonical/anbox-cloud-terraform) is now released as the supported method for charm-based deployments of Anbox Cloud.
+
+### Cuttlefish image support
+
+Anbox Cloud 1.30.0 introduces support for running Cuttlefish images.
+
+### Other
+
+- NVIDIA driver series 580 is now a hard requirement for Anbox Cloud deployments using NVIDIA GPUs.
+- <!-- The experimental feature line-->
 
 ## Removed functionality
 
-There are no removed functionalities in this release.
+- Starting with the 1.30.0 release, standalone bundles on Charmhub ([anbox-cloud-core](https://charmhub.io/anbox-cloud-core) and [anbox-cloud](https://charmhub.io/anbox-cloud)) are removed and unsupported. The [Anbox Cloud Terraform plan](https://github.com/canonical/anbox-cloud-terraform) is the only supported method for charm-based deployments going forward.
 
 ## Deprecations
 
@@ -40,7 +70,16 @@ The fixes for the following CVEs are included with the 1.30.0 release:
 
 ## Bug fixes
 
-<!-- List bugs fixed in 1.30.0 here -->
+- [LP 2125978](https://bugs.launchpad.net/anbox-cloud/+bug/2125978) The `[ams]` container management tests in `anbox-cloud-tests` always fail.
+- [LP 2142120](https://bugs.launchpad.net/anbox-cloud/+bug/2142120) Anbox crashes when using an NVIDIA 580.x driver.
+- [LP 2150144](https://bugs.launchpad.net/anbox-cloud/+bug/2150144) When opening a terminal for an AMS instance in the dashboard UI, `$PATH` is missing `/snap/bin`.
+- [LP 2111598](https://bugs.launchpad.net/anbox-cloud/+bug/2111598) With developer settings enabled in Android 15 with NVIDIA GPU, the *Settings* app crashes.
+- [LP 2133860](https://bugs.launchpad.net/anbox-cloud/+bug/2133860) Application errors out when its base image was cleaned up due to an initialization error.
+- [LP 2147407](https://bugs.launchpad.net/anbox-cloud/+bug/2147407) Running `amc copy` returns `Error: Architecture isn't supported:`.
+- [LP 2143068](https://bugs.launchpad.net/anbox-cloud/+bug/2143068) Instance copy does not preserve the settings of the source instance.
+- [LP 2150064](https://bugs.launchpad.net/anbox-cloud/+bug/2150064) AMS panics under certain conditions.
+- [LP 2101038](https://bugs.launchpad.net/anbox-cloud/+bug/2101038) The instance creation form does not remove a warning when a field gets cleared.
+- [LP 2150693](https://bugs.launchpad.net/anbox-cloud/+bug/2150693) An addon artifact unexpectedly disappears causing instance launch to fail.
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.30.0.md
+++ b/reference/release-notes/1.30.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.30.0: new features, improvements, and changes in this release."
 ---
 # 1.30.0
 
@@ -17,7 +20,7 @@ See the {ref}`Requirements <ref-requirements>` for details on general and deploy
 
 ### Stream controls overhaul
 
-The stream page of the dashboard now features a vertical controls bar. In addition to the existing actions, the following new controls have been added:
+The {ref}`stream page actions sidebar <ref-stream-page-actions>` in the dashboard has been redesigned and expanded. In addition to the existing actions, the following new controls have been added:
 
 - Resize
 - Rotate left/right
@@ -25,27 +28,31 @@ The stream page of the dashboard now features a vertical controls bar. In additi
 - Power
 - Home
 - Back
-- Keyboard capture toggle
+- Release / Capture keyboard
 - Screenshot
 - Screen recording
 
 ### Instance copy support in the dashboard
 
-You can now create an instance using another existing instance as a source, inheriting its disk state and metadata configuration. When an instance is selected as a source, form fields are pre-filled with the data of the source instance, reducing both provision time and network load.
+You can now {ref}`copy an instance <howto-copy-instance>` using another existing instance as a source, inheriting its disk state and metadata configuration. When an instance is selected as a source, form fields are pre-filled with the data of the source instance, reducing both provision time and network load.
 
 
 ### Anbox Cloud Terraform plan
 
 The [Anbox Cloud Terraform plan](https://github.com/canonical/anbox-cloud-terraform) is now released as the supported method for charm-based deployments of Anbox Cloud.
 
-### Cuttlefish image support
+### Virtualized Android
 
-Anbox Cloud 1.30.0 introduces support for running Cuttlefish images.
+Anbox Cloud 1.30.0 introduces virtualized Android as a new execution model, where Android runs inside a Cuttlefish virtual machine within the LXD instance. New `resolute:*-cf:*` images are available for Android 16 (AOSP and AAOS) on both `amd64` and `arm64`.
+
+### Experimental userspace scheduler support
+
+Anbox Cloud 1.30.0 adds experimental support for {ref}`userspace schedulers <howto-scx>` via the Linux kernel's `sched_ext` framework. This can help reduce latency in the streaming pipeline under high load on certain CPU configurations.
 
 ### Other
 
+- The Android WebView has been updated to 149.0.7827.60.
 - NVIDIA driver series 580 is now a hard requirement for Anbox Cloud deployments using NVIDIA GPUs.
-- <!-- The experimental feature line-->
 
 ## Removed functionality
 

--- a/reference/release-notes/1.30.0.md
+++ b/reference/release-notes/1.30.0.md
@@ -84,6 +84,7 @@ The fixes for the following CVEs are included with the 1.30.0 release:
 - [LP 2101038](https://bugs.launchpad.net/anbox-cloud/+bug/2101038) The instance creation form does not remove a warning when a field gets cleared.
 - [LP 2150693](https://bugs.launchpad.net/anbox-cloud/+bug/2150693) An addon artifact unexpectedly disappears causing instance launch to fail.
 - [LP 2154787](https://bugs.launchpad.net/anbox-cloud/+bug/2154787) A segmentation fault occurs when using a customised streaming client.
+- [LP 2150712](https://bugs.launchpad.net/anbox-cloud/+bug/2150712) Private bug
 
 ## Upgrade instructions
 

--- a/reference/release-notes/1.30.0.md
+++ b/reference/release-notes/1.30.0.md
@@ -5,13 +5,13 @@ orphan: true
 
 These release notes cover new features and changes in Anbox Cloud 1.30.0.
 
-Anbox Cloud 1.30.0 is a minor release. To understand minor and patch releases, see [Release notes](https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/release-notes/release-notes).
+Anbox Cloud 1.30.0 is a minor release. To understand minor and patch releases, see {ref}`Release notes <ref-release-notes>`.
 
-Please see [Component versions](https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/component-versions/) for a list of updated components.
+Please see {ref}`Component versions <ref-component-versions>` for a list of updated components.
 
 ## Requirements
 
-See the [Requirements](https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/requirements/) for details on general and deployment specific requirements to run Anbox Cloud.
+See the {ref}`Requirements <ref-requirements>` for details on general and deployment specific requirements to run Anbox Cloud.
 
 ## New features & improvements
 
@@ -53,7 +53,10 @@ Anbox Cloud 1.30.0 introduces support for running Cuttlefish images.
 
 ## Deprecations
 
-There are no deprecations in this release.
+Support for {ref}`applications <howto-manage-applications>`, {ref}`addons <howto-addons>`, and the Anbox Application Registry (AAR) ({ref}`howto-aar`) will be deprecated starting with 1.31.0.
+
+- In 1.31.0: Creating applications and managing the registry via the Anbox Cloud dashboard is disabled. However, applications, addons, and registry management remain functional through the CLI for transition purposes.
+- In 1.32.0: All support for applications, addons, and the AAR is officially removed. Users can no longer create, manage, or use these features via the CLI or dashboard.
 
 ## Known issues
 
@@ -80,7 +83,8 @@ The fixes for the following CVEs are included with the 1.30.0 release:
 - [LP 2150064](https://bugs.launchpad.net/anbox-cloud/+bug/2150064) AMS panics under certain conditions.
 - [LP 2101038](https://bugs.launchpad.net/anbox-cloud/+bug/2101038) The instance creation form does not remove a warning when a field gets cleared.
 - [LP 2150693](https://bugs.launchpad.net/anbox-cloud/+bug/2150693) An addon artifact unexpectedly disappears causing instance launch to fail.
+- [LP 2154787](https://bugs.launchpad.net/anbox-cloud/+bug/2154787) A segmentation fault occurs when using a customised streaming client.
 
 ## Upgrade instructions
 
-See [How to upgrade Anbox Cloud](https://documentation.ubuntu.com/anbox-cloud/en/latest/howto/update/upgrade-anbox/#howto-upgrade-anbox-cloud) and [How to upgrade the Anbox Cloud Appliance](https://documentation.ubuntu.com/anbox-cloud/en/latest/howto/update/upgrade-appliance/#howto-upgrade-appliance) for instructions on how to update your Anbox Cloud deployment to the 1.30.0 release.
+See {ref}`How to upgrade Anbox Cloud <howto-upgrade-anbox-cloud>` for instructions on how to update your Anbox Cloud deployment to the 1.30.0 release.

--- a/reference/release-notes/1.30.0.md
+++ b/reference/release-notes/1.30.0.md
@@ -18,6 +18,10 @@ See the {ref}`Requirements <ref-requirements>` for details on general and deploy
 
 ## New features & improvements
 
+### Virtualized Android support
+
+A new Android execution environment is now available: {ref}`virtualized Android <exp-android-execution-environments>`, where Android runs inside a Cuttlefish virtual machine within the LXD instance. New `resolute:*-cf:*` images for Android 16 (AOSP and AAOS) are available on both `amd64` and `arm64`. The existing containerized Android execution environment remains unchanged.
+
 ### Stream controls overhaul
 
 The {ref}`stream page actions sidebar <ref-stream-page-actions>` in the dashboard has been redesigned and expanded. In addition to the existing actions, the following new controls have been added:
@@ -41,10 +45,6 @@ You can now {ref}`copy an instance <howto-copy-instance>` using another existing
 The [Anbox Cloud Terraform plan](https://github.com/canonical/anbox-cloud-terraform) is now the supported method for charm-based deployments of Anbox Cloud.
 
 Find the latest 1.30.0 version in the [Anbox Cloud Terraform plan v1.30.0 release](https://github.com/canonical/anbox-cloud-terraform/releases/tag/v1.30.0).
-
-### Android execution environments
-
-A new Android execution environment is now available: {ref}`virtualized Android <exp-android-execution-environments>`, where Android runs inside a Cuttlefish virtual machine within the LXD instance. New `resolute:*-cf:*` images for Android 16 (AOSP and AAOS) are available on both `amd64` and `arm64`. The existing containerized Android execution environment remains unchanged.
 
 ### Experimental userspace scheduler support
 

--- a/reference/release-notes/1.30.0.md
+++ b/reference/release-notes/1.30.0.md
@@ -36,18 +36,17 @@ The {ref}`stream page actions sidebar <ref-stream-page-actions>` in the dashboar
 
 You can now {ref}`copy an instance <howto-copy-instance>` using another existing instance as a source, inheriting its disk state and metadata configuration. When an instance is selected as a source, form fields are pre-filled with the data of the source instance, reducing both provision time and network load.
 
-
 ### Anbox Cloud Terraform plan
 
-The [Anbox Cloud Terraform plan](https://github.com/canonical/anbox-cloud-terraform) is now released as the supported method for charm-based deployments of Anbox Cloud.
+The [Anbox Cloud Terraform plan](https://github.com/canonical/anbox-cloud-terraform) is now the supported method for charm-based deployments of Anbox Cloud.
 
-### Virtualized Android
+### Android execution environments
 
-Anbox Cloud 1.30.0 introduces virtualized Android as a new execution model, where Android runs inside a Cuttlefish virtual machine within the LXD instance. New `resolute:*-cf:*` images are available for Android 16 (AOSP and AAOS) on both `amd64` and `arm64`.
+A new Android execution environment is now available: virtualized Android, where Android runs inside a Cuttlefish virtual machine within the LXD instance. New `resolute:*-cf:*` images for Android 16 (AOSP and AAOS) are available on both `amd64` and `arm64`. The existing containerized Android execution environment remains unchanged.
 
 ### Experimental userspace scheduler support
 
-Anbox Cloud 1.30.0 adds experimental support for {ref}`userspace schedulers <howto-scx>` via the Linux kernel's `sched_ext` framework. This can help reduce latency in the streaming pipeline under high load on certain CPU configurations.
+Experimental support for {ref}`userspace schedulers <howto-scx>` is now available via the Linux kernel's `sched_ext` framework. This can help reduce latency in the streaming pipeline under high load on certain CPU configurations.
 
 ### Other
 
@@ -56,7 +55,7 @@ Anbox Cloud 1.30.0 adds experimental support for {ref}`userspace schedulers <how
 
 ## Removed functionality
 
-- Starting with the 1.30.0 release, standalone bundles on Charmhub ([anbox-cloud-core](https://charmhub.io/anbox-cloud-core) and [anbox-cloud](https://charmhub.io/anbox-cloud)) are removed and unsupported. The [Anbox Cloud Terraform plan](https://github.com/canonical/anbox-cloud-terraform) is the only supported method for charm-based deployments going forward.
+- Starting with the 1.30.0 release,standalone bundles on Charmhub ([anbox-cloud-core](https://charmhub.io/anbox-cloud-core) and [anbox-cloud](https://charmhub.io/anbox-cloud)) are no longer supported. The [Anbox Cloud Terraform plan](https://github.com/canonical/anbox-cloud-terraform) is the only supported method for charm-based deployments going forward.
 
 ## Deprecations
 

--- a/reference/release-notes/1.30.0.md
+++ b/reference/release-notes/1.30.0.md
@@ -42,7 +42,7 @@ The [Anbox Cloud Terraform plan](https://github.com/canonical/anbox-cloud-terraf
 
 ### Android execution environments
 
-A new Android execution environment is now available: virtualized Android, where Android runs inside a Cuttlefish virtual machine within the LXD instance. New `resolute:*-cf:*` images for Android 16 (AOSP and AAOS) are available on both `amd64` and `arm64`. The existing containerized Android execution environment remains unchanged.
+A new Android execution environment is now available: {ref}`virtualized Android <exp-android-execution-environments>`, where Android runs inside a Cuttlefish virtual machine within the LXD instance. New `resolute:*-cf:*` images for Android 16 (AOSP and AAOS) are available on both `amd64` and `arm64`. The existing containerized Android execution environment remains unchanged.
 
 ### Experimental userspace scheduler support
 
@@ -55,7 +55,7 @@ Experimental support for {ref}`userspace schedulers <howto-scx>` is now availabl
 
 ## Removed functionality
 
-- Starting with the 1.30.0 release,standalone bundles on Charmhub ([anbox-cloud-core](https://charmhub.io/anbox-cloud-core) and [anbox-cloud](https://charmhub.io/anbox-cloud)) are no longer supported. The [Anbox Cloud Terraform plan](https://github.com/canonical/anbox-cloud-terraform) is the only supported method for charm-based deployments going forward.
+- Starting with the 1.30.0 release, standalone bundles on Charmhub ([anbox-cloud-core](https://charmhub.io/anbox-cloud-core) and [anbox-cloud](https://charmhub.io/anbox-cloud)) are no longer supported. The [Anbox Cloud Terraform plan](https://github.com/canonical/anbox-cloud-terraform) is the only supported method for charm-based deployments going forward.
 
 ## Deprecations
 

--- a/reference/release-notes/1.30.0.md
+++ b/reference/release-notes/1.30.0.md
@@ -70,12 +70,145 @@ See our [open bugs in Launchpad](https://bugs.launchpad.net/anbox-cloud/+bugs?fi
 
 ## CVEs
 
-The fixes for the following CVEs are included with the 1.30.0 release:
+This release includes fixes for the following CVEs:
 
 <!-- List CVEs fixed in 1.30.0 here -->
 
+<!-- markdownlint-disable MD033 -->
+<details><summary>See the full list of CVEs fixed in 1.30.0</summary>
+
 | CVE | Affected components |
-|-----|-------------------|
+| ----- | ------------------- |
+| [CVE-2024-45341](https://nvd.nist.gov/vuln/detail/CVE-2024-45341) | Anbox |
+| [CVE-2024-45336](https://nvd.nist.gov/vuln/detail/CVE-2024-45336) | Anbox |
+| [CVE-2025-22871](https://nvd.nist.gov/vuln/detail/CVE-2025-22871) | Anbox |
+| [CVE-2025-47913](https://nvd.nist.gov/vuln/detail/CVE-2025-47913) | Anbox |
+| [CVE-2025-22873](https://nvd.nist.gov/vuln/detail/CVE-2025-22873) | Anbox (tools) |
+| [CVE-2025-47911](https://nvd.nist.gov/vuln/detail/CVE-2025-47911) | Anbox (tools) |
+| [CVE-2025-58190](https://nvd.nist.gov/vuln/detail/CVE-2025-58190) | Anbox (tools) |
+| [CVE-2026-0073](https://nvd.nist.gov/vuln/detail/CVE-2026-0073) | Android 14, 15, Cuttlefish 16 |
+| [CVE-2025-32313](https://nvd.nist.gov/vuln/detail/CVE-2025-32313) | Android 14, 15, Cuttlefish 16 |
+| [CVE-2026-33750](https://nvd.nist.gov/vuln/detail/CVE-2026-33750) | AMS |
+| [CVE-2026-25645](https://nvd.nist.gov/vuln/detail/CVE-2026-25645) | AMS |
+| [CVE-2026-41176](https://nvd.nist.gov/vuln/detail/CVE-2026-41176) | AMS |
+| [CVE-2026-41179](https://nvd.nist.gov/vuln/detail/CVE-2026-41179) | AMS |
+| [CVE-2026-33816](https://nvd.nist.gov/vuln/detail/CVE-2026-33816) | AMS |
+| [CVE-2023-28452](https://nvd.nist.gov/vuln/detail/CVE-2023-28452) | AMS |
+| [CVE-2025-47950](https://nvd.nist.gov/vuln/detail/CVE-2025-47950) | AMS |
+| [CVE-2025-58063](https://nvd.nist.gov/vuln/detail/CVE-2025-58063) | AMS |
+| [CVE-2026-26017](https://nvd.nist.gov/vuln/detail/CVE-2026-26017) | AMS |
+| [CVE-2026-26018](https://nvd.nist.gov/vuln/detail/CVE-2026-26018) | AMS |
+| [CVE-2022-27191](https://nvd.nist.gov/vuln/detail/CVE-2022-27191) | AMS |
+| [CVE-2026-34040](https://nvd.nist.gov/vuln/detail/CVE-2026-34040) | AMS |
+| [CVE-2026-32285](https://nvd.nist.gov/vuln/detail/CVE-2026-32285) | AMS |
+| [CVE-2022-27664](https://nvd.nist.gov/vuln/detail/CVE-2022-27664) | AMS |
+| [CVE-2022-41723](https://nvd.nist.gov/vuln/detail/CVE-2022-41723) | AMS |
+| [CVE-2023-39325](https://nvd.nist.gov/vuln/detail/CVE-2023-39325) | AMS |
+| [CVE-2025-22868](https://nvd.nist.gov/vuln/detail/CVE-2025-22868) | AMS |
+| [CVE-2024-24786](https://nvd.nist.gov/vuln/detail/CVE-2024-24786) | AMS |
+| [CVE-2026-39883](https://nvd.nist.gov/vuln/detail/CVE-2026-39883) | AMS |
+| [CVE-2022-32149](https://nvd.nist.gov/vuln/detail/CVE-2022-32149) | AMS |
+| [CVE-2025-66471](https://nvd.nist.gov/vuln/detail/CVE-2025-66471) | AMS |
+| [CVE-2026-32286](https://nvd.nist.gov/vuln/detail/CVE-2026-32286) | AMS |
+| [CVE-2023-33955](https://nvd.nist.gov/vuln/detail/CVE-2023-33955) | AMS |
+| [CVE-2024-0874](https://nvd.nist.gov/vuln/detail/CVE-2024-0874) | AMS |
+| [CVE-2023-30464](https://nvd.nist.gov/vuln/detail/CVE-2023-30464) | AMS |
+| [CVE-2025-68151](https://nvd.nist.gov/vuln/detail/CVE-2025-68151) | AMS |
+| [CVE-2022-2835](https://nvd.nist.gov/vuln/detail/CVE-2022-2835) | AMS |
+| [CVE-2022-2837](https://nvd.nist.gov/vuln/detail/CVE-2022-2837) | AMS |
+| [CVE-2023-48795](https://nvd.nist.gov/vuln/detail/CVE-2023-48795) | AMS |
+| [CVE-2026-33997](https://nvd.nist.gov/vuln/detail/CVE-2026-33997) | AMS |
+| [CVE-2023-49290](https://nvd.nist.gov/vuln/detail/CVE-2023-49290) | AMS |
+| [CVE-2024-21664](https://nvd.nist.gov/vuln/detail/CVE-2024-21664) | AMS |
+| [CVE-2024-28122](https://nvd.nist.gov/vuln/detail/CVE-2024-28122) | AMS |
+| [CVE-2022-41717](https://nvd.nist.gov/vuln/detail/CVE-2022-41717) | AMS |
+| [CVE-2023-3978](https://nvd.nist.gov/vuln/detail/CVE-2023-3978) | AMS |
+| [CVE-2023-45288](https://nvd.nist.gov/vuln/detail/CVE-2023-45288) | AMS |
+| [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) | AMS |
+| [CVE-2026-41131](https://nvd.nist.gov/vuln/detail/CVE-2026-41131) | AMS |
+| [CVE-2026-40293](https://nvd.nist.gov/vuln/detail/CVE-2026-40293) | AMS |
+| [CVE-2026-34972](https://nvd.nist.gov/vuln/detail/CVE-2026-34972) | AMS |
+| [CVE-2026-39882](https://nvd.nist.gov/vuln/detail/CVE-2026-39882) | AMS |
+| [CVE-2025-10543](https://nvd.nist.gov/vuln/detail/CVE-2025-10543) | AMS |
+| [CVE-2025-8869](https://nvd.nist.gov/vuln/detail/CVE-2025-8869) | AMS |
+| [CVE-2026-40179](https://nvd.nist.gov/vuln/detail/CVE-2026-40179) | AMS |
+| [CVE-2026-42327](https://nvd.nist.gov/vuln/detail/CVE-2026-42327) | Anbox |
+| [CVE-2025-65018](https://nvd.nist.gov/vuln/detail/CVE-2025-65018) | Android 14,15,16 |
+| [CVE-2025-64720](https://nvd.nist.gov/vuln/detail/CVE-2025-64720) | Android 14,15,16 |
+| [CVE-2025-22424](https://nvd.nist.gov/vuln/detail/CVE-2025-22424) | Android 14,15,16 |
+| [CVE-2025-22426](https://nvd.nist.gov/vuln/detail/CVE-2025-22426) | Android 14,15,16 |
+| [CVE-2025-48570](https://nvd.nist.gov/vuln/detail/CVE-2025-48570) | Android 14 |
+| [CVE-2025-48595](https://nvd.nist.gov/vuln/detail/CVE-2025-48595) | Android 14,15,16 |
+| [CVE-2025-48615](https://nvd.nist.gov/vuln/detail/CVE-2025-48615) | Android 14,15,16 |
+| [CVE-2025-48649](https://nvd.nist.gov/vuln/detail/CVE-2025-48649) | Android 14,15,16 |
+| [CVE-2025-48652](https://nvd.nist.gov/vuln/detail/CVE-2025-48652) | Android 15,16 |
+| [CVE-2026-0009](https://nvd.nist.gov/vuln/detail/CVE-2026-0009) | Android 15,16 |
+| [CVE-2026-0046](https://nvd.nist.gov/vuln/detail/CVE-2026-0046) | Android 14,15,16 |
+| [CVE-2026-0048](https://nvd.nist.gov/vuln/detail/CVE-2026-0048) | Android 14,15,16 |
+| [CVE-2026-0055](https://nvd.nist.gov/vuln/detail/CVE-2026-0055) | Android 14,15,16 |
+| [CVE-2026-0061](https://nvd.nist.gov/vuln/detail/CVE-2026-0061) | Android 14,15,16 |
+| [CVE-2026-0076](https://nvd.nist.gov/vuln/detail/CVE-2026-0076) | Android 14,15,16 |
+| [CVE-2026-0077](https://nvd.nist.gov/vuln/detail/CVE-2026-0077) | Android 16 |
+| [CVE-2026-0078](https://nvd.nist.gov/vuln/detail/CVE-2026-0078) | Android 14,15,16 |
+| [CVE-2026-0087](https://nvd.nist.gov/vuln/detail/CVE-2026-0087) | Android 14,15,16 |
+| [CVE-2026-0089](https://nvd.nist.gov/vuln/detail/CVE-2026-0089) | Android 16 |
+| [CVE-2026-0091](https://nvd.nist.gov/vuln/detail/CVE-2026-0091) | Android 14,15,16 |
+| [CVE-2026-0100](https://nvd.nist.gov/vuln/detail/CVE-2026-0100) | Android 14,15,16 |
+| [CVE-2026-28577](https://nvd.nist.gov/vuln/detail/CVE-2026-28577) | Android 14,15,16 |
+| [CVE-2026-28580](https://nvd.nist.gov/vuln/detail/CVE-2026-28580) | Android 16 |
+| [CVE-2026-0016](https://nvd.nist.gov/vuln/detail/CVE-2026-0016) | Android 16 |
+| [CVE-2026-0036](https://nvd.nist.gov/vuln/detail/CVE-2026-0036) | Android 14,15,16 |
+| [CVE-2026-0056](https://nvd.nist.gov/vuln/detail/CVE-2026-0056) | Android 14,15,16 |
+| [CVE-2026-28586](https://nvd.nist.gov/vuln/detail/CVE-2026-28586) | Android 14,15,16 |
+| [CVE-2025-32348](https://nvd.nist.gov/vuln/detail/CVE-2025-32348) | Android 14,15,16 |
+| [CVE-2026-0018](https://nvd.nist.gov/vuln/detail/CVE-2026-0018) | Android 15,16 |
+| [CVE-2026-0069](https://nvd.nist.gov/vuln/detail/CVE-2026-0069) | Android 14 |
+| [CVE-2026-0070](https://nvd.nist.gov/vuln/detail/CVE-2026-0070) | Android 14,15,16 |
+| [CVE-2026-28578](https://nvd.nist.gov/vuln/detail/CVE-2026-28578) | Android 14,15,16 |
+| [CVE-2026-0043](https://nvd.nist.gov/vuln/detail/CVE-2026-0043) | Android 14,15,16 |
+| [CVE-2026-0097](https://nvd.nist.gov/vuln/detail/CVE-2026-0097) | Android 14,15,16 |
+| [CVE-2026-21352](https://nvd.nist.gov/vuln/detail/CVE-2026-21352) | Android 14,15,16 |
+| [CVE-2026-21353](https://nvd.nist.gov/vuln/detail/CVE-2026-21353) | Android 14,15,16 |
+| [CVE-2025-64505](https://nvd.nist.gov/vuln/detail/CVE-2025-64505) | Android 14,15,16 |
+| [CVE-2026-0039](https://nvd.nist.gov/vuln/detail/CVE-2026-0039) | Android 14,15,16 |
+| [CVE-2026-0040](https://nvd.nist.gov/vuln/detail/CVE-2026-0040) | Android 14,15,16 |
+| [CVE-2026-0041](https://nvd.nist.gov/vuln/detail/CVE-2026-0041) | Android 14,15,16 |
+| [CVE-2026-0042](https://nvd.nist.gov/vuln/detail/CVE-2026-0042) | Android 14,15,16 |
+| [CVE-2026-0044](https://nvd.nist.gov/vuln/detail/CVE-2026-0044) | Android 14,15,16 |
+| [CVE-2026-0051](https://nvd.nist.gov/vuln/detail/CVE-2026-0051) | Android 14,15,16 |
+| [CVE-2026-0052](https://nvd.nist.gov/vuln/detail/CVE-2026-0052) | Android 14,15,16 |
+| [CVE-2026-0080](https://nvd.nist.gov/vuln/detail/CVE-2026-0080) | Android 14,15,16 |
+| [CVE-2026-0059](https://nvd.nist.gov/vuln/detail/CVE-2026-0059) | Android 14,15,16 |
+| [CVE-2025-26418](https://nvd.nist.gov/vuln/detail/CVE-2025-26418) | Android 14,15 |
+| [CVE-2025-48581](https://nvd.nist.gov/vuln/detail/CVE-2025-48581) | Android 16 |
+| [CVE-2025-48612](https://nvd.nist.gov/vuln/detail/CVE-2025-48612) | Android 14,15,16 |
+| [CVE-2026-0045](https://nvd.nist.gov/vuln/detail/CVE-2026-0045) | Android 14,15,16 |
+| [CVE-2026-0075](https://nvd.nist.gov/vuln/detail/CVE-2026-0075) | Android 14,15,16 |
+| [CVE-2026-0086](https://nvd.nist.gov/vuln/detail/CVE-2026-0086) | Android 16 |
+| [CVE-2026-0088](https://nvd.nist.gov/vuln/detail/CVE-2026-0088) | Android 14,15,16 |
+| [CVE-2026-0093](https://nvd.nist.gov/vuln/detail/CVE-2026-0093) | Android 14,15,16 |
+| [CVE-2026-0094](https://nvd.nist.gov/vuln/detail/CVE-2026-0094) | Android 14,15,16 |
+| [CVE-2026-0095](https://nvd.nist.gov/vuln/detail/CVE-2026-0095) | Android 14,15,16 |
+| [CVE-2026-0096](https://nvd.nist.gov/vuln/detail/CVE-2026-0096) | Android 16 |
+| [CVE-2026-0098](https://nvd.nist.gov/vuln/detail/CVE-2026-0098) | Android 14,15,16 |
+| [CVE-2026-0099](https://nvd.nist.gov/vuln/detail/CVE-2026-0099) | Android 14,15,16 |
+| [CVE-2026-28574](https://nvd.nist.gov/vuln/detail/CVE-2026-28574) | Android 16 |
+| [CVE-2025-48600](https://nvd.nist.gov/vuln/detail/CVE-2025-48600) | Android 14,15,16 |
+| [CVE-2025-48616](https://nvd.nist.gov/vuln/detail/CVE-2025-48616) | Android 14,15,16 |
+| [CVE-2026-0050](https://nvd.nist.gov/vuln/detail/CVE-2026-0050) | Android 15,16 |
+| [CVE-2025-48648](https://nvd.nist.gov/vuln/detail/CVE-2025-48648) | Android 14,15,16 |
+| [CVE-2026-0060](https://nvd.nist.gov/vuln/detail/CVE-2026-0060) | Android 14,15,16 |
+| [CVE-2026-0067](https://nvd.nist.gov/vuln/detail/CVE-2026-0067) | Android 14,15,16 |
+| [CVE-2026-0074](https://nvd.nist.gov/vuln/detail/CVE-2026-0074) | Android 14,15,16 |
+| [CVE-2026-0079](https://nvd.nist.gov/vuln/detail/CVE-2026-0079) | Android 14,15,16 |
+| [CVE-2026-0085](https://nvd.nist.gov/vuln/detail/CVE-2026-0085) | Android 14,15,16 |
+| [CVE-2025-22874](https://nvd.nist.gov/vuln/detail/CVE-2025-22874) | Anbox |
+| [CVE-2025-0913](https://nvd.nist.gov/vuln/detail/CVE-2025-0913) | Anbox |
+| [CVE-2025-4673](https://nvd.nist.gov/vuln/detail/CVE-2025-4673) | Anbox |
+| [CVE-2025-47907](https://nvd.nist.gov/vuln/detail/CVE-2025-47907) | Anbox |
+
+</details>
+<!-- markdownlint-enable MD033 -->
 
 ## Bug fixes
 

--- a/reference/release-notes/1.30.0.md
+++ b/reference/release-notes/1.30.0.md
@@ -40,6 +40,8 @@ You can now {ref}`copy an instance <howto-copy-instance>` using another existing
 
 The [Anbox Cloud Terraform plan](https://github.com/canonical/anbox-cloud-terraform) is now the supported method for charm-based deployments of Anbox Cloud.
 
+Find the latest 1.30.0 version in the [Anbox Cloud Terraform plan v1.30.0 release](https://github.com/canonical/anbox-cloud-terraform/releases/tag/v1.30.0).
+
 ### Android execution environments
 
 A new Android execution environment is now available: {ref}`virtualized Android <exp-android-execution-environments>`, where Android runs inside a Cuttlefish virtual machine within the LXD instance. New `resolute:*-cf:*` images for Android 16 (AOSP and AAOS) are available on both `amd64` and `arm64`. The existing containerized Android execution environment remains unchanged.

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -53,10 +53,11 @@ If you are looking for additional support, see [Ubuntu Pro](https://ubuntu.com/s
 
 Along with bug fixes and general improvements, Anbox Cloud 1.30.x includes:
 
-- Stream controls overhaul with a new vertical controls bar in the dashboard, adding resize, rotate, volume, power, home, back, keyboard capture toggle, screenshot, and screen recording
+- Stream controls overhaul with a redesigned and expanded stream page actions sidebar in the dashboard
 - Instance copy support in the dashboard for near-instantaneous cloning of existing instances
 - Anbox Cloud Terraform plan as the supported method for charm-based deployments
-- Cuttlefish image support
+- Virtualized Android as a new execution model using Cuttlefish virtual machines, with new `resolute:*-cf:*` images for Android 16 on `amd64` and `arm64`
+- Experimental userspace scheduler support via the Linux kernel's `sched_ext` framework
 - NVIDIA driver series 580 as a hard requirement for NVIDIA GPU deployments
 
 <details><summary>Click to view earlier releases' notes</summary>

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -15,21 +15,21 @@ For instructions on how to update your Anbox Cloud deployment to later versions,
 
 | Release date   |  Release notes  |
 |----|----|
+| June 17, 2026 | [Anbox Cloud 1.30.0](1.30.0.md) |
 | April 15, 2026 | [Anbox Cloud 1.29.2](1.29.2.md) |
 | March 18, 2026 | [Anbox Cloud 1.29.1](1.29.1.md) |
-| February 18, 2026 | [Anbox Cloud 1.29.0](1.29.0.md) |
 
 ## Upcoming release roadmap
 
-The current, supported minor release is **1.29.0** and the next one will be **1.30.0** expected in June 2026.
+The current, supported minor release is **1.30.0** and the next one will be **1.31.0** expected in September 2026.
 
 The following target dates for upcoming releases are not final and could vary depending on various factors such as availability of Android security patches. The release notes link will be updated on the day of the release.
 
 | Target date | Version | Planned updates |
 |----|----|----|
-| June 17, 2026 | Anbox Cloud 1.30.0 | *New features*<br/>*Android security updates*<br/>Bug fixes |
 | July 15, 2026 | Anbox Cloud 1.30.1 | *Android security updates*<br/>Bug fixes |
 | August 19, 2026 | Anbox Cloud 1.30.2 | *Android security updates*<br/>Bug fixes |
+| September 16, 2026 | Anbox Cloud 1.31.0 | *New features*<br/>*Android security updates*<br/>Bug fixes |
 
 ## Release and support policy
 
@@ -49,22 +49,21 @@ To ensure you receive latest security updates and bug fixes, you should upgrade 
 
 If you are looking for additional support, see [Ubuntu Pro](https://ubuntu.com/support). Canonical can also provide [managed solutions](https://ubuntu.com/managed) for Anbox Cloud.
 
-### What's new in 1.29.x?
+### What's new in 1.30.x?
 
-Along with bug fixes and general improvements, Anbox Cloud 1.29.x includes:
+Along with bug fixes and general improvements, Anbox Cloud 1.30.x includes:
 
-- New instance copy feature for near-instantaneous cloning of existing instances
-- Instance publishing support to create reusable images from running or stopped instances
-- Runtime bitrate control for WebRTC streaming
-- Optimized disk quota with two-tier validation
-- Migration to modernized charms, including charmed-etcd and self-signed-certificates
-- Fine-grained authorization through OpenFGA integration
-- Bug fixes
+- Stream controls overhaul with a new vertical controls bar in the dashboard, adding resize, rotate, volume, power, home, back, keyboard capture toggle, screenshot, and screen recording
+- Instance copy support in the dashboard for near-instantaneous cloning of existing instances
+- Anbox Cloud Terraform plan as the supported method for charm-based deployments
+- Cuttlefish image support
+- NVIDIA driver series 580 as a hard requirement for NVIDIA GPU deployments
 
 <details><summary>Click to view earlier releases' notes</summary>
 
 |  Release date  |  Release notes  |
 |----|----|
+| February 18, 2026 | [Anbox Cloud 1.29.0](1.29.0.md) |
 | January 21, 2026 | [Anbox Cloud 1.28.2](1.28.2.md) |
 | December 10, 2025 | [Anbox Cloud 1.28.1](1.28.1.md) |
 | November 12, 2025 | [Anbox Cloud 1.28.0](1.28.0.md) |

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -56,7 +56,7 @@ Along with bug fixes and general improvements, Anbox Cloud 1.30.x includes:
 - Stream controls overhaul with a redesigned and expanded stream page actions sidebar in the dashboard
 - Instance copy support in the dashboard for near-instantaneous cloning of existing instances
 - Anbox Cloud Terraform plan as the supported method for charm-based deployments
-- Virtualized Android as a new execution model using Cuttlefish virtual machines, with new `resolute:*-cf:*` images for Android 16 on `amd64` and `arm64`
+- Virtualized Android as a new execution environment using Cuttlefish virtual machines, with new `resolute:*-cf:*` images for Android 16 on `amd64` and `arm64`
 - Experimental userspace scheduler support via the Linux kernel's `sched_ext` framework
 - NVIDIA driver series 580 as a hard requirement for NVIDIA GPU deployments
 


### PR DESCRIPTION
# Documentation changes

- Added the release notes for 1.30.0
- Updated the feature descriptions
- Updated the bug fixes list
- Updated the release notes landing page
- Updated the roadmap and what's new in 1.30.x
note: we still need to add the CVEs

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,

- [ ] Run `make spelling` and fix any spelling issues.
- [ ] Run `make linkcheck` and fix any broken links.
- [ ] Run `make lint-md` and fix any linting issues.
- [ ] Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[AC-4690](https://warthogs.atlassian.net/browse/AC-4690)

[AC-4690]: https://warthogs.atlassian.net/browse/AC-4690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ