### PR TITLE
fix: update upcoming release date and clarify patch release details

### DIFF
--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -27,7 +27,7 @@ Target dates for upcoming releases are not final and could vary depending on var
 
 | Target date | Version | Planned updates |
 |----|----|----|
-| July 22, 2026 | Anbox Cloud 1.30.1 | Android security updates<br/>Bug fixes |
+| July 22, 2026 | Anbox Cloud 1.30.1 | Bug fixes |
 | November 25, 2026 | Anbox Cloud 1.31.0 | New features<br/>Android security updates<br/>Bug fixes |
 
 (release-and-support-policy)=

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -23,7 +23,7 @@ For instructions on how to update your Anbox Cloud deployment to later versions,
 
 The current supported minor release is **1.30.0**. The next one will be **1.31.0**, expected in November 2026.
 
-Target dates for upcoming releases are not final and could vary depending on various factors such as availability of Android security patches.
+Target dates for upcoming releases are not final and could vary depending on various factors such as availability of Android security patches. Additional patch releases may be added to this roadmap as they are planned.
 
 | Target date | Version | Planned updates |
 |----|----|----|

--- a/reference/release-notes/release-notes.md
+++ b/reference/release-notes/release-notes.md
@@ -27,7 +27,8 @@ Target dates for upcoming releases are not final and could vary depending on var
 
 | Target date | Version | Planned updates |
 |----|----|----|
-| November 25, 2026 | Anbox Cloud 1.31.0 | *New features*<br/>*Android security updates*<br/>Bug fixes |
+| July 22, 2026 | Anbox Cloud 1.30.1 | Android security updates<br/>Bug fixes |
+| November 25, 2026 | Anbox Cloud 1.31.0 | New features<br/>Android security updates<br/>Bug fixes |
 
 (release-and-support-policy)=
 ## Release and support policy
@@ -35,10 +36,12 @@ Target dates for upcoming releases are not final and could vary depending on var
 Anbox Cloud follows a defined release cycle with minor and patch releases.
 
 Minor releases
-: Anbox Cloud delivers three minor releases per year, in March, June, and November. Minor releases include new features, bug fixes and security updates.
+: A new minor release is delivered three times per year: in March, June and November. It includes new features, bug fixes and security updates.
 
 Patch releases
-: Patch releases are delivered between minor releases and include Android and Chrome security updates alongside Anbox Cloud specific bug fixes. No new features are introduced in patch releases.
+: A patch release includes Android and Chrome security updates alongside Anbox Cloud specific bug fixes. No new features are introduced.
+
+  Patch releases are not issued every month; they are published as needed. When planned, they are listed in the upcoming release roadmap above.
 
 Anbox Cloud supports only the most recent release. Older releases are only supported for a short time after a new minor release is published.
 


### PR DESCRIPTION
# Documentation changes

This PR:

- Clarifies that patch releases are not issued every month and are published as needed (announced when planned in the upcoming release roadmap for now). This is to remove the ambiguity surrounding the expectation of them being happening monthly.
- Adds Anbox Cloud 1.30.1 (target: July 22, 2026) to the roadmap
- Rewrites minor/patch release definitions for clarity and parallel structure

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,

- [x] Run `make spelling` and fix any spelling issues.
- [x] Run `make linkcheck` and fix any broken links.
- [x] Run `make lint-md` and fix any linting issues.
- [x] Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]
