### PR TITLE
docs: updated homepage to pass checks 

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,9 +7,9 @@ myst:
 (home)=
 # Anbox Cloud documentation
 
-**Anbox Cloud provides a scalable platform for running Android in the cloud using lightweight LXD system containers or full virtual machines.**
+**Anbox Cloud runs Android in the cloud using lightweight LXD system containers or full virtual machines.**
 
-**Built on Ubuntu, it deploys, manages, and streams Android workloads across public and private infrastructure with consistent performance and low latency.** It can run up to 100 Android instances per server while maintaining security and isolation.
+**Built on Ubuntu, it provides a scalable platform to deploy, manage, and stream Android workloads across public and private infrastructure with consistent performance and low latency.** It can run up to 100 Android instances per server while maintaining security and isolation.
 
 Anbox Cloud is available as a single-machine {ref}`appliance <sec-variants>` for small-scale deployments or as a {ref}`charmed deployment <sec-variants>` using Juju for production environments and multi-cluster scaling.
 

--- a/index.md
+++ b/index.md
@@ -4,6 +4,7 @@ myst:
     "description": "Run Android at scale in the cloud. Anbox Cloud delivers high-density streaming using LXD containers or VMs on public or private infrastructure."
 ---
 
+(home)=
 # Anbox Cloud documentation
 
 Anbox Cloud is a scalable platform for running Android in the cloud using lightweight LXD system containers or full virtual machines. Built on Ubuntu, it enables you to deploy, manage, and stream Android workloads across public or private infrastructure with consistent performance and low latency.
@@ -12,53 +13,51 @@ Compared to other Android emulation solutions, Anbox Cloud delivers at least twi
 
 This makes it well suited for a wide range of Android workloads. **Cloud gaming service providers** can deliver high-performance streaming experiences at scale, **automotive OEMs** can test infotainment systems without relying on physical hardware, **Android developers** can preview UI changes instantly, and **enterprises** can provide remote Android workspaces as a service.
 
-Anbox Cloud is available as a single-machine [appliance](https://documentation.ubuntu.com/anbox-cloud/explanation/anbox-cloud/#anbox-cloud-appliance) for development and small-scale deployments, or as a [charmed deployment](https://documentation.ubuntu.com/anbox-cloud/explanation/anbox-cloud/#id1) using Juju for production environments and multi-cluster scaling.
+Anbox Cloud is available as a single-machine {ref}`appliance <sec-variants>` for development and small-scale deployments, or as a {ref}`charmed deployment <sec-variants>` using Juju for production environments and multi-cluster scaling.
 
 ## In this documentation
 
 ### Lifecycle
 
-- **Installation:** [Requirements](https://documentation.ubuntu.com/anbox-cloud/reference/requirements/) • [Install using appliance](https://documentation.ubuntu.com/anbox-cloud/tutorial/installing-appliance/) • [Install using charms](https://documentation.ubuntu.com/anbox-cloud/howto/install/deploy-bare-metal/)
-- **Authentication and authorization:** [Custom IdP](https://documentation.ubuntu.com/anbox-cloud/howto/setup-custom-idp/#) • [OIDC](https://documentation.ubuntu.com/anbox-cloud/howto/setup-custom-idp/configure-oidc/) • [User permissions](https://documentation.ubuntu.com/anbox-cloud/howto/anbox/auth/#) • [Authorization entities in Anbox Cloud](https://documentation.ubuntu.com/anbox-cloud/explanation/auth/) • [Entitlements](https://documentation.ubuntu.com/anbox-cloud/reference/auth/)
-- **Configuration:** [Non-interactive configuration](https://documentation.ubuntu.com/anbox-cloud/reference/appliance-preseed/) • [Addon manifest](https://documentation.ubuntu.com/anbox-cloud/reference/addon-manifest/#) • [Application manifest](https://documentation.ubuntu.com/anbox-cloud/reference/application-manifest/) • [AMS parameters](https://documentation.ubuntu.com/anbox-cloud/reference/ams-configuration/) • [Instance parameters](https://documentation.ubuntu.com/anbox-cloud/reference/ams-instance-configuration/#)
-- **Deployment:** [Validate](https://documentation.ubuntu.com/anbox-cloud/howto/install/validate-deployment/) • [Use shared storage](https://documentation.ubuntu.com/anbox-cloud/howto/install/use-ceph-storage/)  • [Customize](https://documentation.ubuntu.com/anbox-cloud/howto/install/customize-installation/#)
-- **Scaling:** [Nodes](https://documentation.ubuntu.com/anbox-cloud/explanation/nodes/) • [Clustering](https://documentation.ubuntu.com/anbox-cloud/explanation/clustering/#) • [Configure clusters](https://documentation.ubuntu.com/anbox-cloud/howto/cluster/configure-nodes/) • [Scale up](https://documentation.ubuntu.com/anbox-cloud/howto/cluster/scale-up/) • [Scale down](https://documentation.ubuntu.com/anbox-cloud/howto/cluster/scale-down/)
-- **Upgrading:** [Appliance](https://documentation.ubuntu.com/anbox-cloud/howto/upgrade/upgrade-appliance/#) • [Charmed Anbox](https://documentation.ubuntu.com/anbox-cloud/howto/upgrade/upgrade-anbox/)
-
+- **Installation:** {ref}`ref-requirements` • {ref}`tut-installing-appliance` • {ref}`howto-deploy-anbox-baremetal`
+- **Authentication and authorization:** {ref}`howto-set-up-idp` • {ref}`howto-configure-oidc` • {ref}`howto-auth` • {ref}`exp-auth` • {ref}`ref-auth`
+- **Configuration:** {ref}`ref-appliance-preseed-config` • {ref}`ref-addon-manifest` • {ref}`ref-application-manifest` • {ref}`ref-ams-configuration` • {ref}`ref-ams-instance-configuration`
+- **Deployment:** {ref}`howto-validate-deployment` • {ref}`howto-use-ceph-storage` • {ref}`howto-customize-installation`
+- **Scaling:** {ref}`exp-nodes` • {ref}`exp-clustering` • {ref}`howto-configure-cluster-nodes` • {ref}`howto-scale-up-cluster` • {ref}`howto-scale-down-cluster`
+- **Upgrading:** {ref}`howto-upgrade-appliance` • {ref}`howto-upgrade-anbox-cloud`
 
 ### Artifacts and interfaces
 
-- **Appliance:** [Introduction](https://documentation.ubuntu.com/anbox-cloud/explanation/anbox-cloud/#variants) • [CLI](https://documentation.ubuntu.com/anbox-cloud/reference/cmd-ref/appliance/anbox-cloud-appliance/) • [Web dashboard](https://documentation.ubuntu.com/anbox-cloud/explanation/web-dashboard/#)
-- **Anbox Management Service:** [Introduction](https://documentation.ubuntu.com/anbox-cloud/explanation/web-dashboard/#) • [Remote access](https://documentation.ubuntu.com/anbox-cloud/howto/anbox/control-ams-remotely/#) • [CLI](https://documentation.ubuntu.com/anbox-cloud/reference/cmd-ref/amc/ams.amc/)
-- **Anbox Application Registry:** [Introduction](https://documentation.ubuntu.com/anbox-cloud/explanation/web-dashboard/#) • [Configure](https://documentation.ubuntu.com/anbox-cloud/howto/aar/configure/#) • [Deploy](https://documentation.ubuntu.com/anbox-cloud/howto/aar/deploy/) • [Revoke a client](https://documentation.ubuntu.com/anbox-cloud/howto/aar/deploy/)
-- **Images:** [Overview](https://documentation.ubuntu.com/anbox-cloud/explanation/images/) • [Image server](https://documentation.ubuntu.com/anbox-cloud/howto/images/configure-image-server/#) • [Add](https://documentation.ubuntu.com/anbox-cloud/howto/images/add-image/) • [Delete](https://documentation.ubuntu.com/anbox-cloud/howto/images/delete-image/) • [Choose](https://documentation.ubuntu.com/anbox-cloud/howto/images/use-specific-release/)
-- **Instances:** [Overview](https://documentation.ubuntu.com/anbox-cloud/explanation/instances/) • [Resource presets](https://documentation.ubuntu.com/anbox-cloud/explanation/resources/) • [Create](https://documentation.ubuntu.com/anbox-cloud/howto/instance/create-instance/) • [Configure](https://documentation.ubuntu.com/anbox-cloud/howto/instance/configure-instance/) • [Start](https://documentation.ubuntu.com/anbox-cloud/howto/instance/start-instance/) • [Stop](https://documentation.ubuntu.com/anbox-cloud/howto/instance/stop-instance/) • [Delete](https://documentation.ubuntu.com/anbox-cloud/howto/instance/delete-instance/) • [Expose services](https://documentation.ubuntu.com/anbox-cloud/howto/instance/expose-services/) • [Logs](https://documentation.ubuntu.com/anbox-cloud/howto/instance/view-instance-logs/) • [Backup](https://documentation.ubuntu.com/anbox-cloud/howto/instance/backup-restore-application-data/) • [Hooks](https://documentation.ubuntu.com/anbox-cloud/reference/hooks/)
-- **Applications:** [Create](https://documentation.ubuntu.com/anbox-cloud/howto/application/create-application/) • [Delete](https://documentation.ubuntu.com/anbox-cloud/howto/application/delete-application/) • [Update](https://documentation.ubuntu.com/anbox-cloud/howto/application/update-application/) • [Custom data](https://documentation.ubuntu.com/anbox-cloud/howto/application/pass-custom-data/) • [Extend](https://documentation.ubuntu.com/anbox-cloud/howto/application/extend-application/) • [Stream](https://documentation.ubuntu.com/anbox-cloud/howto/application/stream-application/)
-- **Addons:** [Create](https://documentation.ubuntu.com/anbox-cloud/howto/addons/create-addon/) • [Enable globally](https://documentation.ubuntu.com/anbox-cloud/howto/addons/create-addon/) • [Migrate from an older version](https://documentation.ubuntu.com/anbox-cloud/howto/addons/create-addon/) • [Update](https://documentation.ubuntu.com/anbox-cloud/howto/addons/create-addon/) • [Best practices](https://documentation.ubuntu.com/anbox-cloud/explanation/addons/)
-- **SDKs:** [Available SDKs](https://documentation.ubuntu.com/anbox-cloud/reference/sdks/) • [Platform SDK API](https://canonical.github.io/anbox-cloud.github.com/latest/anbox-platform-sdk/)
-
+- **Appliance:** {ref}`sec-variants` • [CLI](reference/cmd-ref/appliance/anbox-cloud-appliance.md) • {ref}`exp-web-dashboard`
+- **Anbox Management Service:** {ref}`exp-ams` • {ref}`howto-access-ams-remote` • [CLI](reference/cmd-ref/amc/ams.amc.md)
+- **Anbox Application Registry:** {ref}`exp-aar` • {ref}`howto-configure-aar` • {ref}`howto-deploy-aar` • {ref}`howto-revoke-aar`
+- **Images:** {ref}`exp-images` • {ref}`howto-configure-image-server` • {ref}`howto-add-image` • {ref}`howto-delete-image` • {ref}`howto-use-specific-release`
+- **Instances:** {ref}`exp-instances` • {ref}`exp-resources-presets` • {ref}`howto-create-instance` • {ref}`howto-configure-instance` • {ref}`howto-start-instance` • {ref}`howto-stop-instance` • {ref}`howto-delete-instance` • {ref}`howto-expose-services` • {ref}`howto-view-instance-logs` • {ref}`howto-backup-restore-application-data` • {ref}`ref-hooks`
+- **Applications:** {ref}`howto-create-application` • {ref}`howto-delete-application` • {ref}`howto-update-application` • {ref}`howto-pass-custom-data-application` • {ref}`howto-extend-application` • {ref}`howto-stream-applications`
+- **Addons:** {ref}`howto-create-addon` • {ref}`howto-enable-addons-globally` • {ref}`howto-migrate-addons` • {ref}`howto-update-addons` • {ref}`exp-addons`
+- **SDKs:** {ref}`ref-sdks` • [Platform SDK API](https://canonical.github.io/anbox-cloud.github.com/latest/anbox-platform-sdk/)
 
 ### Features
 
-- **Streaming:** [Streaming Stack](https://documentation.ubuntu.com/anbox-cloud/explanation/application-streaming/#) • [Set up a stream client](https://documentation.ubuntu.com/anbox-cloud/tutorial/stream-client/) • [Stream Gateway API](https://documentation.ubuntu.com/anbox-cloud/reference/api-reference/gateway-api/) • [WebRTC streamer](https://documentation.ubuntu.com/anbox-cloud/reference/webrtc-streamer/) • [Platforms](https://documentation.ubuntu.com/anbox-cloud/explanation/platforms/) • [Share a stream session](https://documentation.ubuntu.com/anbox-cloud/howto/instance/share-session/)
-- **Rendering:** [Architecture](https://documentation.ubuntu.com/anbox-cloud/explanation/rendering-architecture/#) • [Graphical output](https://documentation.ubuntu.com/anbox-cloud/explanation/rendering-graphics/)
-- **Images:** [Custom images](https://documentation.ubuntu.com/anbox-cloud/explanation/custom-images/) • [AAOS images](https://documentation.ubuntu.com/anbox-cloud/explanation/aaos/#)
-- **Supported features:** [Android features](https://documentation.ubuntu.com/anbox-cloud/reference/android-features/) • [Anbox features](https://documentation.ubuntu.com/anbox-cloud/reference/anbox-features/) • [Rendering resources](https://documentation.ubuntu.com/anbox-cloud/reference/supported-rendering-resources/) • [Video codecs](https://documentation.ubuntu.com/anbox-cloud/reference/supported-codecs/) **•** [Feature flags](https://documentation.ubuntu.com/anbox-cloud/reference/feature-flags/)
+- **Streaming:** {ref}`exp-application-streaming` • {ref}`tut-set-up-stream-client` • [Stream Gateway API](reference/api-reference/gateway-api.md) • {ref}`ref-webrtc` • {ref}`exp-platforms` • {ref}`howto-share-session`
+- **Rendering:** {ref}`exp-rendering-architecture` • {ref}`exp-rendering-graphics`
+- **Images:** {ref}`exp-custom-images` • {ref}`exp-aaos`
+- **Supported features:** {ref}`ref-android-features` • {ref}`ref-aosp-aaos` • {ref}`ref-rendering-resources` • {ref}`ref-codecs` • {ref}`ref-feature-flags`
 
 ### Quality
 
-- **Security:** [Security policy](https://documentation.ubuntu.com/anbox-cloud/reference/security-policy/) • [Harden your deployment](https://documentation.ubuntu.com/anbox-cloud/howto/anbox/harden/) • [Set up TLS](https://documentation.ubuntu.com/anbox-cloud/howto/anbox/tls-for-appliance/) • [Component level security](https://documentation.ubuntu.com/anbox-cloud/explanation/security/)
-- **Performance:** [Run benchmarks](https://documentation.ubuntu.com/anbox-cloud/howto/anbox/benchmarks/) • [Reference benchmarks](https://documentation.ubuntu.com/anbox-cloud/reference/perf-benchmarks/) • [Prometheus metrics](https://documentation.ubuntu.com/anbox-cloud/reference/prometheus/)
-- **Plan a deployment:** [Resource planning](https://documentation.ubuntu.com/anbox-cloud/explanation/capacity-planning/) • [Production](https://documentation.ubuntu.com/anbox-cloud/explanation/production-planning/) • [High availability](https://documentation.ubuntu.com/anbox-cloud/howto/install/enable-high-availability/) • [Monitoring](https://documentation.ubuntu.com/anbox-cloud/howto/monitor/)
+- **Security:** {ref}`ref-security-policy` • {ref}`howto-harden` • {ref}`howto-set-up-tls` • {ref}`exp-security`
+- **Performance:** {ref}`howto-run-benchmarks` • {ref}`ref-performance-benchmarks` • {ref}`ref-prometheus-metrics`
+- **Plan a deployment:** {ref}`exp-capacity-planning` • {ref}`exp-production-planning` • {ref}`howto-enable-ha` • {ref}`howto-monitor-anbox`
 
 ## How this documentation is organised
 
 This documentation uses the [Diátaxis documentation structure](https://diataxis.fr/).
 
-- The [Tutorial](https://documentation.ubuntu.com/anbox-cloud/tutorial/) takes you step-by-step through installing Anbox Cloud Appliance and creating your first virtual Android device.
-- [How to guides](https://documentation.ubuntu.com/anbox-cloud/howto/) assume you have basic familiarity with Anbox Cloud. They cover key operations such as managing applications, instances, and clusters.
-- [Reference](https://documentation.ubuntu.com/anbox-cloud/reference/) provides technical details on configuration options, APIs, CLI commands, and system requirements.
-- [Explanation](https://documentation.ubuntu.com/anbox-cloud/explanation/#explanation) offers topic overviews and context on architecture, working with Anbox Cloud, deploying, and security.
+- The {ref}`tutorials` take you step-by-step through installing Anbox Cloud Appliance, creating your first virtual Android device,  and setting up a stream client.
+- {ref}`how-to-guides` assume you have basic familiarity with Anbox Cloud. They cover key operations such as managing applications, instances, and clusters.
+- {ref}`reference` provides technical details on configuration options, APIs, CLI commands, and system requirements.
+- {ref}`explanation` offers topic overviews and context on architecture, working with Anbox Cloud, deploying, and security.
 
 ## Project and community
 
@@ -68,29 +67,28 @@ We welcome community involvement through suggestions, fixes and constructive fee
 
 ### Get involved
 
-- [Join the Discourse forum](https://discourse.ubuntu.com/c/project/anbox-user/148?_gl=1*1q03mla*_ga*Mjg0ODIyOTM5LjE3NzY3MDY4ODQ.*_ga_892F83CXG5*czE3Nzk4NjkzMzEkbzcyJGcxJHQxNzc5ODc0MTQzJGo2MCRsMCRoMA..)
-- [Chat to us on Matrix](https://matrix.to/#/#anbox-cloud:ubuntu.com)
-- [Contribute to this documentation](https://documentation.ubuntu.com/anbox-cloud/contribute/)
-- [Report a bug](https://bugs.launchpad.net/anbox-cloud/+bugs)
-- [Get support](https://ubuntu.com/support?_gl=1*1396238*_ga*Mjg0ODIyOTM5LjE3NzY3MDY4ODQ.*_ga_892F83CXG5*czE3Nzk4NzY2NjUkbzczJGcxJHQxNzc5ODc2OTE0JGo1OSRsMCRoMA..)
+- [Discourse forum](https://discourse.ubuntu.com/c/project/anbox-user/148?_gl=1*1q03mla*_ga*Mjg0ODIyOTM5LjE3NzY3MDY4ODQ.*_ga_892F83CXG5*czE3Nzk4NjkzMzEkbzcyJGcxJHQxNzc5ODc0MTQzJGo2MCRsMCRoMA..)
+- [Matrix channel](https://matrix.to/#/#anbox-cloud:ubuntu.com)
+- {ref}`contribute`
+- [Issue tracker](https://bugs.launchpad.net/anbox-cloud/+bugs)
+- [Support](https://ubuntu.com/support?_gl=1*1396238*_ga*Mjg0ODIyOTM5LjE3NzY3MDY4ODQ.*_ga_892F83CXG5*czE3Nzk4NzY2NjUkbzczJGcxJHQxNzc5ODc2OTE0JGo1OSRsMCRoMA..)
 
 ### Releases
 
-- [Release notes & roadmap](https://documentation.ubuntu.com/anbox-cloud/reference/release-notes/release-notes/)
-- [Component versions](https://documentation.ubuntu.com/anbox-cloud/reference/component-versions/)
-- [Deprecation notices](https://documentation.ubuntu.com/anbox-cloud/reference/deprecation-notices/)
-- [Available images](https://documentation.ubuntu.com/anbox-cloud/reference/provided-images/)
+- {ref}`ref-release-notes`
+- {ref}`ref-component-versions`
+- {ref}`ref-deprecation-notes`
+- {ref}`ref-provided-images`
 
 ### Governance and policies
 
-- [License](https://documentation.ubuntu.com/anbox-cloud/reference/license-information/)
-- [Charm configuration](https://documentation.ubuntu.com/anbox-cloud/reference/charm-configuration/)
+- {ref}`ref-license-information`
+- {ref}`ref-charm-configuration`
 - [Code of conduct](https://ubuntu.com/community/code-of-conduct)
 
 ### Commercial support
 
 Thinking about using Anbox Cloud for your next project? [Get in touch\!](https://canonical.com/anbox-cloud?_gl=1*1hm0lj*_ga*Mjg0ODIyOTM5LjE3NzY3MDY4ODQ.*_ga_892F83CXG5*czE3Nzk4NzY2NjUkbzczJGcxJHQxNzc5ODc3NzAwJGo1OSRsMCRoMA..*_gcl_au*NTcyOTk1ODc5LjE3NzYyNjY3MjQ.*_ga_5LTL1CNEJM*czE3Nzk4NzY2NjQkbzYyJGcxJHQxNzc5ODc3NzAwJGo1OSRsMCRoMA..#get-in-touch)
-
 
 ```{toctree}
 :hidden:

--- a/index.md
+++ b/index.md
@@ -7,11 +7,11 @@ myst:
 (home)=
 # Anbox Cloud documentation
 
-**Anbox Cloud is a platform for running Android at scale in the cloud using lightweight LXD system containers or full virtual machines.**
+**Anbox Cloud provides a scalable platform for running Android in the cloud using lightweight LXD system containers or full virtual machines.**
 
 **Built on Ubuntu, it deploys, manages, and streams Android workloads across public and private infrastructure with consistent performance and low latency.** It can run up to 100 Android instances per server while maintaining security and isolation.
 
-The platform is available as a single-machine {ref}`appliance <sec-variants>` for small-scale deployments or as a {ref}`charmed deployment <sec-variants>` using Juju for production environments and multi-cluster scaling.
+Anbox Cloud is available as a single-machine {ref}`appliance <sec-variants>` for small-scale deployments or as a {ref}`charmed deployment <sec-variants>` using Juju for production environments and multi-cluster scaling.
 
 **You should consider Anbox Cloud for the wide range of Android workloads it supports.** Cloud gaming providers can deliver high-performance streaming at scale, automotive OEMs can test infotainment systems without physical hardware, Android developers can preview UI changes instantly, and enterprises can provide remote Android workspaces as a service.
 

--- a/index.md
+++ b/index.md
@@ -28,8 +28,8 @@ The platform is available as a single-machine {ref}`appliance <sec-variants>` fo
 
 ### Artifacts and interfaces
 
-- **Appliance:** {ref}`sec-variants` • [CLI](reference/cmd-ref/appliance/anbox-cloud-appliance.md) • {ref}`exp-web-dashboard`
-- **Anbox Management Service:** {ref}`exp-ams` • {ref}`howto-access-ams-remote` • [CLI](reference/cmd-ref/amc/ams.amc.md)
+- **Appliance:** {ref}`sec-variants` • {doc}`CLI </reference/cmd-ref/appliance/anbox-cloud-appliance>` • {ref}`exp-web-dashboard`
+- **Anbox Management Service:** {ref}`exp-ams` • {ref}`howto-access-ams-remote` • {doc}`CLI </reference/cmd-ref/amc/ams.amc>`
 - **Anbox Application Registry:** {ref}`exp-aar` • {ref}`howto-configure-aar` • {ref}`howto-deploy-aar` • {ref}`howto-revoke-aar`
 - **Images:** {ref}`exp-images` • {ref}`howto-configure-image-server` • {ref}`howto-add-image` • {ref}`howto-delete-image` • {ref}`howto-use-specific-release`
 - **Instances:** {ref}`exp-instances` • {ref}`exp-resources-presets` • {ref}`howto-create-instance` • {ref}`howto-configure-instance` • {ref}`howto-start-instance` • {ref}`howto-stop-instance` • {ref}`howto-delete-instance` • {ref}`howto-expose-services` • {ref}`howto-view-instance-logs` • {ref}`howto-backup-restore-application-data` • {ref}`ref-hooks`
@@ -39,7 +39,7 @@ The platform is available as a single-machine {ref}`appliance <sec-variants>` fo
 
 ### Features
 
-- **Streaming:** {ref}`exp-application-streaming` • {ref}`tut-set-up-stream-client` • [Stream Gateway API](reference/api-reference/gateway-api.md) • {ref}`ref-webrtc` • {ref}`exp-platforms` • {ref}`howto-share-session`
+- **Streaming:** {ref}`exp-application-streaming` • {ref}`tut-set-up-stream-client` • {doc}`Stream Gateway API </reference/api-reference/gateway-api>` • {ref}`ref-webrtc` • {ref}`exp-platforms` • {ref}`howto-share-session`
 - **Rendering:** {ref}`exp-rendering-architecture` • {ref}`exp-rendering-graphics`
 - **Images:** {ref}`exp-custom-images` • {ref}`exp-aaos`
 - **Supported features:** {ref}`ref-android-features` • {ref}`ref-aosp-aaos` • {ref}`ref-rendering-resources` • {ref}`ref-codecs` • {ref}`ref-feature-flags`

--- a/index.md
+++ b/index.md
@@ -7,13 +7,13 @@ myst:
 (home)=
 # Anbox Cloud documentation
 
-Anbox Cloud is a scalable platform for running Android in the cloud using lightweight LXD system containers or full virtual machines. Built on Ubuntu, it enables you to deploy, manage, and stream Android workloads across public or private infrastructure with consistent performance and low latency.
+**Anbox Cloud is a platform for running Android at scale in the cloud using lightweight LXD system containers or full virtual machines.**
 
-Compared to other Android emulation solutions, Anbox Cloud delivers at least twice the density and can run up to **100 Android instances per server** while maintaining security and isolation for each instance.
+**Built on Ubuntu, it deploys, manages, and streams Android workloads across public and private infrastructure with consistent performance and low latency.** It can run up to 100 Android instances per server while maintaining security and isolation.
 
-This makes it well suited for a wide range of Android workloads. **Cloud gaming service providers** can deliver high-performance streaming experiences at scale, **automotive OEMs** can test infotainment systems without relying on physical hardware, **Android developers** can preview UI changes instantly, and **enterprises** can provide remote Android workspaces as a service.
+The platform is available as a single-machine {ref}`appliance <sec-variants>` for small-scale deployments or as a {ref}`charmed deployment <sec-variants>` using Juju for production environments and multi-cluster scaling.
 
-Anbox Cloud is available as a single-machine {ref}`appliance <sec-variants>` for development and small-scale deployments, or as a {ref}`charmed deployment <sec-variants>` using Juju for production environments and multi-cluster scaling.
+**You should consider Anbox Cloud for the wide range of Android workloads it supports.** Cloud gaming providers can deliver high-performance streaming at scale, automotive OEMs can test infotainment systems without physical hardware, Android developers can preview UI changes instantly, and enterprises can provide remote Android workspaces as a service.
 
 ## In this documentation
 


### PR DESCRIPTION
# Documentation changes

After the implementation of the landing page done by the team, we need to check if it passes the checks

- follows the standard homepage pattern template Standard documentation home page structures
- all docs pages have proper heading anchors (in our case all docs do except for the auto generated content from ams>>> will have a separate PR for that)
- Link text must only describe the destination resource and must omit instructional verbs, which should instead be placed in the surrounding unlinked prose.
- ensure every page that will be linked from it has a page-level anchor (done except for the ones that refer to auto-generated ones without anchors)
- The homepage must use only `{ref}` links to named anchors (for now, the ones referencing content from ams have {docs} after referring to TAs for that but will be changed to ref{})
- homepage: page anchor and title
- Present simple tense throughout.
- No slang, no flowery language, no clichés 

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,

- [ ] Run `make spelling` and fix any spelling issues.
- [ ] Run `make linkcheck` and fix any broken links.
- [ ] Run `make lint-md` and fix any linting issues.
- [ ] Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]
[AC-4666](https://warthogs.atlassian.net/browse/AC-4666)

[AC-4666]: https://warthogs.atlassian.net/browse/AC-4666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ