### PR TITLE
docs: separate maintenance and contributor content in sidebar navigation

### DIFF
--- a/index.md
+++ b/index.md
@@ -94,8 +94,12 @@ Thinking about using Anbox Cloud for your next project? [Get in touch\!](https:/
 :hidden:
 tutorial/index
 howto/index
-explanation/index
 reference/index
-Contribute <contribute/index>
+explanation/index
+```
+
+```{toctree}
+:hidden:
 reference/release-notes/release-notes
+Contribute <contribute/index>
 ```


### PR DESCRIPTION
Fixes [#354](https://github.com/canonical/open-documentation-academy/issues/354)

**What this PR does / why we need it:**
This PR updates the primary documentation navigation structure to separate the core Diátaxis categories from contributor and maintenance-related content. 

Previously, all pages were grouped into a single `toctree`. By splitting the configuration into two separate `toctree` directives in `index.md`, the sidebar now renders a clean visual separation (a horizontal divider) between the product learning material and the administrative pages. 

This enhances the readability of the sidebar and brings the documentation closer to Canonical's navigation standards.

**Changes made:**
- Split the monolithic `toctree` in `index.md` into two distinct blocks.
- Grouped `tutorial`, `howto`, `reference`, and `explanation` in the primary block.
- Grouped `release-notes` and `contribute` in the secondary block.

**Testing performed:**
- Built the documentation locally.
- Verified the sidebar renders correctly with the new grouped structure.
- Ensured no duplicate or missing `toctree` warnings occur during the Sphinx build.