### PR TITLE
Document Virtualized Android/Cuttlefish

### DIFF
--- a/explanation/aaos.md
+++ b/explanation/aaos.md
@@ -7,7 +7,7 @@ myst:
 (exp-aaos)=
 # Android Automotive OS(AAOS)
 
-Since the 1.21.0 release, in addition to providing images based on the Android Open Source Project (AOSP), Anbox Cloud also offers images based on the [Android Automotive OS (AAOS)](https://source.android.com/docs/automotive/start/what_automotive). These images help run Android in automotive infotainment systems at scale.
+Anbox Cloud offers images based on the [Android Automotive OS (AAOS)](https://source.android.com/docs/automotive/start/what_automotive). These images help run Android in automotive infotainment systems at scale.
 
 ```{important}
 - The Anbox Cloud AAOS images are based on Android Automotive and *not* Android Auto. For understanding the differences between the two, see upstream documentation on [Android Automotive and Android Auto](https://source.android.com/docs/automotive/start/what_automotive#android-automotive-android-auto).
@@ -19,7 +19,9 @@ Until the 1.24.0 release, if you created your own VHAL implementation by followi
 
 However, if a third-party VHAL implementation is loaded during Android runtime, on the Anbox Cloud Dashboard, some vehicle property values may still not be accessible while others may not be editable on the Anbox Cloud dashboard, due to [permission controls](https://source.android.com/docs/automotive/vhal/property-configuration) that categorize vehicle properties as read-only, write-only, or read-write.
 
-Anbox Cloud offers an [Anbox-specific VHAL HIDL interface](https://github.com/canonical/vendor_canonical_interfaces). By using this HIDL, the VHAL implementation allows the Anbox VHAL adapter to modify non-writable and access non-readable vehicle property values without encountering permission issues. See the {ref}`how-to guide <howto-integrate-hidl>` on instructions for setting this up with your VHAL implementation.
+Anbox Cloud offers an [Anbox-specific VHAL HIDL interface](https://github.com/canonical/vendor_canonical_interfaces) for containerized images. By using this HIDL, the VHAL implementation allows the Anbox VHAL adapter to modify non-writable and access non-readable vehicle property values without encountering permission issues. See the {ref}`how-to guide <howto-integrate-hidl>` on instructions for setting this up with your VHAL implementation.
+
+Since the 1.30.0 release, AAOS 16 is available through images with virtualized Android (`resolute:aaos16-cf:amd64` and `resolute:aaos16-cf:arm64`). These images provide native gRPC support for the vehicle HAL. See {ref}`exp-android-execution-environments` for details on the virtualized Android execution environment.
 
 ## Related topics
 

--- a/explanation/anbox-cloud.md
+++ b/explanation/anbox-cloud.md
@@ -42,7 +42,7 @@ See the following table for a comparison of features for the different variants:
 |---------|-----------------------|-------------|
 | {ref}`exp-application-streaming` | ✓ | ✓ |
 | {ref}`exp-web-dashboard` | ✓ | ✓ |
-| {ref}`Android versions <ref-provided-images>` | 14, 15 | 14, 15 |
+| {ref}`Android versions <ref-provided-images>` | 14, 15, 16 | 14, 15, 16 |
 | [Security updates](https://ubuntu.com/support) | ✓ | ✓ |
 | [Community support](https://discourse.ubuntu.com/c/project/anbox-user/148) | ✓ | ✓ |
 | [Vendor support available](https://ubuntu.com/support) | ✓* | ✓ |
@@ -52,6 +52,10 @@ See the following table for a comparison of features for the different variants:
 *\* When purchasing the Anbox Cloud Appliance through the AWS Marketplace, the Ubuntu Pro subscription does not include vendor support.*
 
 We recommend starting with the Anbox Cloud Appliance. You can choose to expand to a charmed Anbox Cloud installation later.
+
+## Android execution environments
+
+Anbox Cloud supports two ways of running Android: containerized Android, where the Android system runs directly in the LXD container, and virtualized Android, where Android runs inside a virtual machine within the LXD instance. The execution environment is determined by the image that an instance is based on. See {ref}`exp-android-execution-environments` for details on the two environments and {ref}`ref-feature-support-by-image-type` for a comparison of their supported features.
 
 ## Anbox Cloud Components
 

--- a/explanation/android-execution-models.md
+++ b/explanation/android-execution-models.md
@@ -1,0 +1,49 @@
+(exp-android-execution-environments)=
+# Android execution environments
+
+Anbox Cloud supports two ways of running Android inside an instance: **containerized Android** and **virtualized Android**. The execution environment is determined by the image that an instance is based on - you choose an image when creating an instance, and the image determines how Android runs.
+
+Both execution environments provide access to Android through the same streaming infrastructure and can coexist in the same Anbox Cloud deployment.
+
+## Containerized Android
+
+With containerized Android, the Android system runs directly inside the LXD container. This is the execution environment used by `jammy:*` images (for example, `jammy:android14:amd64`).
+
+Containerized Android supports the full set of Anbox Cloud features:
+
+- {ref}`Applications <exp-applications>` and the application lifecycle (bootstrap, updates, versions)
+- {ref}`Addons <exp-addons>` for image customisation
+- {ref}`Platform plugins <exp-platforms>` for custom rendering and input pipelines
+- Shell access to the Android environment through `anbox-shell`
+
+This is the execution environment that Anbox Cloud has used since its first release. The Android system shares the kernel with the host through LXD's container isolation, which keeps resource overhead low and allows high instance density.
+
+## Virtualized Android
+
+With virtualized Android, the Android system runs inside a [Cuttlefish](https://source.android.com/docs/devices/cuttlefish) virtual machine within the LXD instance. This is the execution environment used by `resolute:*-cf:*` images (for example, `resolute:android16-cf:amd64`). The `-cf` suffix in the image name indicates that the image uses the Cuttlefish virtual device.
+
+Cuttlefish is Google's reference virtual Android device. Running Android through Cuttlefish means you get a standard, unmodified Android environment with no Anbox-specific changes to the Android system itself — the Android system image comes directly from Google's build infrastructure. This is the right choice when you need Android to behave exactly as it does on a physical device or in Google's own test environments.
+
+Virtualized Android supports {ref}`instances <sec-application-raw-instances>`. To access the Android shell, use `adb shell` instead of `anbox-shell`. See {ref}`ref-feature-support-by-image-type` for the full feature comparison.
+
+Virtualized Android is a good fit for the following scenarios:
+
+- **Standard Android environments** where you need Android to behave exactly as it does on a real device, without any Anbox-specific modifications to the Android system.
+- **Custom Android or AAOS builds** where you want to run your own Android system image inside Anbox Cloud. See {ref}`howto-package-custom-android-build` for instructions.
+- **VHAL development** where native gRPC support for the vehicle HAL simplifies automotive development.
+- **Workloads that benefit from stronger isolation** where the additional virtualisation boundary between Android and the host is desirable.
+
+## Choosing between the two environments
+
+Use **virtualized Android** when you need a standard Android environment that behaves exactly like a physical device or Google's reference implementation, when you want to run a custom Android or AAOS build, or when you need native VHAL support for automotive use cases.
+
+Use **containerized Android** when you are building on top of Anbox Cloud's application and addon model for managed APK deployment, or when you need platform plugins for custom rendering and input pipelines.
+
+Both image types can coexist in the same AMS deployment. You can register and use images of both types simultaneously and launch instances from either type as needed.
+
+## Related topics
+
+- {ref}`ref-feature-support-by-image-type`
+- {ref}`tut-getting-started-virtualized-android`
+- {ref}`howto-package-custom-android-build`
+- {ref}`ref-provided-images`

--- a/explanation/custom-images.md
+++ b/explanation/custom-images.md
@@ -12,7 +12,9 @@ Android Automotive OS(AAOS) includes reference designs that can be customized. C
 To enable such use cases, we support customized AAOS images integration with Anbox Cloud. Hence, building custom images of Anbox Cloud based on custom AAOS is possible.
 
 ```{note}
-Building custom images is currently possible only for Android 14 and AAOS images.
+Building custom images is currently possible only for Android 14 and AAOS images (using images with containerized Android).
+
+For images with virtualized Android, you can package a custom Android build as a snap and install it in a running instance. See {ref}`howto-package-custom-android-build` for instructions.
 ```
 
 By default, Anbox Cloud is regularly updated with security updates provided by the Android team to keep systems secure for consumers of generic AAOS images. Anbox Cloud users using a custom AAOS image are expected to maintain their systems secure by integrating these security updates, along with the updated version of Anbox Cloud. This might require manual deployment steps.

--- a/explanation/images.md
+++ b/explanation/images.md
@@ -18,6 +18,7 @@ The following table lists the different statuses that an image can have dependin
 | `initializing` | The image is currently being created. |
 | `created` | The image was uploaded to AMS but not yet available on all LXD nodes. |
 | `available` | The image is present on the remote but not in the LXD cluster. |
+| `queued` | The image operation is queued for a download. |
 | `active` | The image is available on all LXD nodes. |
 | `deleted` | The image has been deleted and no longer available for use. |
 | `error` | The image has encountered an error. |

--- a/explanation/images.md
+++ b/explanation/images.md
@@ -25,3 +25,12 @@ The following table lists the different statuses that an image can have dependin
 | `unknown` | A possible error occurred and the real state of the image cannot be determined. |
 
 If you encounter the `error` or the `unknown` status, [file a bug](https://bugs.launchpad.net/anbox-cloud).
+
+## Image variants
+
+Anbox Cloud provides two variants of images that use different Android execution environments:
+
+- **Images with containerized Android** (`jammy:*`) run Android directly in the LXD container and support the full application model, addons, and platform plugins.
+- **Images with virtualized Android** (`resolute:*-cf:*`) run Android inside a virtual machine within the LXD instance.
+
+The image variant determines which execution environment is used. See {ref}`exp-android-execution-environments` for an explanation of the two environments and {ref}`ref-feature-support-by-image-type` for a detailed feature comparison.

--- a/explanation/index.md
+++ b/explanation/index.md
@@ -32,6 +32,7 @@ Understand the different objects used in the product stack and how to use them t
 - {ref}`AAOS <exp-aaos>`
 - {ref}`exp-platforms`
 - {ref}`exp-clustering`
+- {ref}`exp-android-execution-environments`
 
 ## Authentication and authorization
 
@@ -63,6 +64,7 @@ Also check out the {ref}`tutorials` for step-by-step instructions that help you 
 
 addons
 aar
+android-execution-environments
 anbox-cloud
 web-dashboard
 ams

--- a/explanation/instances.md
+++ b/explanation/instances.md
@@ -31,6 +31,8 @@ Application instances are containers or virtual machines created when launching 
 
 Raw instances are containers or virtual machines created when launching an image. They run the full Android system, without any additional apps installed.
 
+Instances can be based on images with containerized Android or images with virtualized Android. The image determines the {ref}`Android execution environment <exp-android-execution-environments>` used by the instance.
+
 ## Life cycle of an instance
 
 ### Creating an instance

--- a/explanation/security/anbox-runtime.md
+++ b/explanation/security/anbox-runtime.md
@@ -31,8 +31,18 @@ For streaming of audio, video and other data, the Anbox runtime uses WebRTC as p
 
 The security model and cryptographic use of WebRTC is described in [RFC8827](https://www.rfc-editor.org/rfc/rfc8827) and use of WebRTC in the Anbox runtime does not deviate from this.
 
-## Packages used
+## Packages used for containerized Android
 
 - [Go standard library](https://pkg.go.dev/std)
 - [OpenSSL](https://launchpad.net/ubuntu/+source/openssl/)
 - [`ca-certificates`](https://launchpad.net/ubuntu/+source/ca-certificates)
+
+## Virtualized Android
+
+The runtime for virtualized Android is written in Rust and runs within snap confinement. Its security model adds the following properties on top of the general security measures described above:
+
+* **Rust memory safety** - the Rust ownership model eliminates common memory safety vulnerabilities (buffer overflows, use-after-free, data races) at compile time.
+* **Snap confinement** - the runtime runs as a snap with strict confinement, limiting its access to the host system.
+* **QEMU isolation** - Android runs inside a virtual machine, providing an additional isolation boundary between the Android workload and the host.
+
+See {ref}`exp-android-execution-environments` for more details on the two execution environments.

--- a/howto/addons/index.md
+++ b/howto/addons/index.md
@@ -7,6 +7,8 @@ myst:
 (howto-addons)=
 # Addons
 
+The guides in this section apply to images with containerized Android (`jammy:*`). Addons are not supported for images with virtualized Android. See {ref}`exp-android-execution-environments` for details.
+
 In Anbox Cloud, addons can be used to customize images that are used for instances. See {ref}`exp-addons` and {ref}`ref-addon-manifest` to learn about addons in detail.
 
 You can use addons to, for example:

--- a/howto/anbox-runtime/index.md
+++ b/howto/anbox-runtime/index.md
@@ -7,7 +7,9 @@ myst:
 (howto-anbox-runtime)=
 # Work with the Anbox runtime
 
-The guides in this section describe how to work with the Anbox runtime, which is responsible for running the Android container, providing access to any hardware and integrating with streaming protocols.
+The guides in this section describe how to work with the Anbox runtime, which is responsible for running the Android container, providing access to any hardware and integrating with streaming protocols. They apply to images with containerized Android (`jammy:*`).
+
+For images with virtualized Android (`resolute:*-cf:*`), see {ref}`tut-getting-started-virtualized-android` and {ref}`howto-package-custom-android-build`. For a comparison of the two execution environments, see {ref}`exp-android-execution-environments`.
 
 The following guides are available:
 

--- a/howto/application/index.md
+++ b/howto/application/index.md
@@ -7,6 +7,8 @@ myst:
 (howto-manage-applications)=
 # Manage applications
 
+The guides in this section apply to images with containerized Android (`jammy:*`). The application model is not supported for images with virtualized Android. See {ref}`exp-android-execution-environments` for details.
+
 The guides in this section describe how to manage your applications.
 
 See {ref}`exp-applications` for an introduction to how applications are used in Anbox Cloud. To check which configuration options are available for applications, see {ref}`ref-application-manifest`.

--- a/howto/images/index.md
+++ b/howto/images/index.md
@@ -20,4 +20,5 @@ add-image
 publish-instance-as-image
 delete-image
 use-specific-release
+package-custom-android-build
 ```

--- a/howto/images/package-custom-android-build.md
+++ b/howto/images/package-custom-android-build.md
@@ -1,0 +1,160 @@
+---
+myst:
+  html_meta:
+    "description": "How to package a custom Android Cuttlefish build."
+---
+
+(howto-package-custom-android-build)=
+# Package a custom Android build
+
+You can package a custom [Cuttlefish](https://source.android.com/docs/devices/cuttlefish) Android build as a [snap](https://snapcraft.io/) and install it in a running virtualized Android instance. This lets you run your own Android system image while using the Anbox Cloud infrastructure for streaming and instance management.
+
+For background on how virtualized Android works in Anbox Cloud, see {ref}`exp-android-execution-environments`.
+
+## Prerequisites
+
+- An Anbox Cloud deployment with a virtualized Android image available (see {ref}`tut-getting-started-virtualized-android`)
+- Android Cuttlefish build artifacts from your own build:
+  * `cvd-host_package.tar.gz` - Cuttlefish host tools from the Android build
+  * Android images (such as `super.img`, `boot.img`, `vbmeta.img`, and other system images produced by the build)
+- The `snap` command-line tool installed on your build machine
+
+## Prepare the snap directory structure
+
+Create the directory structure for the snap:
+
+```bash
+mkdir -p my-android-snap/host-tools
+mkdir -p my-android-snap/images
+mkdir -p my-android-snap/meta
+```
+
+Extract the Cuttlefish host tools:
+
+    tar xf cvd-host_package.tar.gz -C my-android-snap/host-tools/
+
+Copy the Android system images:
+
+    cp super.img boot.img vbmeta.img vendor_boot.img android-info.txt \
+        my-android-snap/images/
+
+Include all image files that your Cuttlefish build produced and that are required to launch a virtual device.
+
+## Create the snap metadata
+
+Create the file `my-android-snap/meta/snap.yaml`:
+
+```yaml
+name: my-custom-android
+version: '1.0'
+summary: Custom Android Cuttlefish images and host tools
+description: |
+  Provides custom Android system images and Cuttlefish host tools
+  for use with the Anbox Cloud runtime.
+type: app
+base: bare
+architectures:
+  - amd64
+confinement: strict
+grade: stable
+slots:
+  host-tools:
+    interface: content
+    content: android-host-tools
+    read:
+      - $SNAP/host-tools
+  images:
+    interface: content
+    content: android-images
+    read:
+      - $SNAP/images
+```
+
+The snap defines two content interface slots that provide the Cuttlefish host tools and Android system images to the Anbox runtime snap. If you are targeting ARM64, change the `architectures` field to `arm64`.
+
+## Pack the snap
+
+Use `snap pack` to create the snap:
+
+    snap pack my-android-snap/
+
+This produces a file like `my-custom-android_1.0_amd64.snap` in the current directory.
+
+## Launch an instance and install the snap
+
+Launch a virtualized Android instance in development mode so that you can push files to it:
+
+    id="$(amc launch --devmode resolute:android16-cf:amd64)"
+
+Or, for an automotive Android build:
+
+    id="$(amc launch --devmode resolute:aaos16-cf:amd64)"
+
+Wait for the instance to reach the `running` state:
+
+    amc wait "${id}" --timeout 15m
+
+See {ref}`sec-dev-mode` for more information about development mode.
+
+Push the snap into the instance:
+
+    cat my-custom-android_1.0_amd64.snap \
+      | amc exec "${id}" -- sh -c "cat - > /tmp/my-custom-android_1.0_amd64.snap"
+
+Install the snap inside the instance:
+
+    amc exec "${id}" -- snap install --dangerous /tmp/my-custom-android_1.0_amd64.snap
+
+The `--dangerous` flag is required because the snap is not signed by the Snap Store.
+
+## Connect snap interfaces and restart the runtime
+
+Disconnect the existing Android snap from the runtime:
+
+    amc exec "${id}" -- snap disconnect anbox-runtime:android-images
+    amc exec "${id}" -- snap disconnect anbox-runtime:android-host-tools
+
+Connect your custom Android snap to the runtime:
+
+    amc exec "${id}" -- snap connect anbox-runtime:android-images my-custom-android:images
+    amc exec "${id}" -- snap connect anbox-runtime:android-host-tools my-custom-android:host-tools
+
+Restart the runtime to load the new Android images:
+
+    amc exec "${id}" -- snap restart anbox-runtime
+
+## Verify
+
+Connect to the instance and verify that your custom Android build is running:
+
+    amc exec "${id}" -- adb shell getprop ro.build.display.id
+
+The output should show the build ID of your custom Android build.
+
+## Troubleshooting
+
+### Snap content interface connection fails
+
+If `snap connect` fails, verify that the content interface names in your snap match what the runtime expects:
+- The `content` field for host tools must be `android-host-tools`
+- The `content` field for images must be `android-images`
+
+Use `snap connections anbox-runtime` inside the instance to inspect the expected interfaces.
+
+### Runtime fails to start after connecting custom snap
+
+Check the runtime logs:
+
+    amc exec "${id}" -- snap logs anbox-runtime -n 100
+
+Common issues include missing image files or incompatible Cuttlefish host tool versions.
+
+### Snap installation fails
+
+Verify that the snap was built for the correct architecture and that the directory structure is correct. The snap must contain `host-tools/` and `images/` directories at its root.
+
+## Related topics
+
+- {ref}`exp-android-execution-environments`
+- {ref}`tut-getting-started-virtualized-android`
+- {ref}`ref-feature-support-by-image-type`

--- a/howto/instance/access-instance.md
+++ b/howto/instance/access-instance.md
@@ -16,7 +16,13 @@ The `amc` command provides simple shell access to any instance managed by AMS. T
 
     amc shell <id>
 
-This command opens a bash shell inside the instance. To access the nested Android container, use the `anbox-shell` command inside the new shell. If you combined the `anbox-shell` command with `amc exec`, you can get direct access to the Android container:
+This command opens a bash shell inside the instance.
+
+## Access the Android environment
+
+### Containerized Android
+
+Use anbox-shell to access the Android container. If you combine the anbox-shell command with amc exec, you can get direct access to the Android container:
 
     amc exec <id> -- anbox-shell
 
@@ -25,3 +31,9 @@ If you only want to watch the Android log output, use the following command:
     amc exec <id> -- anbox-shell logcat
 
 `amc shell` and `amc exec` open various possibilities for automation use cases. See the help output of the commands for further details.
+
+### Virtualized Android
+
+Use ADB instead of anbox-shell:
+
+    adb exec <id> -- adb shell

--- a/reference/anbox-features.md
+++ b/reference/anbox-features.md
@@ -11,6 +11,8 @@ Anbox Cloud provides images based on the Android Open Source Project (AOSP), an 
 
 The following table lists some Anbox features and whether they are supported for a given base.
 
+The following feature table applies only to images with containerized Android. For a comparison of feature support between containerized and virtualized Android, see {ref}`ref-feature-support-by-image-type`.
+
 |Feature   | AOSP | AAOS |
 |--------|------|------|
 | boot-package and boot-activity in {ref}`ref-application-manifest` | ✓    |  -   |

--- a/reference/feature-support-by-image-type.md
+++ b/reference/feature-support-by-image-type.md
@@ -1,0 +1,65 @@
+(ref-feature-support-by-image-type)=
+# Image types reference
+
+Anbox Cloud provides two types of images, each using a different {ref}`Android execution environment <exp-android-execution-environments>`. This page describes the capabilities, naming, and requirements for each type.
+
+## Image naming
+
+| Pattern | Execution environment | Example |
+|---------|----------------|---------|
+| `jammy:*` | Containerized Android | `jammy:android14:amd64` |
+| `resolute:*-cf:*` | Virtualized Android | `resolute:android16-cf:amd64` |
+
+The `-cf` suffix identifies a Cuttlefish-based image using virtualized Android.
+
+See {ref}`ref-provided-images` for the full list of available images.
+
+## Images with containerized Android
+
+The Android system runs directly in the LXD container. These images support:
+
+- {ref}`Applications <exp-applications>` — managed APK deployment with versioning, bootstrapping, and the full application lifecycle
+- {ref}`Addons <exp-addons>` — customising images with hooks tied to instance lifecycle events
+- {ref}`Platform plugins <exp-platforms>` — custom rendering and input pipelines via the Anbox Platform SDK
+- Streaming
+- Custom Android builds (see {ref}`exp-custom-images`)
+- Shell access via `anbox-shell`
+- VHAL support via adapter
+
+**Minimum resource requirements:**
+- 2 CPU cores per instance.
+- 3GB memory per instance.
+- 3GB disk space per instance.
+- KVM not required.
+
+## Images with virtualized Android
+
+The Android system runs inside a Cuttlefish virtual machine within the LXD instance, providing a standard, unmodified Android environment. These images support:
+
+- Streaming
+- Custom Android or AAOS builds (see {ref}`howto-package-custom-android-build`)
+- Shell access via `adb shell`
+- VHAL support with native gRPC
+- QEMU-based isolation between Android and the host
+
+**Minimum resource requirements:**
+- 4 CPU cores per instance.
+- 5GB memory per instance.
+- 15GB disk space per instance.
+- KVM required on the host.
+
+## Shell access
+
+For containerized Android:
+
+    amc exec <instance_id> -- anbox-shell
+
+For virtualized Android:
+
+    amc exec <instance_id> -- adb shell
+
+## Related topics
+
+* {ref}`exp-android-execution-environments`
+* {ref}`ref-provided-images`
+* {ref}`ref-requirements`

--- a/reference/glossary.md
+++ b/reference/glossary.md
@@ -130,6 +130,9 @@ Bootstrap process
 
     See {ref}`sec-application-bootstrap` for more information.
 
+Containerized Android
+    An {ref}`Android execution environment <exp-android-execution-environments>` where the Android system runs directly inside the LXD container. Used by `jammy:*` images. Supports the full application model, addons, and platform plugins.
+
 Control node
     The machine on which the components that make up the management layer, AMS, AMC, and etcd, are installed.
 
@@ -272,6 +275,9 @@ Ubuntu One
     A central user account system used by all Canonical sites and services. You need an Ubuntu One account to purchase the Ubuntu Pro subscription that is required to run Anbox Cloud, and to log in to the web dashboard.
 
     See [Ubuntu One](https://login.ubuntu.com/) for more information.
+
+Virtualized Android
+    An {ref}`Android execution environment <exp-android-execution-environments>` where the Android system runs inside a Cuttlefish virtual machine within the LXD instance. Used by `resolute:*-cf:*` images.
 
 Watchdog
     A software component that monitors the app in an instance and terminates the instance if the app crashes or is moved to the background.

--- a/reference/index.md
+++ b/reference/index.md
@@ -23,6 +23,7 @@ Understand the difference aspects of using Anbox Cloud such as requirements, sup
 
 - {ref}`ref-requirements`
 - {ref}`Anbox Cloud images <ref-provided-images>`
+- {ref}`ref-feature-support-by-image-type`
 - {ref}`ref-rendering-resources`
 - {ref}`ref-codecs`
 - {ref}`ref-android-features`
@@ -97,6 +98,7 @@ addon-manifest
 ams-configuration
 ams-instance-configuration
 Anbox Cloud images <provided-images>
+feature-support-by-image-type
 appliance-preseed
 appliance-configuration
 auth

--- a/reference/provided-images.md
+++ b/reference/provided-images.md
@@ -15,19 +15,25 @@ Anbox Cloud images are regular [Ubuntu cloud images](https://cloud-images.ubuntu
 
 The following table lists supported images available on the official image server, along with their corresponding image type, Android and Ubuntu versions.
 
-| Name                        | Based on | Android Version | Ubuntu Version | Available since |
-|-----------------------------|----------|-----------------|----------------|---------------|
-| `jammy:aaos15:amd64`        | AAOS     | 15              | 22.04          | 1.26.0 |
-| `jammy:aaos15:arm64`        | AAOS     | 15              | 22.04          | 1.26.0 |
-| `jammy:android15:amd64`     | AOSP     | 15              | 22.04          | 1.26.0 |
-| `jammy:android15:arm64`     | AOSP     | 15              | 22.04          | 1.26.0 |
-| `jammy:aaos14:amd64`        | AAOS     | 14              | 22.04          | 1.24.0 |
-| `jammy:aaos14:arm64`        | AAOS     | 14              | 22.04          | 1.24.0 |
-| `jammy:android14:amd64`     | AOSP     | 14              | 22.04          | 1.24.0 |
-| `jammy:android14:arm64`     | AOSP     | 14              | 22.04          | 1.24.0 |
+| Name                        | Based on | Android Version | Ubuntu Version | Execution environment | Available since |
+|-----------------------------|----------|-----------------|----------------|-----------------|---------------|
+| `resolute:android16-cf:amd64` | AOSP  | 16              | 26.04          | Virtualized | 1.30.0 |
+| `resolute:android16-cf:arm64` | AOSP  | 16              | 26.04          | Virtualized | 1.30.0 |
+| `resolute:aaos16-cf:amd64`    | AAOS  | 16              | 26.04          | Virtualized | 1.30.0 |
+| `resolute:aaos16-cf:arm64`    | AAOS  | 16              | 26.04          | Virtualized | 1.30.0 |
+| `jammy:aaos15:amd64`        | AAOS     | 15              | 22.04          | Containerized | 1.26.0 |
+| `jammy:aaos15:arm64`        | AAOS     | 15              | 22.04          | Containerized | 1.26.0 |
+| `jammy:android15:amd64`     | AOSP     | 15              | 22.04          | Containerized | 1.26.0 |
+| `jammy:android15:arm64`     | AOSP     | 15              | 22.04          | Containerized | 1.26.0 |
+| `jammy:aaos14:amd64`        | AAOS     | 14              | 22.04          | Containerized | 1.24.0 |
+| `jammy:aaos14:arm64`        | AAOS     | 14              | 22.04          | Containerized | 1.24.0 |
+| `jammy:android14:amd64`     | AOSP     | 14              | 22.04          | Containerized | 1.24.0 |
+| `jammy:android14:arm64`     | AOSP     | 14              | 22.04          | Containerized | 1.24.0 |
 
 ## Support for Anbox Cloud images
 
-Currently, Anbox Cloud provides images based on Ubuntu 22.04 LTS (Jammy Jellyfish). Deprecations, if any, are announced at least two releases in advance.
+Currently, Anbox Cloud provides images based on Ubuntu 22.04 LTS (Jammy Jellyfish) and Ubuntu 26.04 LTS (Resolute Raccoon). Deprecations, if any, are announced at least two releases in advance.
+
+Images with containerized Android (`jammy:*`) and images with virtualized Android (`resolute:*-cf:*`) differ in their supported features. See {ref}`ref-feature-support-by-image-type` for a detailed comparison and {ref}`exp-android-execution-environments` for an explanation of the two execution environments.
 
 Android versions are supported as long as Google provides security updates for the respective versions.

--- a/reference/requirements.md
+++ b/reference/requirements.md
@@ -57,6 +57,8 @@ The following hardware specifications are required for running the appliance:
 
 The above recommendation is the minimum requirement to run the appliance. As Anbox Cloud is dependent on available resources to launch its Android containers, the available resources dictate the maximum number of possible Android containers. See {ref}`exp-capacity-planning` for an explanation on how to plan for a specific capacity on your appliance.
 
+Images with virtualized Android have additional requirements: the host CPU must support hardware virtualisation and `/dev/kvm` must be available. Each instance requires a minimum of 4 CPUs, 5GB of memory, and 15GB of disk space. See {ref}`ref-feature-support-by-image-type` for details.
+
 On public clouds, it is always recommended to allocate an additional storage volume for instance storage. If no additional storage volume is available, the appliance creates an on-disk image and uses it for instance storage. This is sufficient for very simple cases but does not provide optimal performance and will slow down operations and instance startup time.
 
 For external access, you must expose a couple of network ports on the machine where the appliance is running. See {ref}`ref-network-ports` for the list of ports that must be exposed. How to allow incoming traffic on the listed ports differs depending on the cloud used. See the documentation of the cloud for further information on how to change the firewall.

--- a/tutorial/getting-started-with-virtualized-android.md
+++ b/tutorial/getting-started-with-virtualized-android.md
@@ -1,0 +1,51 @@
+---
+myst:
+  html_meta:
+    "description": "Learn how to start a virtualized Android instance."
+---
+
+(tut-getting-started-virtualized-android)=
+# Get started with virtualized Android
+
+In this tutorial, we will go through launching our first instance with virtualized Android and connecting to it. At the end, we will have a running Android instance that we can interact with through ADB.
+
+## Prerequisites
+
+To proceed with the tutorial, we need:
+- A working Anbox Cloud deployment (appliance or charmed). If you haven't set one up yet, see {ref}`tut-installing-appliance`. It needs at least:
+  * 4 CPU cores
+  * 5GB of memory
+  * 15 GB of disk space
+- KVM support on the machine running Anbox Cloud. Verify by checking that `/dev/kvm` exists:
+
+    ls /dev/kvm
+
+## Launch an instance
+
+Launch an instance from the image:
+
+    amc launch resolute:android16-cf:amd64 --name test0
+
+Note the instance ID in the output. Wait for the instance to reach the `running` state:
+
+    amc wait test0 --timeout 15m
+
+## Connect to the instance
+
+Open a shell inside the `test0` instance by running
+
+    amc shell test0
+
+Connect to the Android shell through ADB
+
+    adb shell
+
+## Success
+
+We have successfully launched a virtualized Android instance with ADB shell access.
+
+## Next steps
+
+- Read {ref}`exp-android-execution-environments` to understand how virtualized Android differs from containerized Android.
+- See {ref}`howto-package-custom-android-build` to learn how to run your own Android build in Anbox Cloud.
+- Consult {ref}`ref-feature-support-by-image-type` for a full comparison of supported features.

--- a/tutorial/index.md
+++ b/tutorial/index.md
@@ -7,12 +7,24 @@ myst:
 (tutorials)=
 # Tutorials
 
-The tutorials we offer guiding you through installing the {term}`Anbox Cloud Appliance` and creating your first virtual Android device.
-We also offer an optional tutorial to set up your custom stream client.
+The tutorials in this section guide you through the workflows of {term}`Anbox Cloud Appliance`, from installation to running and streaming Android instances.
+
+The following tutorials use images with containerized Android.
+
+- {ref}`tut-installing-appliance`
+- {ref}`tut-create-virtual-device`
+- {ref}`tut-set-up-stream-client`
+
+The following tutorial uses images with virtualized Android.
+
+- {ref}`tut-getting-started-virtualized-android`
+
+For an explanation of the two execution environments, see {ref}`exp-android-execution-environments`.
 
 ```{toctree}
 :maxdepth: 1
 installing-appliance
 create-test-virtual-device
 stream-client
+getting-started-with-virtualized-android
 ```


### PR DESCRIPTION
# Documentation changes

Document Virtualized Android/Cuttlefish for Anbox 1.30.0, and add a missing state.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,

- [ ] Run `make spelling` and fix any spelling issues.
- [ ] Run `make linkcheck` and fix any broken links.
- [ ] Run `make lint-md` and fix any linting issues.
- [ ] Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]
