### PR TITLE
fix(tutorials): remove leading spaces in appliance install tutorial

### DIFF
--- a/tutorial/installing-appliance.md
+++ b/tutorial/installing-appliance.md
@@ -44,17 +44,17 @@ The *Ubuntu Pro (Infra-only)* token does not work and will result in a failed de
 
 1. Install Multipass:
 
-        snap install multipass
+       snap install multipass
 
 2. Create a virtual machine:
 
-        multipass launch --name=anbox --cpus 8 --disk 50G --memory 8G
+       multipass launch --name=anbox --cpus 8 --disk 50G --memory 8G
 
 Make sure to allocate sufficient disk space, memory and CPUs as shown in the example. Otherwise, the VM will run out of space while creating the application. See {ref}`ref-requirements` for information on minimum resource requirements.
 
 3. Shell into the virtual machine:
 
-        multipass shell anbox
+       multipass shell anbox
 
 ## Attach the machine to Ubuntu Pro
 


### PR DESCRIPTION
# Documentation changes

Removed leading spaces from code blocks nested in list items in the appliance installation tutorial.

# Before

<img width="487" height="439" alt="image" src="https://github.com/user-attachments/assets/b30cb933-d1b8-4ba8-b3dd-a6084113c21f" />

# After

<img width="487" height="439" alt="image" src="https://github.com/user-attachments/assets/cc419f67-8519-4cc3-8a0f-adcbe1531f29" />

# Review and preview

Have you reviewed and previewed your documentation updates?
In your local repository,

- [x] Run `make spelling` and fix any spelling issues.
- [x] Run `make linkcheck` and fix any broken links.
- [x] Run `make lint-md` and fix any linting issues.
- [x] Run `make run`. This will build a local copy of the entire documentation and you can preview the updated pages locally before creating this PR.

## Reviewers

Make sure to get at least one review from the [Anbox](https://github.com/orgs/canonical/teams/anbox) team.

# JIRA / Launchpad bug

[Add the associated JIRA ticket or Launchpad bug ID]
