### PR TITLE
Add llms.txt and llms-full.txt support to the documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SPHINX_OPTS      ?= -c . -d $(SPHINX_DIR)/.doctrees -j auto
 SPHINX_BUILD     ?= $(DOCS_VENVDIR)/bin/sphinx-build
 SPHINX_HOST      ?= 127.0.0.1
 SPHINX_PORT      ?= 8000
-SPHINX_AUTOBUILD_OPTS ?=
+SPHINX_AUTOBUILD_OPTS ?= -D llms_txt_enabled=0
 DOCS_VENVDIR     ?= .venv
 DOCS_VENV        ?= $(DOCS_VENVDIR)/bin/activate
 DOCS_SOURCEDIR   ?= .

--- a/conf.py
+++ b/conf.py
@@ -238,6 +238,23 @@ rediraffe_redirects = "redirects.txt"
 rediraffe_dir_only = True
 
 
+############################
+# sphinx-llm configuration #
+############################
+
+# Description included at the top of llms.txt to give LLMs initial context.
+# This repo has no pyproject.toml, so the description must be set explicitly;
+# otherwise the extension has no project description to fall back on.
+llms_txt_description = (
+    "This is the documentation for Anbox Cloud, which runs Android in the "
+    "cloud using lightweight LXD system containers or full virtual machines."
+)
+
+# Base URL prepended to links in the generated Markdown so they are absolute.
+# Reuses the hardcoded html_baseurl defined in the sitemap section above.
+markdown_http_base = html_baseurl
+
+
 ###########################
 # Link checker exceptions #
 ###########################
@@ -338,6 +355,7 @@ extensions = [
     "sphinxext.opengraph",
     "sphinx_last_updated_by_git",
     "sphinx_sitemap",
+    "sphinx_llm.txt",
 ]
 
 # Excludes files or directories from processing

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ packaging
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinx-last-updated-by-git
 sphinx-sitemap
+sphinx-llm~=0.4
 
 # Vale dependencies
 rst2html


### PR DESCRIPTION
# Documentation changes

The docs currently produce no llms.txt or llms-full.txt. 
Added  llms.txt and llms-full.txt to the docs build so that LLMs and AI agents can consume accurate, current documentation. This follows the [llms.txt convention](https://llmstxt.org/) and mirrors the approach used in Canonical's sphinx-stack.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,

- [ ] Run `make spelling` and fix any spelling issues.
- [ ] Run `make linkcheck` and fix any broken links.
- [ ] Run `make lint-md` and fix any linting issues.
- [ ] Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[[AC - 4817]](https://warthogs.atlassian.net/browse/AC-4817)
