### PR TITLE
Add missing API extensions for GET /1.0 endpoint

### DIFF
--- a/reference/api-reference/anbox-https-api.md
+++ b/reference/api-reference/anbox-https-api.md
@@ -102,7 +102,10 @@ Return value for `curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.
           "camera_video_streaming",
           "sensor_support",
           "tracing_support",
-          "vhal_support"
+          "active_sensors",
+          "platform_support",
+          "vhal_support",
+          "location_support",
           "pprof",
           "metrics",
           "log_level",


### PR DESCRIPTION
# Documentation changes
    
Include missing API extensions for the GET /1.0 endpoint to
ensure full compliance with the latest anbox session.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,

- [x] Run `make spelling` and fix any spelling issues.
- [x] Run `make linkcheck` and fix any broken links.
- [x] Run `make lint-md` and fix any linting issues.
- [x] Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]
