### PR TITLE
feat: add search result scoring functionality to deprioritize release notes

### DIFF
--- a/_static/js/search_scorer.js
+++ b/_static/js/search_scorer.js
@@ -1,0 +1,27 @@
+const _searchQuery = new URLSearchParams(window.location.search).get("q")?.toLowerCase().trim() || "";
+
+window.Scorer = {
+  score: result => {
+    const [docName, title, anchor, descr, baseScore, filename] = result;
+    let score = baseScore;
+
+    // Demote release notes
+    if (docName.startsWith("reference/release-notes/")) {
+      return score - 20;
+    }
+
+    // Boost pages whose H1 title contains the search query
+    if (anchor === "" && _searchQuery && title.toLowerCase().includes(_searchQuery)) score += 5;
+
+    return score;
+  },
+
+  objNameMatch: 11,
+  objPartialMatch: 6,
+  objPrio: {0: 15, 1: 5, 2: -5},
+  objPrioDefault: 0,
+  title: 15,
+  partialTitle: 7,
+  term: 5,
+  partialTerm: 2,
+};

--- a/conf.py
+++ b/conf.py
@@ -292,6 +292,12 @@ linkcheck_request_headers = {
     }
 }
 
+##########################
+# Search result scoring  #
+##########################
+
+html_search_scorer = "_static/js/search_scorer.js"
+
 ########################
 # Configuration extras #
 ########################


### PR DESCRIPTION
# Documentation changes

The documentation contains 100+ individual release note files. Because release notes mention common terms like "application", "instance", "image", and "stream" in changelog entries, they flood search results and push down pages that are actually about those topics.

Solution:
Added a custom Sphinx search scorer that adjusts the ranking of search results at query time based on this [Sphinx built-in configuration](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_search_scorer):

- It demotes release notes by pushing them below the pages that are about the specific search topic
- It boosts the title matches 
 Note: Release notes still appear in search results. They are deprioritized, not removed.

## Before
<img width="1603" height="747" alt="Screenshot from 2026-06-29 11-45-06" src="https://github.com/user-attachments/assets/14bfc05b-6bf3-4645-8fc0-4133ce002d44" />

## After
<img width="1512" height="692" alt="Screenshot from 2026-06-29 11-45-48" src="https://github.com/user-attachments/assets/ebb28981-ff94-4a89-aadf-6815030a0ddf" />


# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,

- [ ] Run `make spelling` and fix any spelling issues.
- [ ] Run `make linkcheck` and fix any broken links.
- [ ] Run `make lint-md` and fix any linting issues.
- [ ] Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]
[AC- 4810](https://warthogs.atlassian.net/browse/AC-4810)