### PR TITLE
Document the migration guide for addon and app hooks

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -407,6 +407,8 @@ YUV
 ZFS
 zpool
 zsh
+chmod
+systemctl
 
 # To be removed after AMS sync
 authrorization

--- a/explanation/addons.md
+++ b/explanation/addons.md
@@ -7,6 +7,10 @@ myst:
 (exp-addons)=
 # Addons
 
+```{caution}
+Addons including hooks, are deprecated and are being removed from Anbox Cloud. See {ref}`ref-deprecation-notes` for the removal schedule and {ref}`howto-migrate-from-addon-and-app-hooks` for how to replicate hook behavior without addons.
+```
+
 Addons provide a way to extend and customize images in Anbox Cloud. Once you have created addons, you can create hooks for them that are triggered based on events in the life cycle of an instance. You can create addons independently and later attach it to individual applications.
 
 ## Best practices while using addons

--- a/explanation/applications.md
+++ b/explanation/applications.md
@@ -7,6 +7,10 @@ myst:
 (exp-applications)=
 # Applications
 
+```{caution}
+Applications including hooks, are deprecated and are being removed from Anbox Cloud. See {ref}`ref-deprecation-notes` for the removal schedule and {ref}`howto-migrate-from-addon-and-app-hooks` for how to replicate hook behavior without addons.
+```
+
 Applications are one of the main objects managed by Anbox Management Service (AMS). A single application encapsulates one Android APK ([Android Package Kit](https://en.wikipedia.org/wiki/Android_application_package)) and manages it within the cluster. It takes care of installing the supplied APK and making it available to users. AMS also manages updates to existing applications, which includes allowing the operator to test new uploaded versions before making them available to any users.
 
 ## Application requirements

--- a/howto/instance/index.md
+++ b/howto/instance/index.md
@@ -66,4 +66,5 @@ delete-instance
 backup-restore-application-data
 configure-geographic-location
 expose-services
+migrate-from-addon-and-app-hooks
 ```

--- a/howto/instance/migrate-from-addon-and-app-hooks.md
+++ b/howto/instance/migrate-from-addon-and-app-hooks.md
@@ -1,0 +1,151 @@
+---
+myst:
+  html_meta:
+    "description": "How to migrate from addon or application hooks (pre-start, post-start, post-stop) to a systemd service built into an Anbox image."
+---
+
+(howto-migrate-from-addon-and-app-hooks)=
+# Migrate from app/addon hooks to system units
+
+```{important}
+Addons and application hooks are deprecated and will be removed from Anbox Cloud. See {ref}`ref-deprecation-notes` for the exact release in which support ends.
+```
+Addon and application hooks (`pre-start`, `post-start`, `post-stop`) are available only for instances with containerized Android (`jammy:*` images) and are not supported for virtualized Android (see {ref}`exp-android-execution-models`).
+
+This guide shows how to replace addon and application hook behavior with a `systemd` unit baked into a custom Anbox image. This approach works for both containerized and virtualized Android and does not depend on the addon subsystem.
+
+## Identify what your hook depends on
+
+Before rewriting your hook as a systemd unit, identify its dependencies. Hook scripts had access to environment variables injected by the Anbox runtime that are not available in systemd. Review your existing hook scripts for the variables below and replace each one with its systemd equivalent.
+
+| Hook variable | Migration |
+| --- | --- |
+| `APP_DIR` | Use `/var/lib/anbox/app` directly. |
+| `ANBOX_DIR` | Use `/var/lib/anbox` directly. |
+| `ANDROID_ROOTFS` | Use `/var/lib/anbox/rootfs` directly. |
+| `BOOT_PACKAGE` | Use the `boot-package` attribute from the application manifest file directly in the script instead of `BOOT_PACKAGE`. |
+| `INSTANCE_TYPE` |  Check whether `/var/lib/anbox/bootstrap.yaml` exists. Its presence indicates a `regular` instance; its absence indicates a `base` instance. |
+| `CONTAINER_TYPE` |This variable is deprecated. Use the same `/var/lib/anbox/bootstrap.yaml `check described for `INSTANCE_TYPE`. |
+| `ANBOX_EXIT_CODE` | Query `anbox.service` directly for the exit code: `systemctl show anbox.service --property=ExecMainStatus`. |
+
+## General workflow
+
+To run a script before or after Android starts, or after Android stops, follow this workflow:
+
+1. Launch an instance from a container image.
+2. Inside that instance, write a `systemd` unit that runs your script at the desired point in the Android life cycle, relative to the `anbox.service` unit, which represents the Anbox runtime.
+3. Enable the unit to automatically activate upon the initial startup or every startup of an instance created from this image.
+4. Publish the modified instance as a new image.
+5. Launch future instances from this custom image instead of relying on an addon or application.
+
+The following sections show concrete examples for each of the three hooks that addons or applications used to provide.
+
+## Launch and access a source instance
+
+Launch an instance to use as the base for your custom image:
+
+    amc launch --name source-inst jammy:android15:amd64
+    amc shell source-inst
+
+All steps below run inside this instance.
+
+### Replace a `pre-start` hook
+
+If you need a script to run on every start before Android starts, create a one-shot unit that starts before `anbox.service` is up and running:
+
+1. Inside the instance, create the unit file, for example `/etc/systemd/system/app-pre-start.service`:
+
+      ```systemd
+      [Unit]
+      Description=Run a script before Android starts
+      Before=anbox.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/bin/pre-start.sh
+      TimeoutStartSec=10min
+
+      [Install]
+      WantedBy=anbox.service
+      ```
+1. Verify the unit file for any syntax or spelling errors:
+
+      sudo systemd-analyze verify /etc/systemd/system/app-pre-start.service
+
+1. Add your script (`/usr/local/bin/pre-start.sh` in this example), make it executable, then enable the unit.
+
+      sudo chmod +x /usr/local/bin/pre-start.sh
+      sudo systemctl daemon-reload
+      sudo systemctl enable app-pre-start.service
+
+```{note}
+AMS waits for an instance to become fully up and running with a maximum timeout of 15 minutes. Consequently, all scripts should be as lightweight as possible and avoid long-running operations. We recommend setting an appropriate `TimeoutStartSec` in the unit file to prevent instance launches from failing due to long-running operations in the pre-start unit.
+```
+
+### Replace a `post-start` hook
+
+If you need a script to run every time after Android starts, create a one-shot unit that starts after anbox.service is up and running.
+
+1. Inside the instance, create the unit file, for example `/etc/systemd/system/app-post-start.service`:
+
+      ```systemd
+      [Unit]
+      Description=Run a script after Android has started
+      After=anbox.service
+      Requires=anbox.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/bin/post-start.sh
+
+      [Install]
+      WantedBy=multi-user.target
+      ```
+
+1. Add your script (`/usr/local/bin/post-start.sh` in this example), make it executable, and enable it the same way as in the previous section.
+
+### Replace a `post-stop` hook
+
+If you need a script to run after Android was stopped, bind a unit to the life cycle of `anbox.service` and run your cleanup or data backup logic in `ExecStop`, so it executes whenever `anbox.service` stops:
+
+1. Inside the instance, create the unit file, for example `/etc/systemd/system/app-post-stop.service`:
+
+      ```systemd
+      [Unit]
+      Description=Run a script after Android has stopped
+      Before=anbox.service
+      BindsTo=anbox.service
+
+      [Service]
+      Type=oneshot
+      ExecStop=/usr/local/bin/post-stop.sh
+      RemainAfterExit=yes
+
+      [Install]
+      WantedBy=anbox.service
+      ```
+
+1. Add your script (`/usr/local/bin/post-stop.sh` in this example), make it executable, and enable it the same way as in the previous section.
+
+## Publish and use custom image
+
+Once your units and scripts are in place inside the instance, publish it as a new image(see {ref}`howto-publish-instance-as-image`) and use it for future instances:
+
+    amc publish source-inst --name custom-image --force
+    amc launch --name new-instance custom-image
+
+Verify that your system units ran as expected by checking the instance logs(see {ref}`howto-view-instance-logs`),
+
+    amc logs new-instance
+
+Or check the logs of a specific system unit,
+
+    amc exec new-instance -- journalctl -u app-pre-start.service
+
+## Related topics
+
+- {ref}`ref-hooks`
+- {ref}`ref-deprecation-notes`
+- {ref}`howto-publish-instance-as-image`
+- {ref}`howto-create-instance`
+- {ref}`howto-view-instance-logs`

--- a/reference/deprecation-notices.md
+++ b/reference/deprecation-notices.md
@@ -86,3 +86,5 @@ This transition provides a two-year migration window before legacy charms become
 Support for [applications](/howto/application/index.md), [addons](/howto/addons/index.md), and Anbox Application Registry [AAR](/howto/aar/index.md) is deprecated as of version 1.31.0.
 - In 1.31.0: Creating applications and registry management via the Anbox Cloud dashboard is disabled. However, applications, addons, and registry management remains functional through the CLI for transition purposes.
 - In 1.32.0: All support for applications, addons and registry will be officially removed. Users will no longer be able to create, manage, or utilize these features via the CLI or dashboard.
+
+See {ref}`howto-migrate-from-addon-and-app-hooks` for how to replicate addon hook behavior using a custom image instead.

--- a/reference/deprecation-notices.md
+++ b/reference/deprecation-notices.md
@@ -81,10 +81,10 @@ Starting from 1.29.0, all new Anbox Cloud deployments must use modernized operat
 This transition provides a two-year migration window before legacy charms become completely unsupported. Anbox Cloud 1.34.2 will be the last release that supports deployments using legacy charms. Starting from Anbox Cloud 1.35.0, Anbox Cloud deployments will exclusively support modernized charms.
 
 ## Applications, Addons and Registry in AMS
-*Deprecated in 1.31.0* ; *Unsupported in 1.32.0*
+*Deprecated in 1.32.0* ; *Unsupported in 1.34.0*
 
 Support for [applications](/howto/application/index.md), [addons](/howto/addons/index.md), and Anbox Application Registry [AAR](/howto/aar/index.md) is deprecated as of version 1.31.0.
-- In 1.31.0: Creating applications and registry management via the Anbox Cloud dashboard is disabled. However, applications, addons, and registry management remains functional through the CLI for transition purposes.
-- In 1.32.0: All support for applications, addons and registry will be officially removed. Users will no longer be able to create, manage, or utilize these features via the CLI or dashboard.
+- In 1.32.0: Creating applications and registry management via the Anbox Cloud dashboard is disabled. However, applications, addons, and registry management remains functional through the CLI for transition purposes.
+- In 1.34.0: All support for applications, addons and registry will be officially removed. Users will no longer be able to create, manage, or utilize these features via the CLI or dashboard.
 
 See {ref}`howto-migrate-from-addon-and-app-hooks` for how to replicate addon hook behavior using a custom image instead.

--- a/reference/hooks.md
+++ b/reference/hooks.md
@@ -7,6 +7,10 @@ myst:
 (ref-hooks)=
 # Hooks
 
+```{caution}
+Addons and apps, including hooks, are deprecated and are being removed from Anbox Cloud. See {ref}`ref-deprecation-notes` for the removal schedule and {ref}`howto-migrate-from-addon-and-app-hooks` for how to replicate hook behavior without addons.
+```
+
 Hooks are scripts that automatically trigger actions based on an event performed in the life cycle of an instance. A hook can be any executable file that is placed in the `hooks` directory of an addon or an application folder.
 
 The hook name **must** be one of the following:


### PR DESCRIPTION
# Documentation changes

Given the fact that we are dropping application, addon, and registry
management support from the UI starting in version 1.31.0, we will
provide early awareness to end users. This ensures they can begin
migrating ahead of time for a smooth transition before the feature
is completely removed from Anbox Cloud.

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,

- [ ] Run `make spelling` and fix any spelling issues.
- [ ] Run `make linkcheck` and fix any broken links.
- [ ] Run `make lint-md` and fix any linting issues.
- [ ] Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

https://warthogs.atlassian.net/browse/AC-4854
