### PR TITLE
Update release process and roadmap

### DIFF
--- a/reference/release-notes/1.26.2.md
+++ b/reference/release-notes/1.26.2.md
@@ -34,7 +34,7 @@ This release includes fixes from the respective upstreams and components for the
 The following bug fixes are available as part of this release:
 
 - [LP 2115297](https://bugs.launchpad.net/anbox-cloud/+bug/2115297) After upgrading to version 1.26.0 or later, streaming a session did not work for deployments with an NVIDIA GPU.
-- [LP 2114967](https://bugs.launchpad.net/anbox-cloud/+bug/2114967) With multiple Android users, setting {ref}`\`enable_virtual_keyboard\` <sec-virtual-keyboard>` or {ref}`\`enable_anbox_ime\` <sec-client-side-virtual-keyboard>` feature flags fails. When set, the feature will be enabled, but starting Anbox results in a timeout the values are not set for the correct user.
+- [LP 2114967](https://bugs.launchpad.net/anbox-cloud/+bug/2114967) With multiple Android users, setting {ref}`enable_virtual_keyboard <sec-virtual-keyboard>` or {ref}`enable_anbox_ime <sec-client-side-virtual-keyboard>` feature flags fails. When set, the feature will be enabled, but starting Anbox results in a timeout the values are not set for the correct user.
 - [LP 2114227](https://bugs.launchpad.net/anbox-cloud/+bug/2114227) When deploying with Terraform, when the Anbox kernel modules package is installed, an Ubuntu Pro token is required. However, attaching an Ubuntu Pro token is no longer mandatory to complete the deployment.
 - [LP 2115938](https://bugs.launchpad.net/anbox-cloud/+bug/2115938) When joining an existing session, if the resolution has width or height as an odd number, the session is aborted and the Anbox instance end up with an error status.
 This issue occurs only when the [join API](/reference/api-reference/gateway-api.md#/session/handle-join-session) is used with a resolution that has width or height as an odd number.

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -21,7 +21,7 @@ For instructions on how to update your Anbox Cloud deployment to later versions,
 
 ## Upcoming release roadmap
 
-The current supported release is **1.30.0**. The next minor release will be **1.31.0**, expected in November 2026.
+The current supported minor release is **1.30.0**. The next one will be **1.31.0**, expected in November 2026.
 
 Target dates for upcoming releases are not final and could vary depending on various factors such as availability of Android security patches.
 

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -37,7 +37,7 @@ Minor releases
 : Anbox Cloud delivers three minor releases per year, in March, June, and November. Minor releases include new features, bug fixes and security updates.
 
 Patch releases
-: Patch releases deliver Android and Chrome security updates alongside Anbox Cloud specific bug fixes between minor releases. No new features are introduced in patch releases.
+: Patch releases are delivered between minor releases and include Android and Chrome security updates alongside Anbox Cloud specific bug fixes. No new features are introduced in patch releases.
 
 Anbox Cloud supports only the most recent release. Older releases are only supported for a short time after a new minor release is published.
 

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -23,23 +23,21 @@ For instructions on how to update your Anbox Cloud deployment to later versions,
 
 The current supported release is **1.30.0**. The next minor release will be **1.31.0**, expected in November 2026.
 
-The following target dates for upcoming releases are not final and could vary depending on various factors such as availability of Android security patches. The release notes link will be updated on the day of the release.
+Target dates for upcoming releases are not final and could vary depending on various factors such as availability of Android security patches.
 
 | Target date | Version | Planned updates |
 |----|----|----|
 | November 25, 2026 | Anbox Cloud 1.31.0 | *New features*<br/>*Android security updates*<br/>Bug fixes |
 
-Patch releases addressing security vulnerabilities and critical bug fixes are published between minor releases as needed.
-
 ## Release and support policy
 
-Anbox Cloud follows a defined release cycle with planned minor releases and patch releases as needed.
+Anbox Cloud follows a defined release cycle with minor and patch releases.
 
 Minor releases
 : Anbox Cloud delivers three minor releases per year, in March, June, and November. Minor releases include new features, bug fixes and security updates.
 
 Patch releases
-: Patch releases are published between minor releases to address Android and Chrome security updates alongside Anbox Cloud specific bug fixes. No new features are introduced in patch releases.
+: Patch releases deliver Android and Chrome security updates alongside Anbox Cloud specific bug fixes between minor releases. No new features are introduced in patch releases.
 
 Anbox Cloud supports only the most recent release. Older releases are only supported for a short time after a new minor release is published.
 

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -21,31 +21,31 @@ For instructions on how to update your Anbox Cloud deployment to later versions,
 
 ## Upcoming release roadmap
 
-The current, supported minor release is **1.30.0** and the next one will be **1.31.0** expected in September 2026.
+The current supported release is **1.30.0**. The next minor release will be **1.31.0**, expected in November 2026.
 
 The following target dates for upcoming releases are not final and could vary depending on various factors such as availability of Android security patches. The release notes link will be updated on the day of the release.
 
 | Target date | Version | Planned updates |
 |----|----|----|
-| July 15, 2026 | Anbox Cloud 1.30.1 | *Android security updates*<br/>Bug fixes |
-| August 19, 2026 | Anbox Cloud 1.30.2 | *Android security updates*<br/>Bug fixes |
-| September 16, 2026 | Anbox Cloud 1.31.0 | *New features*<br/>*Android security updates*<br/>Bug fixes |
+| November 25, 2026 | Anbox Cloud 1.31.0 | *New features*<br/>*Android security updates*<br/>Bug fixes |
+
+Patch releases addressing security vulnerabilities and critical bug fixes are published between minor releases as needed.
 
 ## Release and support policy
 
-Anbox Cloud follows a defined release cycle with frequent minor and patch releases.
+Anbox Cloud follows a defined release cycle with planned minor releases and patch releases as needed.
 
 Minor releases
-: A new minor release of Anbox Cloud is released every three months. It includes new features and bug fixes.
+: Anbox Cloud delivers three minor releases per year, in March, June, and November. Minor releases include new features, bug fixes and security updates.
 
 Patch releases
-: A patch release for Anbox Cloud is released every month and includes Android and Chrome security updates alongside Anbox Cloud specific bug fixes.
+: Patch releases are published between minor releases to address Android and Chrome security updates alongside Anbox Cloud specific bug fixes. No new features are introduced in patch releases.
 
-Anbox Cloud supports only the most recent release. Older releases are only supported for a short time after a new minor release was published.
+Anbox Cloud supports only the most recent release. Older releases are only supported for a short time after a new minor release is published.
 
 Feature deprecations are generally announced two releases in advance before the deprecated features are dropped. See {ref}`ref-deprecation-notes` for details.
 
-To ensure you receive latest security updates and bug fixes, you should upgrade to a new release of Anbox Cloud shortly after it is released.
+To ensure you receive the latest security updates and bug fixes, you should upgrade to a new release of Anbox Cloud shortly after it is released.
 
 If you are looking for additional support, see [Ubuntu Pro](https://ubuntu.com/support). Canonical can also provide [managed solutions](https://ubuntu.com/managed) for Anbox Cloud.
 

--- a/tutorial/getting-started-with-virtualized-android.md
+++ b/tutorial/getting-started-with-virtualized-android.md
@@ -12,6 +12,7 @@ In this tutorial, we will go through launching our first instance with virtualiz
 ## Prerequisites
 
 To proceed with the tutorial, we need:
+
 - A working Anbox Cloud deployment (appliance or charmed). If you haven't set one up yet, see {ref}`tut-installing-appliance`. It needs at least:
   * 4 CPU cores
   * 5GB of memory

--- a/tutorial/index.md
+++ b/tutorial/index.md
@@ -22,6 +22,7 @@ The following tutorial uses images with virtualized Android.
 For an explanation of the two execution environments, see {ref}`exp-android-execution-environments`.
 
 ```{toctree}
+:hidden:
 :maxdepth: 1
 installing-appliance
 create-test-virtual-device


### PR DESCRIPTION
# Documentation changes

This PR updates the release and support policy section to align with the new release cadence (3 minor releases per year in March, June, and November, with patch releases between minors as needed rather than monthly). Changes include:

- Updated minor release cadence from "every three months" to "three per year, in March, June, and November"
- Reworded patch release definition to convey that patches will be delivered between minors (reassuring) instead of committing to a fixed monthly schedule 
- Removed pre-scheduled patch release rows from the roadmap table since they are no longer monthly occurrences; only confirmed releases are listed. (will add the patch release to the roadmap once confirmed)
- Removed "The release notes link will be updated on the day of the release" sentence as it describes internal page maintenance rather than user-facing information
- Updated the next minor target to November 25, 2026

non release notes changes specific changes:
- fixed toctree in tutorial landing page
- fixed a link in release notes and linting issue

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,

- [ ] Run `make spelling` and fix any spelling issues.
- [ ] Run `make linkcheck` and fix any broken links.
- [ ] Run `make lint-md` and fix any linting issues.
- [ ] Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[AC-4804](https://warthogs.atlassian.net/browse/AC-4804)

[AC-4804]: https://warthogs.atlassian.net/browse/AC-4804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ