### PR TITLE
Update LXD URLs

### DIFF
--- a/explanation/performance.md
+++ b/explanation/performance.md
@@ -36,7 +36,7 @@ AMS has different modes to grant CPU access to an instance. The `cpu.limit_mode`
     This mode uses the LXD [`limits.cpu.allowance`](https://canonical.com/lxd/docs/latest/reference/instance_options/#cpu-limits) configuration option to grant an instance a CPU time budget via the Linux CFS scheduler. See [CFS Bandwidth Control](https://www.kernel.org/doc/html/latest/scheduler/sched-bwc.html) for more details.
 - `pinning` :
 
-   This mode uses the LXD [`limits.cpu`](https://documentation.ubuntu.com/lxd/latest/reference/instance_options/#cpu-limits) configuration option to pin a set of CPU cores to an instance. LXD is responsible for allocating a specific number of cores to an instance and load-balancing all running instances on all available cores.
+   This mode uses the LXD [`limits.cpu`](https://canonical.com/lxd/docs/latest/reference/instance_options/#cpu-limits) configuration option to pin a set of CPU cores to an instance. LXD is responsible for allocating a specific number of cores to an instance and load-balancing all running instances on all available cores.
 
    Using `pinning` requires a system with [cgroup-v2](https://docs.kernel.org/admin-guide/cgroup-v2.html) enabled. Otherwise, limitations of [cgroup-v1](https://docs.kernel.org/admin-guide/cgroup-v1/index.html) might cause the load distribution over available CPU cores to not be optimal. [cgroup-v2](https://docs.kernel.org/admin-guide/cgroup-v2.html) is enabled by default.
 

--- a/reference/release-notes/1.16.0.md
+++ b/reference/release-notes/1.16.0.md
@@ -68,7 +68,7 @@ The APT mirror used inside Anbox containers has been hard-coded to `archive.ubun
 
 #### Networking ACLs
 
-A new AMS charm configuration `use_network_acl` has been added. This configuration enables AMS to use [LXD network ACLs](https://documentation.ubuntu.com/lxd/en/latest/howto/network_acls/) rather than the AMS node controller (which is used by default) to restrict the network access of Anbox containers. The option is experimental and not ready for general use, but will in the future replace the functionality that is currently part of the AMS node controller.
+A new AMS charm configuration `use_network_acl` has been added. This configuration enables AMS to use [LXD network ACLs](https://canonical.com/lxd/docs/latest/howto/network_acls/) rather than the AMS node controller (which is used by default) to restrict the network access of Anbox containers. The option is experimental and not ready for general use, but will in the future replace the functionality that is currently part of the AMS node controller.
 
 ### Other
 


### PR DESCRIPTION
# Documentation changes

The LXD docs have moved to canonical.com/lxd/docs.


