### PR TITLE
Add metadata descriptions to documentation [AC-3456]

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -252,7 +252,8 @@ linkcheck_ignore = [
     'https://10.2.9.2/',
     'http://Add-SECURITY.md',
     'https://jwt.io/',
-    'https://www.vulkan.org/'
+    'https://www.vulkan.org/',
+    'https://registry.khronos.org/OpenGL/extensions/EXT/EXT_shader_framebuffer_fetch.txt',
     ]
 
 # This setting will check the links but not the anchors

--- a/conf.py
+++ b/conf.py
@@ -253,7 +253,7 @@ linkcheck_ignore = [
     'http://Add-SECURITY.md',
     'https://jwt.io/',
     'https://www.vulkan.org/',
-    'https://registry.khronos.org/OpenGL/extensions/EXT/EXT_shader_framebuffer_fetch.txt',
+    'https://registry.khronos.org/',
     ]
 
 # This setting will check the links but not the anchors

--- a/contribute/anbox-style-guide.md
+++ b/contribute/anbox-style-guide.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for the Anbox Cloud documentation style guide, covering MyST Markdown conventions."
+---
+
 (style-guide)=
 # Anbox Cloud Documentation Style Guide
 

--- a/contribute/doc-cheat-sheet.md
+++ b/contribute/doc-cheat-sheet.md
@@ -1,6 +1,10 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Reference documentation for MyST Markdown syntax used in Anbox Cloud docs."
 ---
+
 (cheat-sheet-myst)=
 # Markdown/MyST cheat sheet
 

--- a/contribute/index.md
+++ b/contribute/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to contribute to Anbox Cloud documentation by fixing errors, adding content, or raising issues."
+---
+
 (contribute)=
 # Contribute to Anbox Cloud documentation
 

--- a/explanation/aaos.md
+++ b/explanation/aaos.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of Android Automotive OS (AAOS) support in Anbox Cloud, with details on VHAL integration and dashboard property visibility."
+---
+
 (exp-aaos)=
 # Android Automotive OS(AAOS)
 

--- a/explanation/aar.md
+++ b/explanation/aar.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of the Anbox Application Registry (AAR), which provides a central repository for syncing applications across deployments."
+---
+
 (exp-aar)=
 # Anbox Application Registry
 

--- a/explanation/addons.md
+++ b/explanation/addons.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of Anbox Cloud addons, which extend images by running hook scripts at instance lifecycle events."
+---
+
 (exp-addons)=
 # Addons
 

--- a/explanation/ams.md
+++ b/explanation/ams.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of the Anbox Management Service (AMS), which handles instance and application lifecycle, scheduling, and resource management."
+---
+
 (exp-ams)=
 # Anbox Management Service
 

--- a/explanation/anbox-cloud.md
+++ b/explanation/anbox-cloud.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of Anbox Cloud architecture, covering the two variants (Appliance and charmed), core components, and supported platforms."
+---
+
 (exp-anbox-cloud)=
 # Anbox Cloud
 

--- a/explanation/application-streaming.md
+++ b/explanation/application-streaming.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of the Anbox Cloud streaming stack, which uses WebRTC-based video encoding with GPU integration and session management."
+---
+
 (exp-application-streaming)=
 # Application streaming
 

--- a/explanation/applications.md
+++ b/explanation/applications.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of applications in Anbox Cloud, covering how AMS manages Android APKs, application lifecycle, versioning, and instances."
+---
+
 (exp-applications)=
 # Applications
 

--- a/explanation/auth.md
+++ b/explanation/auth.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of authentication and authorisation in Anbox Cloud, covering OIDC and TLS identity types, groups, and permission levels."
+---
+
 (exp-auth)=
 # Authentication and authorization
 

--- a/explanation/capacity-planning.md
+++ b/explanation/capacity-planning.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of capacity planning for Anbox Cloud, with guidance on estimating resources based on user load and application profiles."
+---
+
 (exp-capacity-planning)=
 # Capacity planning
 

--- a/explanation/clustering.md
+++ b/explanation/clustering.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of clustering in charmed Anbox Cloud, which uses multi-node LXD clusters managed with Juju for large-scale deployments."
+---
+
 (exp-clustering)=
 # Clustering
 

--- a/explanation/custom-images.md
+++ b/explanation/custom-images.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of custom Anbox Cloud images, which let automotive OEMs build tailored AAOS infotainment experiences."
+---
+
 (exp-custom-images)=
 # Custom images
 

--- a/explanation/images.md
+++ b/explanation/images.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of images in Anbox Cloud, which bundle the Anbox runtime and Android root file system to form the base for instances."
+---
+
 (exp-images)=
 # Images
 

--- a/explanation/index.md
+++ b/explanation/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of Anbox Cloud concepts, covering architecture, components, applications, instances, security, capacity planning, and deployment."
+---
+
 (explanation)=
 # Explanation
 

--- a/explanation/instances.md
+++ b/explanation/instances.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of instances in Anbox Cloud, covering lifecycle states, types, resource handling, and how each runs a full Android system."
+---
+
 (exp-instances)=
 # Instances
 

--- a/explanation/nodes.md
+++ b/explanation/nodes.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of nodes in Anbox Cloud, which are LXD cluster machines serving management or GPU-accelerated streaming roles."
+---
+
 (exp-nodes)=
 # Nodes
 

--- a/explanation/performance.md
+++ b/explanation/performance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of performance factors in Anbox Cloud, with guidance on hardware, configuration, and workload tuning."
+---
+
 (exp-performance)=
 # Performance
 

--- a/explanation/platforms.md
+++ b/explanation/platforms.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of Anbox Cloud platforms (swrast, null, webrtc), covering what each does and how to configure display settings."
+---
+
 (exp-platforms)=
 # Supported platforms
 

--- a/explanation/production-planning.md
+++ b/explanation/production-planning.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of production planning for Anbox Cloud, covering configuration, networking, security, and high availability."
+---
+
 (exp-production-planning)=
 # Production planning
 

--- a/explanation/rendering-architecture.md
+++ b/explanation/rendering-architecture.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of the Anbox Cloud rendering pipeline, covering architecture and rendering models for different GPU types."
+---
+
 (exp-rendering-architecture)=
 # Rendering architecture
 

--- a/explanation/rendering-graphics.md
+++ b/explanation/rendering-graphics.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of rendering modes in Anbox Cloud, covering how graphics behaviour adapts based on GPU availability."
+---
+
 (exp-rendering-graphics)=
 # Rendering graphical output
 

--- a/explanation/resources.md
+++ b/explanation/resources.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of resource presets in Anbox Cloud, which define CPU, memory, and storage allocated to instances."
+---
+
 (exp-resources-presets)=
 # Resources and resource presets
 

--- a/explanation/security/ams.md
+++ b/explanation/security/ams.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of AMS security, which uses TLS transport encryption and mutual TLS or token authentication to secure API access."
+---
+
 (exp-security-ams)=
 # AMS
 

--- a/explanation/security/anbox-runtime.md
+++ b/explanation/security/anbox-runtime.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of Anbox runtime security, which protects communications with TLS encryption and relies on WebRTC mandatory encryption."
+---
+
 (exp-security-anbox-runtime)=
 # Anbox runtime
 

--- a/explanation/security/android.md
+++ b/explanation/security/android.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of Android security in Anbox Cloud, covering monthly security patches applied to AOSP and AAOS images."
+---
+
 # Android
 
 The images that Anbox Cloud provides are based on different Android versions. They are updated with security patches monthly, based on the upstream security tags. You can find detailed information on the security patches that have been included (or considered to be included but found unrelated) in the [Android Security Bulletins](https://source.android.com/docs/security/bulletin). The relevant security bulletin for each Anbox Cloud release is linked in the {ref}`ref-release-notes`.

--- a/explanation/security/charms.md
+++ b/explanation/security/charms.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of charm security in Anbox Cloud, covering TLS-encrypted websocket communication between Juju units and controllers."
+---
+
 (exp-security-charms)=
 # Charms
 

--- a/explanation/security/dashboard.md
+++ b/explanation/security/dashboard.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of dashboard security in Anbox Cloud, covering TLS, registration tokens, and mutual TLS mechanisms."
+---
+
 (exp-security-dashboard)=
 # Dashboard
 

--- a/explanation/security/index.md
+++ b/explanation/security/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of security in Anbox Cloud, covering secure-by-default principles across AMS, the Anbox runtime, and streaming."
+---
+
 (exp-security)=
 # Security
 

--- a/explanation/security/instance.md
+++ b/explanation/security/instance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of instance security in Anbox Cloud, covering isolated LXD containers and VMs with configurable security features."
+---
+
 # Instances
 
 Anbox Cloud uses secure and isolated system instances supplied by [LXD](https://canonical.com/lxd). LXD provides a high degree of flexibility when setting up instances - you get to decide the level of security for your requirements. See [Security](https://documentation.ubuntu.com/lxd/latest/explanation/security/) in the LXD documentation for more information about how a LXD setup can be secured.

--- a/explanation/security/streaming-stack.md
+++ b/explanation/security/streaming-stack.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of streaming stack security in Anbox Cloud, which uses WebRTC with mandatory end-to-end encryption."
+---
+
 (exp-security-streaming)=
 # Streaming
 

--- a/explanation/web-dashboard.md
+++ b/explanation/web-dashboard.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Explanation of the Anbox Cloud dashboard, a web UI for managing applications and streaming sessions."
+---
+
 (exp-web-dashboard)=
 # Anbox Cloud dashboard
 

--- a/howto/aar/configure.md
+++ b/howto/aar/configure.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to configure TLS certificate authentication between the Anbox Application Registry and AMS."
+---
+
 (howto-configure-aar)=
 # Configure
 

--- a/howto/aar/deploy.md
+++ b/howto/aar/deploy.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to deploy an Anbox Application Registry (AAR) and connect it to AMS for centralised application storage."
+---
+
 (howto-deploy-aar)=
 # Deploy
 

--- a/howto/aar/index.md
+++ b/howto/aar/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to manage the Anbox Application Registry (AAR), including deployment, TLS configuration, and certificate revocation."
+---
+
 (howto-aar)=
 # AAR
 

--- a/howto/aar/revoke.md
+++ b/howto/aar/revoke.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to revoke a compromised client certificate from the Anbox Application Registry."
+---
+
 (howto-revoke-aar)=
 
 # Revoke a client

--- a/howto/addons/backup-and-restore-example.md
+++ b/howto/addons/backup-and-restore-example.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to use an Anbox Cloud addon to back up application data on instance stop and restore it on start."
+---
+
 (howto-backup-restore-example)=
 # Example: Back up data
 When an instance is stopped, all the data and logs produced during the runtime are lost. To avoid this, you can use hooks to back up and restore any type of data you want.

--- a/howto/addons/create-addon.md
+++ b/howto/addons/create-addon.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to create an Anbox Cloud addon by writing hook scripts, packaging, and attaching it to applications."
+---
+
 (howto-create-addon)=
 # Create an addon
 

--- a/howto/addons/customize-android-example.md
+++ b/howto/addons/customize-android-example.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to use anbox-shell inside a prepare hook to configure the Android system before your application starts."
+---
+
 (howto-customize-android-example)=
 # Example: Customize Android
 

--- a/howto/addons/emulate-platforms-example.md
+++ b/howto/addons/emulate-platforms-example.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to use an addon hook to emulate non-native CPU architectures for cross-platform application support."
+---
+
 (howto-emulate-platforms-example)=
 # Example: Emulate platforms
 

--- a/howto/addons/enable-addons-globally.md
+++ b/howto/addons/enable-addons-globally.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to enable an Anbox Cloud addon globally so it applies to every application automatically."
+---
+
 (howto-enable-addons-globally)=
 # Enable an addon globally
 

--- a/howto/addons/examples.md
+++ b/howto/addons/examples.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to implement common addon patterns in Anbox Cloud, with worked examples for backup, customisation, and tool installation."
+---
+
 # Examples
 
 Here are some examples to illustrate how to use addons and hooks:

--- a/howto/addons/index.md
+++ b/howto/addons/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to work with Anbox Cloud addons, including creating hooks, enabling addons globally, updating, and migrating from deprecated hooks."
+---
+
 (howto-addons)=
 # Addons
 

--- a/howto/addons/install-tools-example.md
+++ b/howto/addons/install-tools-example.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to install additional tools into an Anbox Cloud instance using an addon install hook."
+---
+
 (howto-install-tools-example)=
 # Example: Install tools
 

--- a/howto/addons/migrate-addon.md
+++ b/howto/addons/migrate-addon.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to migrate Anbox Cloud addons from deprecated hook names to the current format introduced in version 1.12."
+---
+
 (howto-migrate-addons)=
 # Migrate from previous versions
 

--- a/howto/addons/update-addon.md
+++ b/howto/addons/update-addon.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to update an Anbox Cloud addon to a new version and control how running instances receive the update."
+---
+
 (howto-update-addons)=
 # Update addons
 

--- a/howto/anbox-runtime/develop-addon-devmode.md
+++ b/howto/anbox-runtime/develop-addon-devmode.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to develop Anbox Cloud addons in developer mode to iterate quickly without full application bootstrap."
+---
+
 (howto-develop-addons-devmode)=
 # Develop addons in `--devmode`
 

--- a/howto/anbox-runtime/develop-platform-plugin.md
+++ b/howto/anbox-runtime/develop-platform-plugin.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to build a custom Anbox Cloud platform plugin with the Platform SDK."
+---
+
 (howto-develop-platform-plugin)=
 # Develop a platform plugin
 

--- a/howto/anbox-runtime/index.md
+++ b/howto/anbox-runtime/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to work with the Anbox runtime, including addon development in developer mode and building custom platform plugins."
+---
+
 (howto-anbox-runtime)=
 # Work with the Anbox runtime
 

--- a/howto/anbox/auth.md
+++ b/howto/anbox/auth.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to configure user permissions in Anbox Cloud with OpenFGA, including identities, groups, and entitlements."
+---
+
 (howto-auth)=
 # Configure user permissions
 

--- a/howto/anbox/benchmarks.md
+++ b/howto/anbox/benchmarks.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to run Anbox Cloud benchmarks with amc benchmark to measure instance launch throughput and GPU performance."
+---
+
 (howto-run-benchmarks)=
 # Run benchmarks
 

--- a/howto/anbox/control-ams-remotely.md
+++ b/howto/anbox/control-ams-remotely.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to configure AMC to connect to AMS over HTTPS from a remote host."
+---
+
 (howto-access-ams-remote)=
 # Access AMS remotely
 

--- a/howto/anbox/harden.md
+++ b/howto/anbox/harden.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to harden an Anbox Cloud deployment by restricting network exposure and managing TLS certificates."
+---
+
 (howto-harden)=
 # Harden your deployment
 

--- a/howto/anbox/index.md
+++ b/howto/anbox/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to manage an Anbox Cloud deployment, including authentication, remote AMS access, benchmarks, and security hardening."
+---
+
 (howto-manage-anbox)=
 # Manage Anbox Cloud
 

--- a/howto/anbox/resize-storage.md
+++ b/howto/anbox/resize-storage.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to safely resize the LXD storage pool used by Anbox Cloud when capacity is running low."
+---
+
 (howto-resize-lxd-storage)=
 # Resize LXD storage
 

--- a/howto/anbox/tls-for-appliance.md
+++ b/howto/anbox/tls-for-appliance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to replace the self-signed certificate on the Anbox Cloud Appliance with a custom TLS certificate."
+---
+
 (howto-set-up-tls)=
 # Set up TLS for the appliance
 

--- a/howto/android/access-android-instance.md
+++ b/howto/android/access-android-instance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to connect to an Android instance running in Anbox Cloud via ADB over TCP for debugging."
+---
+
 (howto-access-android-instance)=
 # Access an Android instance
 

--- a/howto/android/custom-vhal.md
+++ b/howto/android/custom-vhal.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to replace the default Anbox VHAL with a custom implementation on AAOS images."
+---
+
 (howto-replace-anbox-vhal)=
 # Replace Anbox VHAL
 

--- a/howto/android/debug-graphics-renderdoc.md
+++ b/howto/android/debug-graphics-renderdoc.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to use RenderDoc to capture and analyse GPU frames from Android applications in Anbox Cloud."
+---
+
 (howto-debug-graphics-renderdoc)=
 # Debug graphics with Renderdoc
 

--- a/howto/android/index.md
+++ b/howto/android/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to work with Android in Anbox Cloud, including ADB access, custom VHAL configuration, graphics debugging, and SMS simulation."
+---
+
 (howto-Android)=
 # Work with Android
 

--- a/howto/android/integrate-hidl.md
+++ b/howto/android/integrate-hidl.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to integrate the Anbox HIDL interface to connect a custom VHAL implementation with Android HAL."
+---
+
 (howto-integrate-hidl)=
 # Integrate Anbox HIDL interface
 

--- a/howto/android/set-automotive-properties.md
+++ b/howto/android/set-automotive-properties.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to set Android Automotive VHAL properties in Anbox Cloud to simulate vehicle states."
+---
+
 (howto-set-automotive-properties)=
 # Set automotive properties using VHAL
 

--- a/howto/android/simulate-incoming-sms.md
+++ b/howto/android/simulate-incoming-sms.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to simulate incoming SMS messages for Android apps in Anbox Cloud."
+---
+
 (howto-simulate-incoming-sms)=
 # Simulate incoming SMS messages
 

--- a/howto/application/create-application.md
+++ b/howto/application/create-application.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to create an Anbox Cloud application from an APK using the dashboard or amc application create."
+---
+
 (howto-create-application)=
 # Create an application
 

--- a/howto/application/delete-application.md
+++ b/howto/application/delete-application.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to delete an Anbox Cloud application and all its versions using the dashboard or CLI."
+---
+
 (howto-delete-application)=
 # Delete an application
 

--- a/howto/application/extend-application.md
+++ b/howto/application/extend-application.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to extend an Anbox Cloud application with custom behaviour using hooks or addons."
+---
+
 (howto-extend-application)=
 # Extend an application
 

--- a/howto/application/index.md
+++ b/howto/application/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to manage Anbox Cloud applications, including creating, updating, deleting, extending with addons, and streaming."
+---
+
 (howto-manage-applications)=
 # Manage applications
 

--- a/howto/application/list-applications.md
+++ b/howto/application/list-applications.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to list and inspect Anbox Cloud applications using amc application list or the dashboard."
+---
+
 (howto-list-applications)=
 # List applications
 

--- a/howto/application/pass-custom-data.md
+++ b/howto/application/pass-custom-data.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to pass arbitrary data to an Anbox Cloud application at launch time and read it inside addon hooks."
+---
+
 (howto-pass-custom-data-application)=
 # Pass custom data to an application
 

--- a/howto/application/stream-application.md
+++ b/howto/application/stream-application.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to stream an Anbox Cloud application to a browser via the dashboard or a custom client."
+---
+
 (howto-stream-applications)=
 # Stream applications
 

--- a/howto/application/test-application.md
+++ b/howto/application/test-application.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to run automated tests for Android applications at scale in Anbox Cloud using raw instances."
+---
+
 (howto-test-application)=
 # Test your application
 

--- a/howto/application/update-application.md
+++ b/howto/application/update-application.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to update an Anbox Cloud application to a new APK version using amc application update."
+---
+
 (howto-update-application)=
 # Update an application
 

--- a/howto/application/wait-for-application.md
+++ b/howto/application/wait-for-application.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to wait for an Anbox Cloud application to reach a ready state using amc wait."
+---
+
 (howto-wait-for-application)=
 # Wait for an application
 

--- a/howto/cluster/configure-nodes.md
+++ b/howto/cluster/configure-nodes.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to configure individual nodes in an Anbox Cloud LXD cluster, including capacity limits and GPU assignment."
+---
+
 (howto-configure-cluster-nodes)=
 # Configure cluster nodes
 

--- a/howto/cluster/index.md
+++ b/howto/cluster/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to manage an Anbox Cloud LXD cluster, including adding nodes, configuring capacity, and scaling up or down."
+---
+
 (howto-manage-cluster)=
 # Manage cluster nodes
 

--- a/howto/cluster/scale-down.md
+++ b/howto/cluster/scale-down.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to remove a node from an Anbox Cloud LXD cluster safely by draining instances and detaching with Juju."
+---
+
 (howto-scale-down-cluster)=
 # Scale down a LXD cluster
 

--- a/howto/cluster/scale-up.md
+++ b/howto/cluster/scale-up.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to add a new node to an Anbox Cloud LXD cluster using Juju to increase instance capacity."
+---
+
 (howto-scale-up-cluster)=
 # Scale up a LXD cluster
 

--- a/howto/dashboard/index.md
+++ b/howto/dashboard/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to use the Anbox Cloud dashboard to launch applications, start streaming sessions, and monitor instance status."
+---
+
 (howto-use-web-dashboard)=
 # Use the dashboard
 The Anbox Cloud Dashboard offers a web GUI that users can use to create, manage and stream applications from their web browser. If you have configured the Anbox Application Registry (AAR), you can also view applications in the registry using the **Registry** button on the main menu. You can use the pre-installed dashboard almost immediately after deploying Anbox Cloud.

--- a/howto/gpu/increase-instance-density.md
+++ b/howto/gpu/increase-instance-density.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to increase GPU-accelerated instance density on NVIDIA hardware by enabling Multi-Process Service (MPS)."
+---
+
 (howto-increase-instance-density)=
 # Increase instance density
 

--- a/howto/gpu/index.md
+++ b/howto/gpu/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to configure GPUs in Anbox Cloud, including benchmarking and enabling NVIDIA MPS to increase instance density."
+---
+
 (howto-gpu)=
 # GPU
 

--- a/howto/images/add-image.md
+++ b/howto/images/add-image.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to add an Anbox Cloud image to AMS from the Canonical image server or a custom registry."
+---
+
 (howto-add-image)=
 # Add an image
 

--- a/howto/images/configure-image-server.md
+++ b/howto/images/configure-image-server.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to configure which images AMS downloads from the Canonical image server."
+---
+
 (howto-configure-image-server)=
 # Configure an image server
 

--- a/howto/images/delete-image.md
+++ b/howto/images/delete-image.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to delete an Anbox Cloud image from AMS using amc image delete."
+---
+
 (howto-delete-image)=
 # Delete an image
 

--- a/howto/images/index.md
+++ b/howto/images/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to manage Anbox Cloud images, including adding from the Canonical server, publishing custom images, and pinning releases."
+---
+
 (howto-manage-images)=
 # Manage images
 

--- a/howto/images/publish-instance-as-image.md
+++ b/howto/images/publish-instance-as-image.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to capture the current state of an Anbox Cloud instance as a reusable custom image."
+---
+
 (howto-publish-instance-as-image)=
 # Publish an instance as an image
 

--- a/howto/images/use-specific-release.md
+++ b/howto/images/use-specific-release.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to pin an Anbox Cloud image to a specific release version to prevent automatic updates."
+---
+
 (howto-use-specific-release)=
 # Use a specific release
 

--- a/howto/index.md
+++ b/howto/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to perform common tasks in Anbox Cloud, covering installation, application management, instance operations, and troubleshooting."
+---
+
 (how-to-guides)=
 # How-to guides
 

--- a/howto/install-appliance/index.md
+++ b/howto/install-appliance/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to install the Anbox Cloud Appliance on AWS, Azure, Google Cloud, or inside a GitHub Actions workflow."
+---
+
 (howto-install-appliance)=
 # Install the appliance
 

--- a/howto/install-appliance/install-on-aws.md
+++ b/howto/install-appliance/install-on-aws.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to install the Anbox Cloud Appliance on AWS via the Marketplace or by manually launching an EC2 instance."
+---
+
 (howto-install-appliance-aws)=
 # Install on AWS
 

--- a/howto/install-appliance/install-on-azure.md
+++ b/howto/install-appliance/install-on-azure.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to install the Anbox Cloud Appliance on Microsoft Azure by provisioning a VM and deploying the snap."
+---
+
 (howto-install-appliance-azure)=
 # Install on Azure
 

--- a/howto/install-appliance/install-on-github.md
+++ b/howto/install-appliance/install-on-github.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to run the Anbox Cloud Appliance inside a GitHub Actions workflow for automated CI testing."
+---
+
 (howto-install-appliance-github)=
 # Install on GitHub
 

--- a/howto/install-appliance/install-on-google-cloud.md
+++ b/howto/install-appliance/install-on-google-cloud.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to install the Anbox Cloud Appliance on Google Cloud by creating a Compute Engine VM."
+---
+
 (howto-install-appliance-google-cloud)=
 # Install on Google Cloud
 

--- a/howto/install/customize-installation.md
+++ b/howto/install/customize-installation.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to customise a charmed Anbox Cloud deployment using Juju overlay files or modified bundle files."
+---
+
 (howto-customize-installation)=
 # Customize installation
 

--- a/howto/install/deploy-bare-metal.md
+++ b/howto/install/deploy-bare-metal.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to deploy Anbox Cloud on bare metal using Juju's manual cloud option."
+---
+
 (howto-deploy-anbox-baremetal)=
 # Deploy on bare metal
 

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to deploy Anbox Cloud on AWS, Azure, or Google Cloud by bootstrapping a Juju controller."
+---
+
 (howto-deploy-anbox-juju)=
 # Deploy on a public cloud
 

--- a/howto/install/deploy-terraform.md
+++ b/howto/install/deploy-terraform.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to deploy Anbox Cloud with Terraform using the Juju provider for infrastructure-as-code deployments."
+---
+
 (howto-deploy-anbox-terraform)=
 # Deploy with Terraform
 

--- a/howto/install/enable-high-availability.md
+++ b/howto/install/enable-high-availability.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to enable high availability for charmed Anbox Cloud by deploying additional units using Juju."
+---
+
 (howto-enable-ha)=
 # Enable High Availability
 

--- a/howto/install/index.md
+++ b/howto/install/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to install charmed Anbox Cloud with Juju, including deployment on bare metal or public cloud and enabling high availability."
+---
+
 (howto-install-anbox-cloud)=
 # Install Anbox Cloud
 

--- a/howto/install/use-ceph-storage.md
+++ b/howto/install/use-ceph-storage.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to configure Anbox Cloud to use Ceph as shared distributed storage instead of local LXD storage."
+---
+
 (howto-use-ceph-storage)=
 # Use Ceph storage
 

--- a/howto/install/validate-deployment.md
+++ b/howto/install/validate-deployment.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to validate a new Anbox Cloud deployment by running the built-in test suite."
+---
+
 (howto-validate-deployment)=
 # Validate your deployment
 

--- a/howto/instance/access-instance.md
+++ b/howto/instance/access-instance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to access an Anbox Cloud instance for debugging using amc shell or amc exec."
+---
+
 (howto-access-instance)=
 # Access an instance
 

--- a/howto/instance/backup-restore-application-data.md
+++ b/howto/instance/backup-restore-application-data.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to back up and restore Android application data across Anbox Cloud instance restarts."
+---
+
 (howto-backup-restore-application-data)=
 # Back up and restore application data
 

--- a/howto/instance/configure-geographic-location.md
+++ b/howto/instance/configure-geographic-location.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to set a GPS location on an Anbox Cloud Android container for location-aware applications."
+---
+
 (howto-configure-geographic-location)=
 # Configure geographic location
 

--- a/howto/instance/configure-instance.md
+++ b/howto/instance/configure-instance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to change configuration on a running or stopped Anbox Cloud instance using amc set or the dashboard."
+---
+
 (howto-configure-instance)=
 # Configure an instance
 

--- a/howto/instance/copy-instance.md
+++ b/howto/instance/copy-instance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to copy an Anbox Cloud instance to duplicate its current state for testing or debugging."
+---
+
 (howto-copy-instance)=
 
 # Copy an instance

--- a/howto/instance/create-instance.md
+++ b/howto/instance/create-instance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to launch an Anbox Cloud instance from an application or raw image using amc launch or amc init."
+---
+
 (howto-create-instance)=
 # Create an instance
 To launch an application or an image, Anbox Cloud creates an instance for it. To create and launch an instance, you can use the Anbox Cloud dashboard or the CLI.

--- a/howto/instance/delete-instance.md
+++ b/howto/instance/delete-instance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to delete an Anbox Cloud instance with amc delete to release its resources."
+---
+
 (howto-delete-instance)=
 # Delete an instance
 

--- a/howto/instance/expose-services.md
+++ b/howto/instance/expose-services.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to expose TCP or UDP services running inside an Anbox Cloud instance to the external network."
+---
+
 (howto-expose-services)=
 # Expose services on an instance
 

--- a/howto/instance/index.md
+++ b/howto/instance/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to manage Anbox Cloud instances, including creating, configuring, starting, stopping, accessing, and viewing logs."
+---
+
 (howto-instance)=
 # Manage instances
 

--- a/howto/instance/list-instances.md
+++ b/howto/instance/list-instances.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to list Anbox Cloud instances with amc ls and filter by application, status, or node."
+---
+
 (howto-list-instances)=
 # List instances
 

--- a/howto/instance/restart-instance.md
+++ b/howto/instance/restart-instance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to restart an Anbox Cloud instance with amc restart to apply configuration changes."
+---
+
 (howto-restart-instance)=
 # Restart an instance
 

--- a/howto/instance/share-session.md
+++ b/howto/instance/share-session.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to share an active Anbox Cloud streaming session with another user via the Stream Gateway."
+---
+
 (howto-share-session)=
 # Share a session
 

--- a/howto/instance/start-instance.md
+++ b/howto/instance/start-instance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to start an Anbox Cloud instance that was initialised with amc init or previously stopped."
+---
+
 (howto-start-instance)=
 # Start an instance
 

--- a/howto/instance/stop-instance.md
+++ b/howto/instance/stop-instance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to stop a running Anbox Cloud instance gracefully or immediately with amc stop."
+---
+
 (howto-stop-instance)=
 # Stop an instance
 

--- a/howto/instance/view-instance-logs.md
+++ b/howto/instance/view-instance-logs.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to view Anbox and Android system logs for a running or failed Anbox Cloud instance."
+---
+
 (howto-view-instance-logs)=
 # View instance logs
 

--- a/howto/instance/wait-for-instance.md
+++ b/howto/instance/wait-for-instance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to use amc wait to pause automation until an Anbox Cloud instance reaches the running state."
+---
+
 (howto-wait-for-instance)=
 # Wait for an instance
 

--- a/howto/monitor/index.md
+++ b/howto/monitor/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to set up monitoring for Anbox Cloud with Prometheus and Grafana, including scraping metrics and building dashboards."
+---
+
 (howto-monitor-anbox)=
 
 # Monitor Anbox Cloud

--- a/howto/port/choose-apk-architecture.md
+++ b/howto/port/choose-apk-architecture.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to choose the correct APK architecture for Anbox Cloud based on your host CPU type."
+---
+
 (howto-choose-apk-architecture)=
 # Choose APK architecture
 

--- a/howto/port/configure-watchdog.md
+++ b/howto/port/configure-watchdog.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to configure the Anbox Cloud watchdog to monitor a running Android app and trigger restarts."
+---
+
 (howto-configure-watchdog)=
 # Configure the watchdog
 

--- a/howto/port/grant-runtime-permissions.md
+++ b/howto/port/grant-runtime-permissions.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to grant Android runtime permissions to an app in Anbox Cloud at bootstrap time."
+---
+
 (howto-grant-runtime-permissions)=
 # Grant runtime permissions
 

--- a/howto/port/index.md
+++ b/howto/port/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to port Android APKs to Anbox Cloud, including architecture selection, watchdog configuration, and OBB files."
+---
+
 (howto-port-android-apps)=
 # Port Android apps
 

--- a/howto/port/install-apk-system-app.md
+++ b/howto/port/install-apk-system-app.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to install an Android APK as a system application in Anbox Cloud for elevated privileges."
+---
+
 (howto-install-apk-system-app)=
 # Install an APK as a system app
 

--- a/howto/port/port-apk-obb-files.md
+++ b/howto/port/port-apk-obb-files.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to port an Android APK with OBB expansion files to Anbox Cloud."
+---
+
 (howto-port-apk-oob)=
 # Port APKs with OBB files
 

--- a/howto/setup-custom-idp/configure-oidc.md
+++ b/howto/setup-custom-idp/configure-oidc.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to configure OIDC authentication for the Anbox Cloud Appliance using a preseed file."
+---
+
 (howto-configure-oidc)=
 # Configure OIDC for the appliance
 

--- a/howto/setup-custom-idp/index.md
+++ b/howto/setup-custom-idp/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to set up a custom identity provider for Anbox Cloud using OpenID Connect."
+---
+
 (howto-set-up-idp)=
 # Set up a custom identity provider
 

--- a/howto/stream/access-stream-gateway.md
+++ b/howto/stream/access-stream-gateway.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to access the Anbox Cloud Stream Gateway API using a service account token."
+---
+
 (howto-access-stream-gateway)=
 # Access the stream gateway
 

--- a/howto/stream/enable-client-side-video-upscaling.md
+++ b/howto/stream/enable-client-side-video-upscaling.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to enable client-side video upscaling in Anbox Cloud streams using AMD FidelityFX Super Resolution."
+---
+
 (howto-enable-client-side-video-upscaling)=
 # Enable client-side video upscaling
 

--- a/howto/stream/exchange-oob-data.md
+++ b/howto/stream/exchange-oob-data.md
@@ -1,3 +1,8 @@
+---
+myst:
+  html_meta:
+    "description": "How to exchange out-of-band data between an Android app and a WebRTC client in Anbox Cloud."
+---
 
 (howto-exchange-oob-data)=
 # Exchange out-of-band data

--- a/howto/stream/index.md
+++ b/howto/stream/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to configure Anbox Cloud streaming, including Stream Gateway access, video upscaling, and virtual keyboard integration."
+---
+
 (howto-streaming)=
 # Implement streaming
 

--- a/howto/stream/integrate-virtual-keyboard.md
+++ b/howto/stream/integrate-virtual-keyboard.md
@@ -1,3 +1,8 @@
+---
+myst:
+  html_meta:
+    "description": "How to integrate a virtual keyboard into an Anbox Cloud web streaming application."
+---
 
 (howto-integrate-virtual-keyboard)=
 # Integrate a client-side virtual keyboard

--- a/howto/troubleshoot/index.md
+++ b/howto/troubleshoot/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to troubleshoot Anbox Cloud issues, including application creation failures, cluster problems, and streaming faults."
+---
+
 (howto-ts-anbox-cloud)=
 # Troubleshoot Anbox Cloud
 

--- a/howto/troubleshoot/troubleshoot-application-creation.md
+++ b/howto/troubleshoot/troubleshoot-application-creation.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to diagnose Anbox Cloud application creation failures, including bootstrap errors and APK issues."
+---
+
 (howto-ts-application-creation-issues)=
 # Troubleshoot issues with application creation
 

--- a/howto/troubleshoot/troubleshoot-cluster-issues.md
+++ b/howto/troubleshoot/troubleshoot-cluster-issues.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to resolve Anbox Cloud LXD cluster problems, including node connectivity and database errors."
+---
+
 (howto-ts-lxd-clustering)=
 # Troubleshoot issues with LXD clustering
 

--- a/howto/troubleshoot/troubleshoot-dashboard-issues.md
+++ b/howto/troubleshoot/troubleshoot-dashboard-issues.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to fix Anbox Cloud dashboard problems, including login failures and certificate errors."
+---
+
 (howto-ts-web-dashboard)=
 # Troubleshoot issues while using the web dashboard
 

--- a/howto/troubleshoot/troubleshoot-initial-setup.md
+++ b/howto/troubleshoot/troubleshoot-initial-setup.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to diagnose Anbox Cloud setup failures, including snap installation and LXD initialisation problems."
+---
+
 (howto-ts-initial-setup)=
 # Troubleshoot issues with initial setup
 

--- a/howto/troubleshoot/troubleshoot-instance-failures.md
+++ b/howto/troubleshoot/troubleshoot-instance-failures.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to investigate Anbox Cloud instance failures by interpreting error states and reading logs."
+---
+
 (howto-ts-instance-failures)=
 # Troubleshoot instance failures
 

--- a/howto/troubleshoot/troubleshoot-streaming-issues.md
+++ b/howto/troubleshoot/troubleshoot-streaming-issues.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to debug Anbox Cloud streaming problems, including WebRTC ICE failures and codec mismatches."
+---
+
 (howto-ts-streaming-issues)=
 # Troubleshoot streaming issues
 

--- a/howto/troubleshoot/view-logs.md
+++ b/howto/troubleshoot/view-logs.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to collect Anbox Cloud logs from AMS, instances, and the Anbox runtime for troubleshooting."
+---
+
 (howto-ts-view-logs)=
 # View logs
 

--- a/howto/upgrade/index.md
+++ b/howto/upgrade/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to upgrade charmed Anbox Cloud or the Anbox Cloud Appliance to the latest release."
+---
+
 (howto-upgrade)=
 # Upgrade Anbox Cloud
 

--- a/howto/upgrade/upgrade-anbox.md
+++ b/howto/upgrade/upgrade-anbox.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to upgrade charmed Anbox Cloud to the latest release using Juju."
+---
+
 (howto-upgrade-anbox-cloud)=
 # Upgrade charmed deployment
 

--- a/howto/upgrade/upgrade-appliance.md
+++ b/howto/upgrade/upgrade-appliance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "How to upgrade the Anbox Cloud Appliance by refreshing the snap to the target channel."
+---
+
 (howto-upgrade-appliance)=
 # Upgrade appliance
 

--- a/index.md
+++ b/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Run Android at scale in the cloud. Anbox Cloud delivers high-density streaming using LXD containers or VMs on public or private infrastructure."
+---
+
 # Anbox Cloud documentation
 
 Anbox Cloud runs Android in the cloud using lightweight LXD system containers or full virtual machines. Built on Ubuntu, it provides a scalable platform to deploy, manage, and stream Android workloads across public or private infrastructure. Compared to other Android emulation solutions, Anbox Cloud can provide at least twice the density and can serve up to **100 Android instances per server**.

--- a/reference/addon-manifest.md
+++ b/reference/addon-manifest.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for the Anbox Cloud addon manifest, which defines addon metadata and hook scripts."
+---
+
 (ref-addon-manifest)=
 # Addon manifest
 

--- a/reference/ams-instance-configuration.md
+++ b/reference/ams-instance-configuration.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for per-instance configuration in AMS, covering CPU, memory, GPU, and display settings."
+---
+
 (ref-ams-instance-configuration)=
 # AMS instance configuration
 

--- a/reference/anbox-features.md
+++ b/reference/anbox-features.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud feature comparison between AOSP and AAOS images."
+---
+
 (ref-aosp-aaos)=
 # Supported features for AOSP vs AAOS images
 

--- a/reference/android-features.md
+++ b/reference/android-features.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Android features in Anbox Cloud, covering available, limited, and unsupported APIs."
+---
+
 (ref-android-features)=
 # Supported Android features
 

--- a/reference/api-reference/anbox-https-api.md
+++ b/reference/api-reference/anbox-https-api.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for the Anbox HTTP API available inside every instance via Unix socket."
+---
+
 (anbox-https-api)=
 # Anbox HTTPS API
 

--- a/reference/api-reference/index.md
+++ b/reference/api-reference/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud APIs, covering AMS HTTP API, Stream Gateway API, and Platform SDK."
+---
+
 (ref-api)=
 # API reference
 

--- a/reference/appliance-configuration.md
+++ b/reference/appliance-configuration.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud Appliance configuration, covering all available settings and defaults."
+---
+
 (ref-appliance-configuration)=
 # Anbox Cloud Appliance configuration
 

--- a/reference/appliance-preseed.md
+++ b/reference/appliance-preseed.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud Appliance preseed configuration for automated initialisation."
+---
+
 (ref-appliance-preseed-config)=
 # Anbox Cloud Appliance preseed configuration format
 

--- a/reference/application-manifest.md
+++ b/reference/application-manifest.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for the Anbox Cloud application manifest, covering all keys and their effects."
+---
+
 (ref-application-manifest)=
 # Application manifest
 

--- a/reference/auth.md
+++ b/reference/auth.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for authorisation in Anbox Cloud, covering entitlements, identity types, and groups."
+---
+
 (ref-auth)=
 # Authentication and authorization
 

--- a/reference/charm-configuration.md
+++ b/reference/charm-configuration.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud Juju charm configuration options and their defaults."
+---
+
 (ref-charm-configuration)=
 # Charm Configuration
 

--- a/reference/cmd-ref/index.md
+++ b/reference/cmd-ref/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud command-line tools: amc, anbox-cloud-appliance, and aar."
+---
+
 (ref-cmd-ref)=
 # Command reference
 

--- a/reference/compatibility-considerations.md
+++ b/reference/compatibility-considerations.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud compatibility, covering Android API limitations and hardware gaps."
+---
+
 (ref-compatibility-considerations)=
 # Compatibility Considerations
 

--- a/reference/component-versions.md
+++ b/reference/component-versions.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud component versions across releases."
+---
+
 (ref-component-versions)=
 # Component versions
 

--- a/reference/deprecation-notices.md
+++ b/reference/deprecation-notices.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud deprecation notices, covering features and APIs scheduled for removal."
+---
+
 (ref-deprecation-notes)=
 # Deprecation notices
 

--- a/reference/feature-flags.md
+++ b/reference/feature-flags.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud feature flags, which enable optional and experimental capabilities."
+---
+
 (ref-feature-flags)=
 # Feature flags
 

--- a/reference/glossary.md
+++ b/reference/glossary.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud terminology, with definitions for AMS, AAR, instances, and more."
+---
+
 (ref-glossary)=
 # Glossary
 

--- a/reference/hooks.md
+++ b/reference/hooks.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud addon hooks, covering supported hook names and environment variables."
+---
+
 (ref-hooks)=
 # Hooks
 

--- a/reference/index.md
+++ b/reference/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud, covering configuration, requirements, APIs, SDKs, and release notes."
+---
+
 (reference)=
 # Reference
 

--- a/reference/license-information.md
+++ b/reference/license-information.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud licensing, with guidance on finding copyright and license files."
+---
+
 (ref-license-information)=
 # License information
 The copyright and license information of Anbox Cloud can be found within the container or the virtual machine at `/usr/share/doc/anbox/copyright`.

--- a/reference/network-ports.md
+++ b/reference/network-ports.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for network ports used by Anbox Cloud services."
+---
+
 (ref-network-ports)=
 # Network ports
 

--- a/reference/perf-benchmarks.md
+++ b/reference/perf-benchmarks.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud performance benchmarks, covering instance density and GPU throughput."
+---
+
 (ref-performance-benchmarks)=
 # Performance benchmarks
 

--- a/reference/prometheus.md
+++ b/reference/prometheus.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Prometheus metrics exposed by Anbox Cloud."
+---
+
 (ref-prometheus-metrics)=
 # Prometheus metrics
 

--- a/reference/provided-images.md
+++ b/reference/provided-images.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for images provided by Anbox Cloud, covering Android versions and architectures."
+---
+
 (ref-provided-images)=
 # Provided Anbox Cloud images
 

--- a/reference/release-notes/1.0.0.md
+++ b/reference/release-notes/1.0.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.0.0: new features, improvements, and changes in this release."
 ---
 # 1.0.0 (November 2018)
 

--- a/reference/release-notes/1.0.1.md
+++ b/reference/release-notes/1.0.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.0.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.0.1 (December 2018)
 

--- a/reference/release-notes/1.1.0.md
+++ b/reference/release-notes/1.1.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.1.0: new features, improvements, and changes in this release."
 ---
 # 1.1.0 (January 2019)
 

--- a/reference/release-notes/1.1.1.md
+++ b/reference/release-notes/1.1.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.1.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.1.1 (February 2019)
 

--- a/reference/release-notes/1.10.0.md
+++ b/reference/release-notes/1.10.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.10.0: new features, improvements, and changes in this release."
 ---
 # 1.10.0
 

--- a/reference/release-notes/1.10.1.md
+++ b/reference/release-notes/1.10.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.10.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.10.1
 

--- a/reference/release-notes/1.10.2.md
+++ b/reference/release-notes/1.10.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.10.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.10.2
 

--- a/reference/release-notes/1.10.3.md
+++ b/reference/release-notes/1.10.3.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.10.3: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.10.3
 

--- a/reference/release-notes/1.11.0.md
+++ b/reference/release-notes/1.11.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.11.0: new features, improvements, and changes in this release."
 ---
 # 1.11.0
 

--- a/reference/release-notes/1.11.1.md
+++ b/reference/release-notes/1.11.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.11.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.11.1
 

--- a/reference/release-notes/1.11.2.md
+++ b/reference/release-notes/1.11.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.11.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.11.2
 

--- a/reference/release-notes/1.11.3.md
+++ b/reference/release-notes/1.11.3.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.11.3: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.11.3
 

--- a/reference/release-notes/1.11.4.md
+++ b/reference/release-notes/1.11.4.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.11.4: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.11.4
 

--- a/reference/release-notes/1.11.5.md
+++ b/reference/release-notes/1.11.5.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.11.5: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.11.5
 

--- a/reference/release-notes/1.12.0.md
+++ b/reference/release-notes/1.12.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.12.0: new features, improvements, and changes in this release."
 ---
 # 1.12.0
 

--- a/reference/release-notes/1.12.1.md
+++ b/reference/release-notes/1.12.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.12.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.12.1
 

--- a/reference/release-notes/1.12.2.md
+++ b/reference/release-notes/1.12.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.12.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.12.2
 

--- a/reference/release-notes/1.12.3.md
+++ b/reference/release-notes/1.12.3.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.12.3: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.12.3
 

--- a/reference/release-notes/1.12.4.md
+++ b/reference/release-notes/1.12.4.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.12.4: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.12.4
 

--- a/reference/release-notes/1.12.5.md
+++ b/reference/release-notes/1.12.5.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.12.5: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.12.5
 

--- a/reference/release-notes/1.13.0.md
+++ b/reference/release-notes/1.13.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.13.0: new features, improvements, and changes in this release."
 ---
 # 1.13.0
 

--- a/reference/release-notes/1.13.1.md
+++ b/reference/release-notes/1.13.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.13.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.13.1
 

--- a/reference/release-notes/1.13.2.md
+++ b/reference/release-notes/1.13.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.13.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.13.2
 

--- a/reference/release-notes/1.14.0.md
+++ b/reference/release-notes/1.14.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.14.0: new features, improvements, and changes in this release."
 ---
 # 1.14.0
 

--- a/reference/release-notes/1.14.1.md
+++ b/reference/release-notes/1.14.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.14.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.14.1
 

--- a/reference/release-notes/1.14.2.md
+++ b/reference/release-notes/1.14.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.14.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.14.2
 

--- a/reference/release-notes/1.15.0.md
+++ b/reference/release-notes/1.15.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.15.0: new features, improvements, and changes in this release."
 ---
 # 1.15.0
 

--- a/reference/release-notes/1.15.1.md
+++ b/reference/release-notes/1.15.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.15.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.15.1
 

--- a/reference/release-notes/1.15.2.md
+++ b/reference/release-notes/1.15.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.15.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.15.2
 

--- a/reference/release-notes/1.15.3.md
+++ b/reference/release-notes/1.15.3.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.15.3: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.15.3
 

--- a/reference/release-notes/1.16.0.md
+++ b/reference/release-notes/1.16.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.16.0: new features, improvements, and changes in this release."
 ---
 # 1.16.0
 

--- a/reference/release-notes/1.16.1.md
+++ b/reference/release-notes/1.16.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.16.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.16.1
 

--- a/reference/release-notes/1.16.2.md
+++ b/reference/release-notes/1.16.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.16.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.16.2
 

--- a/reference/release-notes/1.16.3.md
+++ b/reference/release-notes/1.16.3.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.16.3: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.16.3
 

--- a/reference/release-notes/1.16.4.md
+++ b/reference/release-notes/1.16.4.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.16.4: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.16.4
 

--- a/reference/release-notes/1.17.0.md
+++ b/reference/release-notes/1.17.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.17.0: new features, improvements, and changes in this release."
 ---
 # 1.17.0
 

--- a/reference/release-notes/1.17.1.md
+++ b/reference/release-notes/1.17.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.17.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.17.1
 

--- a/reference/release-notes/1.17.2.md
+++ b/reference/release-notes/1.17.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.17.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.17.2
 

--- a/reference/release-notes/1.18.0.md
+++ b/reference/release-notes/1.18.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.18.0: new features, improvements, and changes in this release."
 ---
 # 1.18.0
 

--- a/reference/release-notes/1.18.1.md
+++ b/reference/release-notes/1.18.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.18.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.18.1
 

--- a/reference/release-notes/1.18.2.md
+++ b/reference/release-notes/1.18.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.18.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.18.2
 

--- a/reference/release-notes/1.19.0-fix1.md
+++ b/reference/release-notes/1.19.0-fix1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.19.0-fix1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # Release notes for 1.19.0-fix1 hotfix
 

--- a/reference/release-notes/1.19.0.md
+++ b/reference/release-notes/1.19.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.19.0: new features, improvements, and changes in this release."
 ---
 # 1.19.0
 

--- a/reference/release-notes/1.19.1.md
+++ b/reference/release-notes/1.19.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.19.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.19.1
 

--- a/reference/release-notes/1.19.2.md
+++ b/reference/release-notes/1.19.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.19.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.19.2
 

--- a/reference/release-notes/1.2.0.md
+++ b/reference/release-notes/1.2.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.2.0: new features, improvements, and changes in this release."
 ---
 # 1.2.0 (April 2019)
 

--- a/reference/release-notes/1.2.1.md
+++ b/reference/release-notes/1.2.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.2.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.2.1 (April 2019)
 

--- a/reference/release-notes/1.20.0.md
+++ b/reference/release-notes/1.20.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.20.0: new features, improvements, and changes in this release."
 ---
 # 1.20.0
 

--- a/reference/release-notes/1.20.1.md
+++ b/reference/release-notes/1.20.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.20.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.20.1
 

--- a/reference/release-notes/1.20.2.md
+++ b/reference/release-notes/1.20.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.20.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.20.2
 

--- a/reference/release-notes/1.21.0.md
+++ b/reference/release-notes/1.21.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.21.0: new features, improvements, and changes in this release."
 ---
 # 1.21.0
 

--- a/reference/release-notes/1.21.1.md
+++ b/reference/release-notes/1.21.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.21.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.21.1
 

--- a/reference/release-notes/1.21.2.md
+++ b/reference/release-notes/1.21.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.21.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.21.2
 

--- a/reference/release-notes/1.22.0.md
+++ b/reference/release-notes/1.22.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.22.0: new features, improvements, and changes in this release."
 ---
 # 1.22.0
 

--- a/reference/release-notes/1.22.1.md
+++ b/reference/release-notes/1.22.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.22.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.22.1
 

--- a/reference/release-notes/1.22.2.md
+++ b/reference/release-notes/1.22.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.22.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # Introduction
 

--- a/reference/release-notes/1.23.0.md
+++ b/reference/release-notes/1.23.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.23.0: new features, improvements, and changes in this release."
 ---
 # 1.23.0
 

--- a/reference/release-notes/1.23.1.md
+++ b/reference/release-notes/1.23.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.23.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.23.1
 

--- a/reference/release-notes/1.23.2-hotfix1.md
+++ b/reference/release-notes/1.23.2-hotfix1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.23.2 hotfix: critical bug fixes and patches for this version."
 ---
 # 1.23.2 hotfix 1
 

--- a/reference/release-notes/1.23.2.md
+++ b/reference/release-notes/1.23.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.23.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.23.2
 

--- a/reference/release-notes/1.23.3.md
+++ b/reference/release-notes/1.23.3.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.23.3: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.23.3
 

--- a/reference/release-notes/1.24.0.md
+++ b/reference/release-notes/1.24.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.24.0: new features, improvements, and changes in this release."
 ---
 # 1.24.0
 

--- a/reference/release-notes/1.24.1.md
+++ b/reference/release-notes/1.24.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.24.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.24.1
 

--- a/reference/release-notes/1.24.2.md
+++ b/reference/release-notes/1.24.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.24.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.24.2
 

--- a/reference/release-notes/1.25.0.md
+++ b/reference/release-notes/1.25.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.25.0: new features, improvements, and changes in this release."
 ---
 # 1.25.0
 

--- a/reference/release-notes/1.25.1.md
+++ b/reference/release-notes/1.25.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.25.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.25.1
 

--- a/reference/release-notes/1.25.2.md
+++ b/reference/release-notes/1.25.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.25.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.25.2
 

--- a/reference/release-notes/1.26.0.md
+++ b/reference/release-notes/1.26.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.26.0: new features, improvements, and changes in this release."
 ---
 # 1.26.0
 

--- a/reference/release-notes/1.26.1.md
+++ b/reference/release-notes/1.26.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.26.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.26.1
 

--- a/reference/release-notes/1.26.2.md
+++ b/reference/release-notes/1.26.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.26.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.26.2
 

--- a/reference/release-notes/1.27.0.md
+++ b/reference/release-notes/1.27.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.27.0: new features, improvements, and changes in this release."
 ---
 # 1.27.0
 

--- a/reference/release-notes/1.27.1.md
+++ b/reference/release-notes/1.27.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.27.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.27.1
 

--- a/reference/release-notes/1.27.2.md
+++ b/reference/release-notes/1.27.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.27.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.27.2
 

--- a/reference/release-notes/1.28.0.md
+++ b/reference/release-notes/1.28.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.28.0: new features, improvements, and changes in this release."
 ---
 # 1.28.0
 

--- a/reference/release-notes/1.28.1.md
+++ b/reference/release-notes/1.28.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.28.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.28.1
 

--- a/reference/release-notes/1.28.2.md
+++ b/reference/release-notes/1.28.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.28.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.28.2
 

--- a/reference/release-notes/1.29.0.md
+++ b/reference/release-notes/1.29.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.29.0: new features, improvements, and changes in this release."
 ---
 # 1.29.0
 

--- a/reference/release-notes/1.29.1.md
+++ b/reference/release-notes/1.29.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.29.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.29.1
 

--- a/reference/release-notes/1.29.2.md
+++ b/reference/release-notes/1.29.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.29.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.29.2
 

--- a/reference/release-notes/1.3.0.md
+++ b/reference/release-notes/1.3.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.3.0: new features, improvements, and changes in this release."
 ---
 # 1.3.0 (August 2019)
 

--- a/reference/release-notes/1.3.1.md
+++ b/reference/release-notes/1.3.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.3.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.3.1 (September 2019)
 

--- a/reference/release-notes/1.3.2.md
+++ b/reference/release-notes/1.3.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.3.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # New features & improvements
 

--- a/reference/release-notes/1.3.3.md
+++ b/reference/release-notes/1.3.3.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.3.3: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.3 (January 2020)
 

--- a/reference/release-notes/1.4.0.md
+++ b/reference/release-notes/1.4.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.4.0: new features, improvements, and changes in this release."
 ---
 # 1.4.0 (March 2020)
 

--- a/reference/release-notes/1.5.0.md
+++ b/reference/release-notes/1.5.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.5.0: new features, improvements, and changes in this release."
 ---
 # 1.5.0 (April 2020)
 

--- a/reference/release-notes/1.5.1.md
+++ b/reference/release-notes/1.5.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.5.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.5.1 (May 2020)
 

--- a/reference/release-notes/1.5.2.md
+++ b/reference/release-notes/1.5.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.5.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.5.2 (June 2020)
 

--- a/reference/release-notes/1.6.0.md
+++ b/reference/release-notes/1.6.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.6.0: new features, improvements, and changes in this release."
 ---
 # 1.6.0 (June 2020)
 

--- a/reference/release-notes/1.6.1.md
+++ b/reference/release-notes/1.6.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.6.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.6.1 (June 2020)
 

--- a/reference/release-notes/1.6.2.md
+++ b/reference/release-notes/1.6.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.6.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.6.2 (June 2020)
 

--- a/reference/release-notes/1.6.3.md
+++ b/reference/release-notes/1.6.3.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.6.3: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.6.3 (July 2020)
 

--- a/reference/release-notes/1.7.0.md
+++ b/reference/release-notes/1.7.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.7.0: new features, improvements, and changes in this release."
 ---
 # 1.7.0 (August 2020)
 

--- a/reference/release-notes/1.7.1.md
+++ b/reference/release-notes/1.7.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.7.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.7.1
 

--- a/reference/release-notes/1.7.2.md
+++ b/reference/release-notes/1.7.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.7.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.7.2
 

--- a/reference/release-notes/1.7.3.md
+++ b/reference/release-notes/1.7.3.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.7.3: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.7.3
 

--- a/reference/release-notes/1.7.4.md
+++ b/reference/release-notes/1.7.4.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.7.4: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.7.4
 

--- a/reference/release-notes/1.8.0.md
+++ b/reference/release-notes/1.8.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.8.0: new features, improvements, and changes in this release."
 ---
 # 1.8.0
 

--- a/reference/release-notes/1.8.1.md
+++ b/reference/release-notes/1.8.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.8.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.8.1
 

--- a/reference/release-notes/1.8.2.md
+++ b/reference/release-notes/1.8.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.8.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.8.2
 

--- a/reference/release-notes/1.8.3.md
+++ b/reference/release-notes/1.8.3.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.8.3: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.8.3
 

--- a/reference/release-notes/1.9.0.md
+++ b/reference/release-notes/1.9.0.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.9.0: new features, improvements, and changes in this release."
 ---
 # 1.9.0
 

--- a/reference/release-notes/1.9.1.md
+++ b/reference/release-notes/1.9.1.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.9.1: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.9.1
 

--- a/reference/release-notes/1.9.2.md
+++ b/reference/release-notes/1.9.2.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.9.2: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.9.2
 

--- a/reference/release-notes/1.9.3.md
+++ b/reference/release-notes/1.9.3.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.9.3: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.9.3
 

--- a/reference/release-notes/1.9.4.md
+++ b/reference/release-notes/1.9.4.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.9.4: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.9.4
 

--- a/reference/release-notes/1.9.5.md
+++ b/reference/release-notes/1.9.5.md
@@ -1,5 +1,8 @@
 ---
 orphan: true
+myst:
+  html_meta:
+    "description": "Release notes for Anbox Cloud 1.9.5: bug fixes, security patches, and minor improvements in this patch release."
 ---
 # 1.9.5
 

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud release notes, with links to per-version changelogs."
+---
+
 (ref-release-notes)=
 # Release notes
 

--- a/reference/requirements.md
+++ b/reference/requirements.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud system requirements, covering hardware, Ubuntu versions, and LXD."
+---
+
 (ref-requirements)=
 # Requirements
 

--- a/reference/sdks.md
+++ b/reference/sdks.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud SDKs, covering the Streaming SDK, AMS SDK, and Platform SDK."
+---
+
 (ref-sdks)=
 # Anbox Cloud SDKs
 

--- a/reference/security-notices.md
+++ b/reference/security-notices.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud security notices, covering published vulnerabilities and fixes."
+---
+
 (ref-security-notices)=
 # Security notices
 

--- a/reference/security-policy.md
+++ b/reference/security-policy.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for Anbox Cloud security policy, covering release cadence and vulnerability reporting."
+---
+
 (ref-security-policy)=
 # Security policy
 

--- a/reference/supported-codecs.md
+++ b/reference/supported-codecs.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for video codecs supported by Anbox Cloud, covering H.264, H.265, and VP8/VP9."
+---
+
 (ref-codecs)=
 # Supported video codecs
 

--- a/reference/supported-rendering-resources.md
+++ b/reference/supported-rendering-resources.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for supported GPU hardware and rendering APIs in Anbox Cloud."
+---
+
 (ref-rendering-resources)=
 # Supported rendering resources
 

--- a/reference/webrtc-streamer.md
+++ b/reference/webrtc-streamer.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Reference documentation for WebRTC streamer configuration in Anbox Cloud."
+---
+
 (ref-webrtc)=
 # WebRTC streamer
 

--- a/tutorial/create-test-virtual-device.md
+++ b/tutorial/create-test-virtual-device.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Learn how to create a virtual Android device. In this tutorial, we use the CLI or dashboard to launch and test an Anbox Cloud instance."
+---
+
 (tut-create-virtual-device)=
 # Create and test a virtual device
 

--- a/tutorial/index.md
+++ b/tutorial/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Learn Anbox Cloud essentials. In this section, we guide you through installation, creating virtual devices, and building streaming clients."
+---
+
 (tutorials)=
 # Tutorials
 

--- a/tutorial/installing-appliance.md
+++ b/tutorial/installing-appliance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Learn how to install the Anbox Cloud Appliance. In this tutorial, we set up the snap inside a Multipass VM and access the web dashboard."
+---
+
 (tut-installing-appliance)=
 # Install the appliance
 

--- a/tutorial/stream-client.md
+++ b/tutorial/stream-client.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description": "Learn how to build a streaming client for Anbox Cloud. In this tutorial, we set up WebRTC, service accounts, and a Flask proxy server."
+---
+
 (tut-set-up-stream-client)=
 
 # Set up a stream client


### PR DESCRIPTION
# Documentation changes

This is one of the initiatives to improve traffic, SEO, and analysis.
We have been asked to generate description metadata to better documentation traffic and visibility for search engines.

The resources we have for that are below.

https://library.canonical.com/documentation/documentation-practice/html-metadata/set-useful-html-meta-descriptions 

https://library.canonical.com/documentation/documentation-practice/documentation-objectives/seo

I applied the same approach to the metadata as shown in the exemplar below:
https://canonical-docs-examples-of-good.readthedocs-hosted.com/metadata/description/

I haven't added any metadata to the auto-generated content.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,

- [ ] Run `make spelling` and fix any spelling issues.
- [ ] Run `make linkcheck` and fix any broken links.
- [ ] Run `make lint-md` and fix any linting issues.
- [ ] Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[AC-3456
](https://warthogs.atlassian.net/browse/AC-3456)