### PR TITLE
fix: updated target dates for upcoming releases and adjusted metadata descriptions

### DIFF
--- a/explanation/auth.md
+++ b/explanation/auth.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    "description": "Explanation of authentication and authorisation in Anbox Cloud, covering OIDC and TLS identity types, groups, and permission levels."
+    "description": "Explanation of authentication and authorization in Anbox Cloud, covering OIDC and TLS identity types, groups, and permission levels."
 ---
 
 (exp-auth)=

--- a/explanation/rendering-graphics.md
+++ b/explanation/rendering-graphics.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    "description": "Explanation of rendering modes in Anbox Cloud, covering how graphics behaviour adapts based on GPU availability."
+    "description": "Explanation of rendering modes in Anbox Cloud, covering how graphics behavior adapts based on GPU availability."
 ---
 
 (exp-rendering-graphics)=

--- a/howto/addons/examples.md
+++ b/howto/addons/examples.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    "description": "How to implement common addon patterns in Anbox Cloud, with worked examples for backup, customisation, and tool installation."
+    "description": "How to implement common addon patterns in Anbox Cloud, with worked examples for backup, customization, and tool installation."
 ---
 
 # Examples

--- a/howto/android/debug-graphics-renderdoc.md
+++ b/howto/android/debug-graphics-renderdoc.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    "description": "How to use RenderDoc to capture and analyse GPU frames from Android applications in Anbox Cloud."
+    "description": "How to use RenderDoc to capture and analyze GPU frames from Android applications in Anbox Cloud."
 ---
 
 (howto-debug-graphics-renderdoc)=

--- a/howto/application/extend-application.md
+++ b/howto/application/extend-application.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    "description": "How to extend an Anbox Cloud application with custom behaviour using hooks or addons."
+    "description": "How to extend an Anbox Cloud application with custom behavior using hooks or addons."
 ---
 
 (howto-extend-application)=

--- a/howto/install/customize-installation.md
+++ b/howto/install/customize-installation.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    "description": "How to customise a charmed Anbox Cloud deployment using Juju overlay files or modified bundle files."
+    "description": "How to customize a charmed Anbox Cloud deployment using Juju overlay files or modified bundle files."
 ---
 
 (howto-customize-installation)=

--- a/howto/instance/start-instance.md
+++ b/howto/instance/start-instance.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    "description": "How to start an Anbox Cloud instance that was initialised with amc init or previously stopped."
+    "description": "How to start an Anbox Cloud instance that was initialized with amc init or previously stopped."
 ---
 
 (howto-start-instance)=

--- a/howto/troubleshoot/troubleshoot-initial-setup.md
+++ b/howto/troubleshoot/troubleshoot-initial-setup.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    "description": "How to diagnose Anbox Cloud setup failures, including snap installation and LXD initialisation problems."
+    "description": "How to diagnose Anbox Cloud setup failures, including snap installation and LXD initialization problems."
 ---
 
 (howto-ts-initial-setup)=

--- a/reference/appliance-preseed.md
+++ b/reference/appliance-preseed.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    "description": "Reference documentation for Anbox Cloud Appliance preseed configuration for automated initialisation."
+    "description": "Reference documentation for Anbox Cloud Appliance preseed configuration for automated initialization."
 ---
 
 (ref-appliance-preseed-config)=

--- a/reference/auth.md
+++ b/reference/auth.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    "description": "Reference documentation for authorisation in Anbox Cloud, covering entitlements, identity types, and groups."
+    "description": "Reference documentation for authorization in Anbox Cloud, covering entitlements, identity types, and groups."
 ---
 
 (ref-auth)=

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -27,9 +27,9 @@ The following target dates for upcoming releases are not final and could vary de
 
 | Target date | Version | Planned updates |
 |----|----|----|
-| June TBD | Anbox Cloud 1.30.0 | *New features<br/>* Android security updates<br/> * Bug fixes |
-| TBD | Anbox Cloud 1.30.1 | *Android security updates<br/>* Bug fixes |
-| TBD | Anbox Cloud 1.30.2 | *Android security updates<br/>* Bug fixes |
+| June 17, 2026 | Anbox Cloud 1.30.0 | *New features<br/>* Android security updates<br/> * Bug fixes |
+| July 15, 2026 | Anbox Cloud 1.30.1 | *Android security updates<br/>* Bug fixes |
+| August 19, 2026 | Anbox Cloud 1.30.2 | *Android security updates<br/>* Bug fixes |
 
 ## Release and support policy
 

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -27,9 +27,9 @@ The following target dates for upcoming releases are not final and could vary de
 
 | Target date | Version | Planned updates |
 |----|----|----|
-| May 20, 2026 | Anbox Cloud 1.30.0 | *New features<br/>* Android security updated<br/> * Bug fixes |
-| June 17, 2026 | Anbox Cloud 1.30.1 | *Android security updated<br/>* Bug fixes |
-| July 15, 2026 | Anbox Cloud 1.30.2 | *Android security updated<br/>* Bug fixes |
+| June TBD | Anbox Cloud 1.30.0 | *New features<br/>* Android security updates<br/> * Bug fixes |
+| TBD | Anbox Cloud 1.30.1 | *Android security updates<br/>* Bug fixes |
+| TBD | Anbox Cloud 1.30.2 | *Android security updates<br/>* Bug fixes |
 
 ## Release and support policy
 


### PR DESCRIPTION
# Documentation changes

- Updated the target dates for Anbox Cloud releases (so that 1.30 is not outdated, and TBD for the patches)
- Fixed quick mistake in the description of the releases (Android security update**d** -> Android security update**s**)
- Adjusted the metadata descriptions to follow US English instead of UK English as per the [documentation style guide](https://documentation.ubuntu.com/style-guide/#spelling)

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,

- [ ] Run `make spelling` and fix any spelling issues.
- [ ] Run `make linkcheck` and fix any broken links.
- [ ] Run `make lint-md` and fix any linting issues.
- [ ] Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

N/A
